### PR TITLE
Add support ROCM AMD GPU

### DIFF
--- a/dockerfiles/Dockerfile.mi350
+++ b/dockerfiles/Dockerfile.mi350
@@ -25,15 +25,15 @@ RUN git clone https://github.com/ROCm/aiter.git /tmp/aiter && \
     pip install --no-cache-dir -e . && \
     rm -rf /tmp/aiter/.git
 
-# Install flash-attn for ROCm (if not already in base image)
-RUN pip install --no-cache-dir flash-attn --no-build-isolation 2>/dev/null || true
+# Install flash-attn for ROCm
+RUN pip install --no-cache-dir flash-attn --no-build-isolation
 
 # Copy LightX2V source
 COPY . /workspace/LightX2V
 
 # Install LightX2V dependencies
 WORKDIR /workspace/LightX2V
-RUN pip install --no-cache-dir -r requirements.txt 2>/dev/null || true
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Install LightX2V
 RUN pip install --no-cache-dir -e .

--- a/lightx2v/__init__.py
+++ b/lightx2v/__init__.py
@@ -2,10 +2,6 @@ __version__ = "0.1.0"
 __author__ = "LightX2V Contributors"
 __license__ = "Apache 2.0"
 
-# AMD ROCm optimizations (must be before other imports)
-from lightx2v_platform.base.amd_rocm import init_amd_rocm
-init_amd_rocm()
-
 import lightx2v_platform.set_ai_device
 from lightx2v import common, deploy, models, utils
 from lightx2v.pipeline import LightX2VPipeline

--- a/lightx2v/common/ops/attn/__init__.py
+++ b/lightx2v/common/ops/attn/__init__.py
@@ -8,8 +8,3 @@ from .svg2_attn import Svg2AttnWeight
 from .svg_attn import SvgAttnWeight
 from .torch_sdpa import TorchSDPAWeight
 from .ulysses_attn import Ulysses4090AttnWeight, UlyssesAttnWeight
-
-try:
-    from .aiter_attn import AiterAttnWeight
-except ImportError as e:
-    print(f"Failed to import AiterAttnWeight: {e}")

--- a/lightx2v_platform/base/__init__.py
+++ b/lightx2v_platform/base/__init__.py
@@ -1,7 +1,8 @@
 from lightx2v_platform.base.base import check_ai_device, init_ai_device
+from lightx2v_platform.base.amd_rocm import AmdRocmDevice
 from lightx2v_platform.base.cambricon_mlu import MluDevice
 from lightx2v_platform.base.hygon_dcu import HygonDcuDevice
 from lightx2v_platform.base.metax import MetaxDevice
 from lightx2v_platform.base.nvidia import CudaDevice
 
-__all__ = ["init_ai_device", "check_ai_device", "CudaDevice", "MluDevice", "MetaxDevice", "HygonDcuDevice"]
+__all__ = ["init_ai_device", "check_ai_device", "CudaDevice", "MluDevice", "MetaxDevice", "HygonDcuDevice", "AmdRocmDevice"]

--- a/lightx2v_platform/ops/__init__.py
+++ b/lightx2v_platform/ops/__init__.py
@@ -6,6 +6,8 @@ if AI_DEVICE == "mlu":
     from .attn.cambricon_mlu import *
     from .mm.cambricon_mlu import *
 elif AI_DEVICE == "cuda":
-    # Check if running on Hygon DCU platform
-    if os.getenv("PLATFORM") == "hygon_dcu":
+    platform = os.getenv("PLATFORM")
+    if platform == "hygon_dcu":
         from .attn.hygon_dcu import *
+    elif platform == "amd_rocm":
+        from .attn.amd_rocm import *

--- a/lightx2v_platform/ops/attn/amd_rocm/__init__.py
+++ b/lightx2v_platform/ops/attn/amd_rocm/__init__.py
@@ -1,0 +1,2 @@
+from .flash_attn import *
+


### PR DESCRIPTION
# AMD ROCm Support for LightX2V

## Summary

This PR adds AMD ROCm support for LightX2V, enabling high-performance video generation on AMD GPUs. The implementation leverages the `aiter` library for optimized kernels.

## End-to-End Performance

### Wan2.1-T2V-1.3B (33 frames, 480×848, 20 steps)

