### PR TITLE
Make vllm optional when using int8-sgl

### DIFF
--- a/lightx2v/common/ops/mm/mm_weight.py
+++ b/lightx2v/common/ops/mm/mm_weight.py
@@ -1697,9 +1697,14 @@ class MMWeightWint8channelAint8channeldynamicSglActVllm(MMWeightQuantTemplate):
         )
         self.load_func = self.load_int8_perchannel_sym
         # Priority sglang > vllm > toarchao > triton
-        self.act_quant_func = sglang_int8_act_quant or (
-            self.act_quant_int8_perchannel_sym_vllm if vllm_ops else self.act_quant_int8_perchannel_sym_torchao if torchao_int8_quant else int8_quantize_triton
-        )
+        if sglang_int8_act_quant:
+            self.act_quant_func = sglang_int8_act_quant
+        elif vllm_ops:
+            self.act_quant_func = self.act_quant_int8_perchannel_sym_vllm
+        elif torchao_int8_quant:
+            self.act_quant_func = self.act_quant_int8_perchannel_sym_torchao
+        else:
+            self.act_quant_func = int8_quantize_triton
         self.weight_need_transpose = True
         self.scale_force_fp32 = True
 

--- a/lightx2v/common/ops/mm/mm_weight.py
+++ b/lightx2v/common/ops/mm/mm_weight.py
@@ -41,9 +41,15 @@ except ImportError:
     scaled_mxfp8_quant, cutlass_scaled_mxfp8_mm = None, None
 
 try:
-    from vllm import _custom_ops as ops
+    from vllm import _custom_ops as vllm_ops
 except ImportError:
-    ops = None
+    vllm_ops = None
+
+
+try:
+    from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8 as sglang_int8_act_quant
+except ImportError:
+    sglang_int8_act_quant = None
 
 try:
     import sgl_kernel
@@ -527,6 +533,8 @@ class MMWeightQuantTemplate(MMWeightTemplate):
     # =========================
     def act_quant_int8_perchannel_sym_torchao(self, x):
         input_tensor_quant, input_tensor_scale = torchao_int8_quant(x)
+        if self.scale_force_fp32:
+            input_tensor_scale = input_tensor_scale.to(torch.float32)
         return input_tensor_quant, input_tensor_scale
 
     def act_quant_fp8_perchannel_sym_torchao(self, x):
@@ -537,7 +545,7 @@ class MMWeightQuantTemplate(MMWeightTemplate):
         return quantized, scale.float()
 
     def act_quant_fp8_perchannel_sym_vllm(self, x):
-        input_tensor_quant, input_tensor_scale = ops.scaled_fp8_quant(x, None, scale_ub=None, use_per_token_if_dynamic=True)
+        input_tensor_quant, input_tensor_scale = vllm_ops.scaled_fp8_quant(x, None, scale_ub=None, use_per_token_if_dynamic=True)
         return input_tensor_quant, input_tensor_scale
 
     def act_quant_fp8_perchannel_sym_sgl(self, x):
@@ -548,7 +556,7 @@ class MMWeightQuantTemplate(MMWeightTemplate):
         return input_tensor_quant, input_tensor_scale
 
     def act_quant_int8_perchannel_sym_vllm(self, x):
-        input_tensor_quant, input_tensor_scale, _ = ops.scaled_int8_quant(x, scale=None, azp=None, symmetric=True)
+        input_tensor_quant, input_tensor_scale, _ = vllm_ops.scaled_int8_quant(x, scale=None, azp=None, symmetric=True)
         return input_tensor_quant, input_tensor_scale
 
     def act_quant_nvfp4(self, x):
@@ -1336,7 +1344,7 @@ class MMWeightWfp8channelAfp8channeldynamicQ8F(MMWeightQuantTemplate):
         self.weight_need_transpose = False
         self.bias_force_fp32 = True
         self.scale_force_fp32 = True
-        if ops is not None:
+        if vllm_ops is not None:
             self.act_quant_func = self.act_quant_fp8_perchannel_sym_vllm
         else:
             self.act_quant_func = fp8_quantize_triton
@@ -1394,7 +1402,7 @@ class MMWeightWint8channelAint8channeldynamicQ8F(MMWeightQuantTemplate):
         self.weight_need_transpose = False
         self.bias_force_fp32 = True
         self.scale_force_fp32 = True
-        if ops is not None:
+        if vllm_ops is not None:
             self.act_quant_func = self.act_quant_int8_perchannel_sym_vllm
         else:
             self.act_quant_func = int8_quantize_triton
@@ -1661,7 +1669,7 @@ class MMWeightWint8channelAint8channeldynamicSglActVllm(MMWeightQuantTemplate):
     Quant MM:
         Weight: int8 perchannel sym
         Act: int8 perchannel dynamic sym
