### PR TITLE
fix: add cm scheduler reproduce noise generator

### DIFF
--- a/lightx2v/models/schedulers/wan/step_distill/scheduler.py
+++ b/lightx2v/models/schedulers/wan/step_distill/scheduler.py
@@ -52,5 +52,6 @@ class WanStepDistillScheduler(WanScheduler):
         noisy_image_or_video = self.latents.to(torch.float32) - sigma * flow_pred
         if self.step_index < self.infer_steps - 1:
             sigma = self.sigmas[self.step_index + 1].item()
-            noisy_image_or_video = self.add_noise(noisy_image_or_video, torch.randn_like(noisy_image_or_video), self.sigmas[self.step_index + 1].item())
+            noise = torch.randn(noisy_image_or_video.shape, dtype=torch.float32, device=self.device, generator=self.generator)
+            noisy_image_or_video = self.add_noise(noisy_image_or_video, noise=noise, sigma=self.sigmas[self.step_index + 1].item())
         self.latents = noisy_image_or_video.to(self.latents.dtype)


### PR DESCRIPTION
- [x] fix schedulers/wan/step_distill/scheduler.py for reproducable output when using the same input with the same seed.