### PR TITLE
Add channels_last_3d optimization for VAE Conv3d

### DIFF
--- a/lightx2v/models/video_encoders/hf/wan/vae.py
+++ b/lightx2v/models/video_encoders/hf/wan/vae.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from loguru import logger
 
+from lightx2v.utils.envs import GET_USE_CHANNELS_LAST_3D
 from lightx2v.utils.utils import load_weights
 from lightx2v_platform.base.global_var import AI_DEVICE
 
@@ -22,7 +23,7 @@ CACHE_T = 2
 
 class CausalConv3d(nn.Conv3d):
     """
-    Causal 3d convolusion.
+    Causal 3d convolution.
     """
 
     def __init__(self, *args, **kwargs):
@@ -46,6 +47,18 @@ class CausalConv3d(nn.Conv3d):
         x = F.pad(x, padding)
 
         return super().forward(x)
+
+
+def convert_to_channels_last_3d(module):
+    """
+    Recursively convert all Conv3d weights in module to channels_last_3d format.
+    This eliminates NCHW<->NHWC format conversion overhead in cuDNN.
+    """
+    for child in module.children():
+        if isinstance(child, nn.Conv3d):
+            child.weight.data = child.weight.data.to(memory_format=torch.channels_last_3d)
+        else:
+            convert_to_channels_last_3d(child)
 
 
 class RMS_norm(nn.Module):
@@ -827,6 +840,11 @@ def _video_vae(pretrained_path=None, z_dim=None, device="cpu", cpu_offload=False
         if weights_dict[k].dtype != dtype:
             weights_dict[k] = weights_dict[k].to(dtype)
     model.load_state_dict(weights_dict, assign=True)
+
+    # Convert Conv3d weights to channels_last_3d for cuDNN optimization
+    if GET_USE_CHANNELS_LAST_3D():
+        convert_to_channels_last_3d(model)
+        logger.info("VAE: Converted Conv3d weights to channels_last_3d format")
 
     return model
 

--- a/lightx2v/utils/envs.py
+++ b/lightx2v/utils/envs.py
@@ -47,3 +47,18 @@ def GET_SENSITIVE_DTYPE():
 def GET_RECORDER_MODE():
     RECORDER_MODE = int(os.getenv("RECORDER_MODE", "0"))
     return RECORDER_MODE
+
+
+@lru_cache(maxsize=None)
+def GET_USE_CHANNELS_LAST_3D():
+    """
+    Check if channels_last_3d memory format optimization is enabled.
+
+    When enabled (USE_CHANNELS_LAST_3D=1), Conv3d weights are converted to
+    channels_last_3d format, eliminating NCHW<->NHWC format conversion overhead
+    in cuDNN (~9% faster).
+
+    Returns:
+        bool: True if optimization is enabled, False otherwise (default).
+    """
+    return os.getenv("USE_CHANNELS_LAST_3D", "0") == "1"


### PR DESCRIPTION
## Summary

Add optional `channels_last_3d` memory format optimization for Conv3d operations in VAE:
- **PyTorch ≤2.8.0**: ~9% performance improvement (eliminates format conversion overhead)
- **PyTorch 2.9.x**: ~78% performance improvement (workaround for cuDNN 9.8+ bug)

## Motivation

The `channels_last_3d` (NDHWC) memory format eliminates format conversion overhead in cuDNN:

- **Eliminates format conversion**: Default NCDHW format requires NCHW↔NHWC conversions (17 kernel calls), `channels_last_3d` eliminates them
- **Same convolution kernels**: Both use 6 cuDNN convolution kernels, but default has extra overhead
- **No correctness impact**: Same mathematical operations, different memory layout

## Benchmark

```python
import time, torch, torch.nn as nn, torch.nn.functional as F

class Decoder(nn.Module):
    def __init__(self, use_cl3d=False):
        super().__init__()
        self.convs = nn.ModuleList([
            nn.Conv3d(16, 128, 3, padding=1), nn.Conv3d(128, 128, 3, padding=1),
            nn.Conv3d(128, 256, 3, padding=1), nn.Conv3d(256, 256, 3, padding=1),
            nn.Conv3d(256, 128, 3, padding=1), nn.Conv3d(128, 3, 3, padding=1),
        ])
        if use_cl3d:
            for c in self.convs:
                c.weight.data = c.weight.data.to(memory_format=torch.channels_last_3d)
    def forward(self, x):
        for c in self.convs:
            x = F.silu(c(F.pad(x, (1,1,1,1,2,0))))[:, :c.out_channels]
        return x

def bench(model, x, n=30):
    with torch.no_grad():
        for _ in range(5): model(x)
        torch.cuda.synchronize(); t = time.time()
        for _ in range(n): model(x)
        torch.cuda.synchronize()
    return (time.time() - t) / n * 1000

x = torch.randn(1, 16, 21, 60, 104, device="cuda", dtype=torch.bfloat16)
t1 = bench(Decoder(False).cuda().bfloat16().eval(), x)
t2 = bench(Decoder(True).cuda().bfloat16().eval(), x)
print(f"Default: {t1:.2f}ms, channels_last_3d: {t2:.2f}ms, speedup: {t1/t2:.2f}x")
```

### Results (RTX 5090, bfloat16)

| PyTorch | Default | channels_last_3d | Speedup |
|---------|---------|------------------|---------|
| 2.8.0 | 12.73 ms | 11.68 ms | **1.09x** |

### cuDNN Kernel Analysis

| Mode | Conv Kernels | Format Conversion | Other | Total |
|------|--------------|-------------------|-------|-------|
| Default | 6 | 17 (nchw↔nhwc) | 1 | 24 |
| channels_last_3d | 6 | 0 | 2 | 8 |

Eliminating 17 format conversion calls = ~9% faster.

## Additional Benefit for PyTorch 2.9.x Users

PyTorch 2.9.0 disabled cuDNN for bfloat16/float16 Conv3d due to a cuDNN 9.8+ bug ([pytorch#163539](https://github.com/pytorch/pytorch/issues/163539)). This causes significant performance regression (~2x slower). The `channels_last_3d` format bypasses this limitation, restoring cuDNN performance.

| PyTorch | Default | channels_last_3d | Speedup |
|---------|---------|------------------|---------|
| 2.9.0 | 20.47 ms | 11.50 ms | **1.78x** |

*Note: The cuDNN bug is fixed in PyTorch 2.10.0+ (cuDNN 9.15+), so the 2.9.x regression no longer exists. However, the ~9% optimization from eliminating format conversion still applies.*

## Changes

```python
# lightx2v/utils/envs.py
@lru_cache(maxsize=None)
def GET_USE_CHANNELS_LAST_3D():
    return os.getenv("USE_CHANNELS_LAST_3D", "0") == "1"

# lightx2v/models/video_encoders/hf/wan/vae.py (and vae_2_2.py)
def convert_to_channels_last_3d(module):
    for child in module.children():
        if isinstance(child, nn.Conv3d):
            child.weight.data = child.weight.data.to(memory_format=torch.channels_last_3d)
        else:
            convert_to_channels_last_3d(child)

# In _video_vae(), after load_state_dict:
if GET_USE_CHANNELS_LAST_3D():
    convert_to_channels_last_3d(model)
```

## Usage

```bash
USE_CHANNELS_LAST_3D=1 python script.py
```

## Notes

- Default is disabled (`USE_CHANNELS_LAST_3D=0`) for backward compatibility
- No memory overhead
