### PR TITLE
Align qwen-image RoPE function naming with other models

### DIFF
--- a/lightx2v/models/networks/qwen_image/infer/transformer_infer.py
+++ b/lightx2v/models/networks/qwen_image/infer/transformer_infer.py
@@ -7,7 +7,7 @@ from .triton_ops import (
     fuse_scale_shift_gate_select01_kernel,
     fuse_scale_shift_kernel,
 )
-from .utils import apply_rotary_emb_qwen, apply_rotary_emb_qwen_naive, apply_wan_rope_with_flashinfer
+from .utils import apply_qwen_rope_with_flashinfer, apply_qwen_rope_with_torch, apply_qwen_rope_with_torch_naive
 
 
 def calculate_q_k_len(q, k_lens):
@@ -38,12 +38,12 @@ class QwenImageTransformerInfer(BaseTransformerInfer):
         else:
             self.modulate_func = lambda x, scale, shift: x * (1 + scale) + shift
         rope_funcs = {
-            "flashinfer": apply_wan_rope_with_flashinfer,
-            "torch_naive": apply_rotary_emb_qwen_naive,
-            "torch": apply_rotary_emb_qwen,
+            "flashinfer": apply_qwen_rope_with_flashinfer,
+            "torch": apply_qwen_rope_with_torch,
+            "torch_naive": apply_qwen_rope_with_torch_naive,
         }
         rope_type = config.get("rope_type", "flashinfer")
-        self.apply_rope_func = rope_funcs.get(rope_type, apply_rotary_emb_qwen)
+        self.apply_rope_func = rope_funcs.get(rope_type, apply_qwen_rope_with_torch)
 
         self.img_qkv_len1 = None
         self.cu_seqlens_qkv1 = None

--- a/lightx2v/models/networks/qwen_image/infer/utils.py
+++ b/lightx2v/models/networks/qwen_image/infer/utils.py
@@ -8,7 +8,7 @@ except ImportError:
     apply_rope_with_cos_sin_cache_inplace = None
 
 
-def apply_wan_rope_with_flashinfer(
+def apply_qwen_rope_with_flashinfer(
     xq: torch.Tensor,
     xk: torch.Tensor,
     cos_sin_cache: torch.Tensor,
@@ -34,7 +34,7 @@ def apply_wan_rope_with_flashinfer(
     return xq_out, xk_out
 
 
-def apply_rotary_emb_qwen(
+def apply_qwen_rope_with_torch(
     xq: torch.Tensor,
     xk: torch.Tensor,
     cos_sin_cache: torch.Tensor,
@@ -47,7 +47,7 @@ def apply_rotary_emb_qwen(
     return xq_out.type_as(xq), xk_out.type_as(xk)
 
 
-def apply_rotary_emb_qwen_naive(
+def apply_qwen_rope_with_torch_naive(
     xq: torch.Tensor,
     xk: torch.Tensor,
     cos_sin_cache: torch.Tensor,

--- a/lightx2v/models/networks/wan/infer/transformer_infer.py
+++ b/lightx2v/models/networks/wan/infer/transformer_infer.py
@@ -34,8 +34,8 @@ class WanTransformerInfer(BaseTransformerInfer):
             self.modulate_func = modulate
         rope_funcs = {
             "flashinfer": apply_wan_rope_with_flashinfer,
-            "torch_naive": apply_wan_rope_with_torch_naive,
             "torch": apply_wan_rope_with_torch,
+            "torch_naive": apply_wan_rope_with_torch_naive,
         }
         rope_type = self.config.get("rope_type", "flashinfer")
         rope_func = rope_funcs.get(rope_type, apply_wan_rope_with_torch)


### PR DESCRIPTION
This PR renames the qwen-image RoPE function to `apply_qwen_rope_with_xxx` to align with the naming conventions used by RoPE functions in other models, improving consistency and readability across the codebase.

### Testing Done
```bash
root@worker3218:/ws/scripts/platforms/mthreads_musa# ./qwen_image_i2i_2511.sh
```