### PR TITLE
fix(qwen): add USP support for Qwen-Image-Edit-2511

### DIFF
--- a/lightx2v/common/ops/attn/ulysses_attn.py
+++ b/lightx2v/common/ops/attn/ulysses_attn.py
@@ -142,10 +142,15 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                 shard_txt_k = txt_k[:, (cur_rank * shard_heads + h) : (cur_rank * shard_heads + h + 1), :]
                 shard_txt_v = txt_v[:, (cur_rank * shard_heads + h) : (cur_rank * shard_heads + h + 1), :]
 
-                # 合并图像和文本的查询、键和值
-                q = torch.cat((shard_img_q, shard_txt_q), dim=0)
-                k = torch.cat((shard_img_k, shard_txt_k), dim=0)
-                v = torch.cat((shard_img_v, shard_txt_v), dim=0)
+                # 合并图像和文本的查询、键和值（根据 img_first 决定顺序）
+                if img_first:
+                    q = torch.cat((shard_img_q, shard_txt_q), dim=0)
+                    k = torch.cat((shard_img_k, shard_txt_k), dim=0)
+                    v = torch.cat((shard_img_v, shard_txt_v), dim=0)
+                else:
+                    q = torch.cat((shard_txt_q, shard_img_q), dim=0)
+                    k = torch.cat((shard_txt_k, shard_img_k), dim=0)
+                    v = torch.cat((shard_txt_v, shard_img_v), dim=0)
 
                 # 调用注意力函数计算注意力结果
                 head_attn = attention_module.apply(q=q, k=k, v=v, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=max_seqlen_qkv, max_seqlen_kv=max_seqlen_qkv, **kwargs)


### PR DESCRIPTION
This commit fixes Ulysses Sequence Parallelism (USP) support for Qwen-Image-Edit-2511 models, addressing three critical issues:

1. img_first parameter handling in ulysses_attn.py
   - Fix Q/K/V concatenation order based on img_first flag
   - Qwen models use img_first=False (text before image)
   - Previously caused noise output in USP mode

2. Remove duplicate modulate_index sharding in transformer_infer.py
   - modulate_index was sharded twice (in scheduler.prepare and transformer_infer)
   - Caused bottom 25% of images to have noise artifacts

3. Add proper padding handling in model.py
   - Track padding size during sequence sharding
   - Remove padding in post-processing to restore correct shape

Test Results (8x RTX 5090):
- Before: Complete noise output or bottom artifacts
- After: Mean pixel diff=0.42, Max diff=52 (vs single GPU)
- PSNR > 40dB (excellent quality)
- 4-GPU: 1.68x speedup at 1664 resolution
- 8-GPU: 1.83x speedup at 1664 resolution

Fixes support for multi-GPU inference with Qwen-Image-Edit models.