| Configuration | Time | Speedup |
|---------------|------|---------|
| After PR (`flash_attn2`) | 13.96s | 1.00x |
| **After PR (`aiter_attn`)** | **6.31s** | **2.21x** |

### Qwen-Image-Edit-2511 (1024×1024, 8 steps)

| Configuration | Time | Speedup |
|---------------|------|---------|
| After PR (`flash_attn2`) | 4.83s | 1.00x |
| **After PR (`aiter_attn`)** | **2.86s** | **1.69x** |

> **Note**: Before this PR, LightX2V does not work on AMD ROCm due to missing `sgl_kernel` support. This PR enables AMD support and provides significant performance optimizations.

## Optimizations Added

| Optimization | Description | How to Enable |
|--------------|-------------|---------------|
| **sgl_kernel replacement** | Uses `aiter` for RMSNorm, FP8/INT8 GEMM | Automatic (required on AMD) |
| **VAE cudnn disabled** | Disables cudnn for faster convolution | Automatic |
| **aiter_attn** | Optimized Flash Attention using aiter FA3 | `attn_mode="aiter_attn"` |

### Kernel-Level Performance

| Kernel | Speedup (vs baseline) |
|--------|----------------------|
| Flash Attention (aiter vs flash_attn) | 5.5x - 5.7x |
| RMSNorm (aiter vs torch) | 3x - 4.2x |
| VAE Conv (cudnn disabled) | ~1.2x |

## Usage

### Environment Setup

Set the platform environment variable for AMD ROCm:

```bash
export PLATFORM=amd_rocm
```

### Wan Models (Text-to-Video)

```python
from lightx2v import LightX2VPipeline

# Initialize pipeline
pipe = LightX2VPipeline(
    model_path="/path/to/Wan2.1-T2V-14B",
    model_cls="wan2.1",
    task="t2v",
)

# Create generator with aiter_attn for AMD ROCm optimization
pipe.create_generator(
    attn_mode="aiter_attn",  # Use aiter_attn for 2.21x speedup on AMD
    infer_steps=50,
    height=480,
    width=832,
    num_frames=81,
    guidance_scale=5.0,
    sample_shift=5.0,
)

# Generate video
pipe.generate(
    seed=42,
    prompt="Two anthropomorphic cats in comfy boxing gear fight on a spotlighted stage.",
    negative_prompt="",
    save_result_path="output.mp4",
)
```

### Qwen-Image-Edit Models (Image-to-Image)

```python
from lightx2v import LightX2VPipeline

# Initialize pipeline
pipe = LightX2VPipeline(
    model_path="/path/to/Qwen-Image-Edit-2511",
    model_cls="qwen-image-edit-2511",
    task="i2i",
)

# Create generator with aiter_attn for AMD ROCm optimization
pipe.create_generator(
    attn_mode="aiter_attn",  # Use aiter_attn for 1.69x speedup on AMD
    auto_resize=True,
    infer_steps=8,
    guidance_scale=1,
)

# Generate image
pipe.generate(
    seed=42,
    image_path="input.png",
    prompt="Replace the shirt with a light blue shirt.",
    negative_prompt="",
    save_result_path="output.png",
)
```

## Installation

### Prerequisites

For AMD ROCm platform, `aiter` is **required**:

```bash
git clone https://github.com/ROCm/aiter.git /tmp/aiter && \
cd /tmp/aiter && \
git checkout a7d3bf8cd47afbaf6a6133c1f12e3b01d2c27b0e && \
pip install -e .
```

### Docker Support

Build AMD ROCm image:

```bash
docker build -f dockerfiles/Dockerfile.mi350 -t lightx2v:rocm .
```

Run container:

```bash
docker run --device=/dev/kfd --device=/dev/dri \
    --group-add video --cap-add=SYS_PTRACE \
    --security-opt seccomp=unconfined \
    -v /path/to/models:/models \
    lightx2v:rocm python your_script.py
```

## Platform Detection

AMD ROCm is automatically detected:
```python
IS_AMD_ROCM = hasattr(torch.version, "hip") and torch.version.hip is not None
```

When AMD ROCm is detected:
1. `aiter` is injected as `sgl_kernel` replacement (required for AMD support)
2. `cudnn` is automatically disabled (VAE optimization)
3. User can use `attn_mode="aiter_attn"` for additional Flash Attention optimization
