### PR TITLE
add rmsnorm one-pass triton kernel for small hidden-dim model

### DIFF
--- a/lightx2v/common/ops/norm/rms_norm_weight.py
+++ b/lightx2v/common/ops/norm/rms_norm_weight.py
@@ -9,6 +9,7 @@ from safetensors import safe_open
 from lightx2v.utils.envs import *
 from lightx2v.utils.registry_factory import RMS_WEIGHT_REGISTER
 from lightx2v_platform.base.global_var import AI_DEVICE
+from lightx2v.common.ops.norm.triton_ops import rms_norm_kernel
 
 try:
     import sgl_kernel
@@ -202,3 +203,21 @@ class RMSWeightSF(RMSWeight):
 
     def apply(self, x):
         return self._norm(x.float()).type_as(x) * self.weight
+
+
+@RMS_WEIGHT_REGISTER("one-pass")
+class RMSWeightOnePass(RMSWeight):
+    def __init__(
+        self,
+        weight_name,
+        create_cuda_buffer=False,
+        create_cpu_buffer=False,
+        lazy_load=False,
+        lazy_load_file=None,
+        is_post_adapter=False,
+        eps=1e-6,
+    ):
+        super().__init__(weight_name, create_cuda_buffer, create_cpu_buffer, lazy_load, lazy_load_file, is_post_adapter, eps)
+
+    def apply(self, input_tensor):
+        return rms_norm_kernel(input_tensor, self.weight, self.eps)

--- a/lightx2v/common/ops/norm/triton_ops.py
+++ b/lightx2v/common/ops/norm/triton_ops.py
@@ -900,3 +900,59 @@ def rms_norm_fn(
         out,
         residual_out,
     )
