### PR TITLE
fix(ltx2): restore Stage 1 sigma schedule at each run start

### DIFF
--- a/lightx2v/models/runners/ltx2/ltx2_runner.py
+++ b/lightx2v/models/runners/ltx2/ltx2_runner.py
@@ -435,6 +435,10 @@ class LTX2Runner(DefaultRunner):
             self.model = self.load_transformer()
             self.model.set_scheduler(self.scheduler)
 
+        if self.config.get("distilled_sigma_values") is not None:
+            stage1_sigmas = torch.tensor(self.config["distilled_sigma_values"], dtype=torch.float32, device=AI_DEVICE)
+            self.model.scheduler.reset_sigmas(stage1_sigmas)
+
         # Image conditioning (if any) is already prepared in run_input_encoder
         # and stored in self.video_denoise_mask and self.initial_video_latent
         self._prepare_scheduler()


### PR DESCRIPTION
Restores the full Stage 1 sigma schedule in init_run() before each job so long-lived workers do not keep the upsampler's shorter sigma schedule (which left Stage 1 at 3 steps instead of 8 after a prior Stage 2 run).