### PR TITLE
fix: add hasattr check for bias in _get_actual_bias

### DIFF
--- a/lightx2v/common/ops/mm/mm_weight.py
+++ b/lightx2v/common/ops/mm/mm_weight.py
@@ -1306,6 +1306,7 @@ class MMWeightWfp8channelAfp8channeldynamicQ8F(MMWeightQuantTemplate):
         self.load_func = self.load_fp8_perchannel_sym
         self.weight_need_transpose = False
         self.bias_force_fp32 = True
+        self.scale_force_fp32 = True
         if ops is not None:
             self.act_quant_func = self.act_quant_fp8_perchannel_sym_vllm
         else:
@@ -1363,6 +1364,7 @@ class MMWeightWint8channelAint8channeldynamicQ8F(MMWeightQuantTemplate):
         self.load_func = self.load_int8_perchannel_sym
         self.weight_need_transpose = False
         self.bias_force_fp32 = True
+        self.scale_force_fp32 = True
         if ops is not None:
             self.act_quant_func = self.act_quant_int8_perchannel_sym_vllm
         else:


### PR DESCRIPTION
## Problem

When using phase-level CPU offload with FP8 quantized models (e.g., `fp8-q8f`), the T5 encoder fails with two errors:

### Error 1: Missing bias attribute
```
AttributeError: 'MMWeightWfp8channelAfp8channeldynamicQ8F' object has no attribute 'bias'
```

### Error 2: Wrong dtype for weight_scale
```
RuntimeError: expected scalar type Float but found BFloat16
```

## Configuration that triggers these bugs

```json
{
  "t5_cpu_offload": true,
  "t5_offload_granularity": "phase",
  "t5_quantized": true,
  "t5_quant_scheme": "fp8-q8f",
  "use_bfloat16": true
}
```

## Root Causes

### Bug 1: Missing bias attribute
In `MMWeightTemplate._get_actual_bias()` (line 152), the code directly accesses `self.bias` without first checking if the attribute exists. The `load_quantized()` method only initializes `self.bias = None` if `bias` is in `base_attrs`, but `_update_base_attrs()` only adds bias to `base_attrs` if `bias_name is not None`. For layers without bias (like T5 attention Q/K/V projections), the `bias` attribute is never created.

### Bug 2: Wrong dtype for weight_scale
In `MMWeightWfp8channelAfp8channeldynamicQ8F.apply()`, `input_tensor_scale` is correctly cast to `.float()`, but `weight_scale` was not. The `q8_kernels.fp8_linear` function requires Float32 scales, but `weight_scale` remained in BFloat16.

## Fixes

### Fix 1: Add hasattr check (line 152)
```python
# Before
if self.bias is None:

# After
if not hasattr(self, "bias") or self.bias is None:
```

### Fix 2: Cast weight_scale to float32 (line 1321)
```python
# Before
self.weight_scale,

# After
self.weight_scale.float(),
```