+
+
+@triton.jit
+def _rms_norm_tiled_onepass(
+    y_ptr,
+    x_ptr,
+    w_ptr,
+    SEQ: tl.constexpr,
+    DIM: tl.constexpr,
+    EPS: tl.constexpr,
+    BLOCK_SIZE_SEQ: tl.constexpr,
+    BLOCK_SIZE_DIM: tl.constexpr,
+):
+    seq_blk_id = tl.program_id(0)
+    seq_id = seq_blk_id * BLOCK_SIZE_SEQ
+
+    seq_offset = seq_id + tl.arange(0, BLOCK_SIZE_SEQ)[:, None]
+    s_mask = seq_offset < SEQ
+    d_offset = tl.arange(0, BLOCK_SIZE_DIM)[None, :]
+    d_mask = d_offset < DIM
+    y_blk = y_ptr + seq_offset * DIM + d_offset
+    x_blk = x_ptr + seq_offset * DIM + d_offset
+    mask = s_mask & d_mask
+
+    x = tl.load(x_blk, mask=mask, other=0.0).to(tl.float32)
+    mean_square = tl.sum(x * x, axis=1, keep_dims=True) / DIM
+    rstd = tl.math.rsqrt(mean_square + EPS)
+    w = tl.load(w_ptr + d_offset, mask=mask)
+    tl.store(y_blk, x * rstd * w, mask=mask)
+
+
+def rms_norm_kernel(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6):
+    shape = x.shape
+    x = x.contiguous()
+    y = torch.empty_like(x)
+    x_view = x.reshape(-1, shape[-1])
+    y_view = y.reshape(-1, shape[-1])
+    S, D = x_view.shape
+
+    BLOCK_SIZE_SEQ = min(16, triton.next_power_of_2(max(1, S // 512)))
+    grid = triton.cdiv(S, BLOCK_SIZE_SEQ),
+
+    with torch.cuda.device(x.device):
+        torch.library.wrap_triton(
+            _rms_norm_tiled_onepass
+        )[grid](
+            y_view,
+            x_view,
+            w,
+            S,
+            D,
+            eps,
+            BLOCK_SIZE_DIM=triton.next_power_of_2(D),
+            BLOCK_SIZE_SEQ=BLOCK_SIZE_SEQ,
+        )
+    return y

--- a/lightx2v/models/networks/qwen_image/weights/transformer_weights.py
+++ b/lightx2v/models/networks/qwen_image/weights/transformer_weights.py
@@ -143,7 +143,7 @@ class QwenImageCrossAttention(WeightModule):
         self.sparge = config.get("sparge", False)
         self.attn_type = config.get("attn_type", "flash_attn3")
         self.heads = config["attention_out_dim"] // config["attention_dim_head"]
-        self.rms_norm_type = config.get("rms_norm_type", "sgl-kernel")
+        self.rms_norm_type = config.get("rms_norm_type", "one-pass")
 
         self.lazy_load = lazy_load
         self.lazy_load_file = lazy_load_file


### PR DESCRIPTION
Performance(H800):

baseline:
``` text
2025-12-26 10:56:22.491 | INFO     | lightx2v.models.runners.qwen_image.qwen_image_runner:run:176 - ==> step_index: 38 / 40
2025-12-26 10:56:22.492 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_pre cost 0.000382 seconds
2025-12-26 10:56:24.057 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log 🚀 infer_main cost 1.565482 seconds
2025-12-26 10:56:24.057 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_post cost 0.000142 seconds
2025-12-26 10:56:24.057 | INFO     | lightx2v.models.runners.qwen_image.qwen_image_runner:run:176 - ==> step_index: 39 / 40
2025-12-26 10:56:24.058 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_pre cost 0.000405 seconds
2025-12-26 10:56:25.620 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log 🚀 infer_main cost 1.561535 seconds
2025-12-26 10:56:25.620 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_post cost 0.000144 seconds
2025-12-26 10:56:25.620 | INFO     | lightx2v.models.runners.qwen_image.qwen_image_runner:run:176 - ==> step_index: 40 / 40
2025-12-26 10:56:25.620 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_pre cost 0.000384 seconds
2025-12-26 10:56:27.179 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log 🚀 infer_main cost 1.558493 seconds
2025-12-26 10:56:27.179 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_post cost 0.000140 seconds
```

opt:
``` text
2025-12-26 11:30:11.594 | INFO     | lightx2v.models.runners.qwen_image.qwen_image_runner:run:176 - ==> step_index: 38 / 40
2025-12-26 11:30:11.595 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_pre cost 0.000395 seconds
2025-12-26 11:30:13.093 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log 🚀 infer_main cost 1.498101 seconds
2025-12-26 11:30:13.093 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_post cost 0.000164 seconds
2025-12-26 11:30:13.093 | INFO     | lightx2v.models.runners.qwen_image.qwen_image_runner:run:176 - ==> step_index: 39 / 40
2025-12-26 11:30:13.094 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_pre cost 0.000408 seconds
2025-12-26 11:30:14.591 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log 🚀 infer_main cost 1.497171 seconds
2025-12-26 11:30:14.591 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_post cost 0.000166 seconds
2025-12-26 11:30:14.591 | INFO     | lightx2v.models.runners.qwen_image.qwen_image_runner:run:176 - ==> step_index: 40 / 40
2025-12-26 11:30:14.592 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_pre cost 0.000432 seconds
2025-12-26 11:30:16.089 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log 🚀 infer_main cost 1.497309 seconds
2025-12-26 11:30:16.090 | INFO     | lightx2v.utils.profiler:__exit__:57 - [Profile] Single GPU - Level1_Log step_post cost 0.000142 seconds
```

torch profiler:

baseline: 470us

<img width="930" height="198" alt="image" src="https://github.com/user-attachments/assets/82d8d67c-bbf0-4ebd-8667-71f4d14f41e0" />

opt: 68us

<img width="828" height="212" alt="image" src="https://github.com/user-attachments/assets/40c545e4-12d1-4656-afbd-97a536127de3" />


