### PR TITLE
Fix: add missing `get_byt5_text_tokens()`

### DIFF
--- a/lightx2v/models/input_encoders/hf/hunyuan15/byt5/model.py
+++ b/lightx2v/models/input_encoders/hf/hunyuan15/byt5/model.py
@@ -286,6 +286,32 @@ class ByT5TextEncoder:
             byt5_mask = text_mask
 
         return byt5_embeddings, byt5_mask
+    
+    @staticmethod
+    def get_byt5_text_tokens(byt5_tokenizer, byt5_max_length, text_prompt):
+        """
+        Tokenize text prompt for byT5 model.
+
+        Args:
+            byt5_tokenizer: The byT5 tokenizer.
+            byt5_max_length: Maximum sequence length for tokenization.
+            text_prompt: Text prompt string to tokenize.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]:
+                - input_ids: Tokenized input IDs.
+                - attention_mask: Attention mask tensor.
+        """
+        byt5_text_inputs = byt5_tokenizer(
+            text_prompt,
+            padding="max_length",
+            max_length=byt5_max_length,
+            truncation=True,
+            add_special_tokens=True,
+            return_tensors="pt",
+        )
+
+        return byt5_text_inputs.input_ids, byt5_text_inputs.attention_mask
 
     def _prepare_byt5_embeddings(self, prompts):
         if isinstance(prompts, str):


### PR DESCRIPTION
## Summary

- This PR adds the missing `get_byt5_text_tokens()`.
- Running the LightX2VPipeline t2v demo (hunyuan_video_1.5) fails when the prompt contains quotation marks (e.g., A "shiny" robot walking).
- Root cause: _process_single_byt5_prompt calls get_byt5_text_tokens(), but ByT5TextEncoder lacks this method, raising AttributeError.


Demo code:
```
from lightx2v import LightX2VPipeline

# Initialize pipeline
pipe = LightX2VPipeline(
    model_path="/path/to/hunyuanvideo-1.5/",  # Original model path
    model_cls="hunyuan_video_1.5",
    transformer_model_name="480p_t2v",
    task="t2v",
    # 4-step distilled model ckpt
    dit_original_ckpt="/path/to/hy1.5_t2v_480p_lightx2v_4step.safetensors"
)

# Enable FP8 quantization for the distilled model
pipe.enable_quantize(
    quant_scheme='fp8-sgl',
    dit_quantized=True,
    dit_quantized_ckpt="/path/to/hy1.5_t2v_480p_scaled_fp8_e4m3_lightx2v_4step.safetensors",
    text_encoder_quantized=False,  # Optional: can also quantize text encoder
    text_encoder_quantized_ckpt="/path/to/hy15_qwen25vl_llm_encoder_fp8_e4m3_lightx2v.safetensors",  # Optional
    image_encoder_quantized=False,
)

# Enable offloading for lower VRAM usage
pipe.enable_offload(
    cpu_offload=True,
    offload_granularity="block",
    text_encoder_offload=True,
    image_encoder_offload=False,
    vae_offload=False,
)

# Create generator
pipe.create_generator(
    attn_mode="sage_attn2",
    infer_steps=4,
    num_frames=81,
    guidance_scale=1,
    sample_shift=9.0,
    aspect_ratio="16:9",
    fps=16,
    denoising_step_list=[1000, 750, 500, 250]
)

# Generate video
pipe.generate(
    seed=123,
    prompt='A "shiny" robot walking',
    negative_prompt="",
    save_result_path="/path/to/output.mp4",
)

```

Error
```
Traceback (most recent call last):
  File "/weights/lab/LightX2V/run.py", line 69, in <module>
    pipe.generate(
  File "/opt/conda/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/weights/lab/LightX2V/lightx2v/pipeline.py", line 346, in generate
    self.runner.run_pipeline(input_info)
  File "/weights/lab/LightX2V/lightx2v/utils/profiler.py", line 80, in sync_wrapper
    return func(*args, **kwargs)
  File "/weights/lab/LightX2V/lightx2v/models/runners/default_runner.py", line 381, in run_pipeline
    self.inputs = self.run_input_encoder()
  File "/weights/lab/LightX2V/lightx2v/utils/profiler.py", line 80, in sync_wrapper
    return func(*args, **kwargs)
  File "/weights/lab/LightX2V/lightx2v/models/runners/hunyuan_video/hunyuan_video_15_runner.py", line 436, in _run_input_encoder_local_t2v
    text_encoder_output = self.run_text_encoder(self.input_info)
  File "/weights/lab/LightX2V/lightx2v/models/runners/hunyuan_video/hunyuan_video_15_runner.py", line 290, in run_text_encoder
    byt5_features, byt5_masks = self.text_encoders[1].infer([prompt])
  File "/opt/conda/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/weights/lab/LightX2V/lightx2v/models/input_encoders/hf/hunyuan15/byt5/model.py", line 333, in infer
    byt5_embeddings, byt5_masks = self._prepare_byt5_embeddings(prompts)
  File "/weights/lab/LightX2V/lightx2v/models/input_encoders/hf/hunyuan15/byt5/model.py", line 304, in _prepare_byt5_embeddings
    pos_emb, pos_mask = self._process_single_byt5_prompt(prompt, AI_DEVICE)
  File "/weights/lab/LightX2V/lightx2v/models/input_encoders/hf/hunyuan15/byt5/model.py", line 280, in _process_single_byt5_prompt
    text_ids, text_mask = self.get_byt5_text_tokens(self.byt5_tokenizer, self.byt5_max_length, formatted_text)
AttributeError: 'ByT5TextEncoder' object has no attribute 'get_byt5_text_tokens'
```