-        Kernel: quant-mm using Sgl-kernel, act dynamic quant using vllm
+        Kernel: quant-mm using Sgl-kernel, act dynamic quant using sglang and fallbacke to whathever quant backend available with this priority: vllm > toarchao > triton
     """
 
     def __init__(
@@ -1688,7 +1696,10 @@ class MMWeightWint8channelAint8channeldynamicSglActVllm(MMWeightQuantTemplate):
             lora_path,
         )
         self.load_func = self.load_int8_perchannel_sym
-        self.act_quant_func = self.act_quant_int8_perchannel_sym_vllm
+        # Priority sglang > vllm > toarchao > triton
+        self.act_quant_func = sglang_int8_act_quant or (
+            self.act_quant_int8_perchannel_sym_vllm if vllm_ops else self.act_quant_int8_perchannel_sym_torchao if torchao_int8_quant else int8_quantize_triton
+        )
         self.weight_need_transpose = True
         self.scale_force_fp32 = True
 

--- a/lightx2v/common/ops/mm/mm_weight.py
+++ b/lightx2v/common/ops/mm/mm_weight.py
@@ -1669,7 +1669,7 @@ class MMWeightWint8channelAint8channeldynamicSglActVllm(MMWeightQuantTemplate):
     Quant MM:
         Weight: int8 perchannel sym
         Act: int8 perchannel dynamic sym
-        Kernel: quant-mm using Sgl-kernel, act dynamic quant using sglang and fallbacke to whathever quant backend available with this priority: vllm > toarchao > triton
+        Kernel: quant-mm using Sgl-kernel, act dynamic quant using sglang and fallback to whatever quant backend available with this priority: vllm > torchao > triton
     """
 
     def __init__(


### PR DESCRIPTION
### 4 steps durations (after 4 warmups):
- int8-sgl+sglang | DiT cost 0.949300 seconds
- int8-vllm | DiT cost 0.925486 seconds
- int8-triton | DiT cost 1.361189 seconds
- int8-sgl+torchao | Run DiT cost 2.184162 seconds
- int8-sgl+torchao-compile | Run DiT cost 1.305696 seconds - Decorated `def act_quant_int8_perchannel_sym_torchao(self, x)` with @torch.compile(). Just an experiment, not included in this PR.
- int8-torchao | DiT cost 9.677256 seconds
</br>

#### Env:
- GPU: Nvidia H100
- Base docker image:  nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04
- Pytorch: 2.9.1 (forked lightx2v and upgraded, it's working fine. Even 2.10.0 worked)
- FlashAttention 3

</br>
</br>

| **fp8 4steps**   | **fp8 8stpes**   |
|-----------------------|-----------------------|
| ![qwen_img_2512-fp8-sgl-4steps](https://github.com/user-attachments/assets/12f95d39-899e-4e4f-ac18-e40e8c1614a6) | ![qwen_img_2512-fp8-sgl-8steps](https://github.com/user-attachments/assets/1c4018d0-5d54-4f44-9b54-a0157d4c41e4) |
| **int8 4stpes**   | **int8 8steps**   |
| ![qwen_img_2512-int8-sgl-4steps](https://github.com/user-attachments/assets/75123a4a-b3b4-4f68-adc6-36fd6f2cf6ef) | ![qwen_img_2512-int8-sgl-8steps](https://github.com/user-attachments/assets/648ceabb-4b4c-4413-93ae-1ce08f2f7d5c) |

</br>
</br>

| **fp8 5stpes**   | **int8 5steps**   |
|-----------------------|-----------------------|
| ![qwen_img_2512-fp8-sgl-5steps_1](https://github.com/user-attachments/assets/3930e345-0a56-4902-9ef1-10387339582b) | ![qwen_img_2512-int8-sgl-5steps_1](https://github.com/user-attachments/assets/2ef58dea-049e-4f0d-a927-7c7082b8166b) |
| **fp8 5stpes**   | **int8 5steps**   |
| ![qwen_img_2512-fp8-sgl-5steps_3](https://github.com/user-attachments/assets/f0976ddb-9e6f-4913-9887-0bc2fda4a1e9) | ![qwen_img_2512-int8-sgl-5steps_3](https://github.com/user-attachments/assets/9fe3e886-df2d-45ac-9515-33eb1bc66d54) |
| **fp8 5stpes**   | **int8 5steps**   |
| ![qwen_img_2512-fp8-sgl-5steps_2](https://github.com/user-attachments/assets/4ae6e1d8-0632-4c50-afd0-4e98b1083541) | ![qwen_img_2512-int8-sgl-5steps_2](https://github.com/user-attachments/assets/207b3240-fbd4-4634-a363-2772a4a6ca12) |

The quality of triton int8 quant was worse, that's why I put it last in the priority.