### PR TITLE
add elastic scheduling and make the system more stable

### DIFF
--- a/configs/disagg/wan_t2v_disagg_controller.json
+++ b/configs/disagg/wan_t2v_disagg_controller.json
@@ -16,6 +16,7 @@
     "disagg_config": {
         "bootstrap_addr": "127.0.0.1",
         "bootstrap_room": 0,
+        "ranks" : 8,
         "encoder_engine_rank": 0,
         "transformer_engine_rank": 1,
         "decoder_engine_rank": 2,

--- a/lightx2v/disagg/conn.py
+++ b/lightx2v/disagg/conn.py
@@ -480,6 +480,15 @@ class DataManager:
             if self.transfer_event is not None:
                 self.transfer_event.set()
 
+    def get_backlog_counts(self) -> Dict[str, int]:
+        with self.pool_lock:
+            waiting_pool_size = len(self.waiting_pool) if hasattr(self, "waiting_pool") else 0
+            return {
+                "request_pool": len(self.request_pool),
+                "waiting_pool": waiting_pool_size,
+                "request_status": len(self.request_status),
+            }
+
     def check_status(self, bootstrap_room: int):
         with self.pool_lock:
             if (

--- a/lightx2v/disagg/examples/run_service.py
+++ b/lightx2v/disagg/examples/run_service.py
@@ -49,6 +49,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default="auto",
         help="Service role. auto = infer from config_json.disagg_mode",
     )
+    parser.add_argument(
+        "--engine_rank",
+        type=int,
+        default=None,
+        help="Override engine rank for encoder/transformer/decoder service.",
+    )
     return parser
 
 
@@ -109,6 +115,10 @@ def main():
     args = _build_parser().parse_args()
     config, raw_cfg = _build_runtime_config(args)
     service_mode = _resolve_service_mode(args, raw_cfg)
+
+    if args.engine_rank is not None and service_mode in {"encoder", "transformer", "decoder"}:
+        rank_key = f"{service_mode}_engine_rank"
+        config[rank_key] = int(args.engine_rank)
 
     seed_all(args.seed)
     logger.info("Starting disagg service mode={}", service_mode)

--- a/lightx2v/disagg/monitor.py
+++ b/lightx2v/disagg/monitor.py
@@ -26,6 +26,12 @@ class Reporter:
         )
         self._context = zmq.Context.instance()
         self._stop_event = threading.Event()
+        self._metrics_lock = threading.Lock()
+        self._extra_metrics_provider: Optional[Callable[[], Dict[str, Any]]] = None
+
+    def set_extra_metrics_provider(self, provider: Optional[Callable[[], Dict[str, Any]]]):
+        with self._metrics_lock:
+            self._extra_metrics_provider = provider
 
     def _query_gpu_metrics(self) -> Dict[str, Any]:
         cmd = [
@@ -55,6 +61,13 @@ class Reporter:
         try:
             metrics.update(self._query_gpu_metrics())
             metrics["status"] = "ok"
+
+            with self._metrics_lock:
+                provider = self._extra_metrics_provider
+            if provider is not None:
+                extra_metrics = provider()
+                if isinstance(extra_metrics, dict):
+                    metrics.update(extra_metrics)
         except Exception as exc:
             metrics["status"] = "error"
             metrics["error"] = str(exc)

--- a/lightx2v/disagg/rdma_client.py
+++ b/lightx2v/disagg/rdma_client.py
@@ -29,12 +29,15 @@ class QPType:
 class WROpcode:
     RDMA_WRITE = e.IBV_WR_RDMA_WRITE
     RDMA_READ = e.IBV_WR_RDMA_READ
+    ATOMIC_FETCH_AND_ADD = e.IBV_WR_ATOMIC_FETCH_AND_ADD
+    ATOMIC_CMP_AND_SWP = e.IBV_WR_ATOMIC_CMP_AND_SWP
 
 
 class AccessFlag:
     LOCAL_WRITE = e.IBV_ACCESS_LOCAL_WRITE
     REMOTE_WRITE = e.IBV_ACCESS_REMOTE_WRITE
     REMOTE_READ = e.IBV_ACCESS_REMOTE_READ
+    REMOTE_ATOMIC = e.IBV_ACCESS_REMOTE_ATOMIC
 
 
 class RDMAClient:
@@ -100,7 +103,7 @@ class RDMAClient:
     def _modify_qp_to_rts(self):
         # Follow the standard RC flow: INIT -> RTR -> RTS.
         init_attr = QPAttr(port_num=self.port_num)
-        init_attr.qp_access_flags = AccessFlag.LOCAL_WRITE | AccessFlag.REMOTE_WRITE | AccessFlag.REMOTE_READ
+        init_attr.qp_access_flags = AccessFlag.LOCAL_WRITE | AccessFlag.REMOTE_WRITE | AccessFlag.REMOTE_READ | AccessFlag.REMOTE_ATOMIC
         self.qp.to_init(init_attr)
 
         rtr_attr = QPAttr(port_num=self.port_num)
@@ -208,16 +211,60 @@ class RDMAClient:
                 self.remote_info["rkey"] = old_rkey
 
     def rdma_faa(self, remote_addr, add_value, rkey=None):
-        """Best-effort FAA semantics via read-modify-write.
-
-        NOTE: This is not a true remote atomic verb; it is a compatibility shim
-        until atomic WR support is implemented.
-        """
+        """Execute true remote atomic fetch-and-add and return previous value."""
         with self._io_lock:
-            old = self.rdma_read_from(int(remote_addr), 8, rkey=rkey)
+            self._ensure_local_mr_capacity(8)
+
+            # The original remote value will be written into this local buffer.
+            self.local_mr.write(b"\x00" * 8, 8, 0)
+
+            sge = SGE(self.local_mr.buf, 8, self.local_mr.lkey)
+            wr = WR(
+                wr_id=125,
+                opcode=WROpcode.ATOMIC_FETCH_AND_ADD,
+                num_sge=1,
+                sg=[sge],
+                send_flags=e.IBV_SEND_SIGNALED,
+            )
+
+            target_rkey = int(self.remote_info["rkey"] if rkey is None else rkey)
+            add_u64 = int(add_value) & ((1 << 64) - 1)
+            wr.set_wr_atomic(target_rkey, int(remote_addr), add_u64, 0)
+
+            self.qp.post_send(wr)
+            self._poll_cq()
+
+            old = self.local_mr.read(8, 0)
             old_v = int.from_bytes(old, byteorder="little", signed=False)
-            new_v = (old_v + int(add_value)) & ((1 << 64) - 1)
-            self.rdma_write_to(int(remote_addr), new_v.to_bytes(8, byteorder="little", signed=False), rkey=rkey)
+            return old_v
+
+    def rdma_cas(self, remote_addr, compare_value, swap_value, rkey=None):
+        """Execute true remote atomic compare-and-swap and return previous value."""
+        with self._io_lock:
+            self._ensure_local_mr_capacity(8)
+
+            # The original remote value will be written into this local buffer.
+            self.local_mr.write(b"\x00" * 8, 8, 0)
+
+            sge = SGE(self.local_mr.buf, 8, self.local_mr.lkey)
+            wr = WR(
+                wr_id=126,
+                opcode=WROpcode.ATOMIC_CMP_AND_SWP,
+                num_sge=1,
+                sg=[sge],
+                send_flags=e.IBV_SEND_SIGNALED,
+            )
+
+            target_rkey = int(self.remote_info["rkey"] if rkey is None else rkey)
+            compare_u64 = int(compare_value) & ((1 << 64) - 1)
+            swap_u64 = int(swap_value) & ((1 << 64) - 1)
+            wr.set_wr_atomic(target_rkey, int(remote_addr), compare_u64, swap_u64)
+
+            self.qp.post_send(wr)
+            self._poll_cq()
+
+            old = self.local_mr.read(8, 0)
+            old_v = int.from_bytes(old, byteorder="little", signed=False)
             return old_v
 
     def _poll_cq(self):
@@ -245,10 +292,28 @@ class RDMAClient:
 #     cli.connect_to_server('127.0.0.1') # 替换为服务器 IP
 
 #     # 执行单边写
-#     msg = b"Hello RDMA!"
-#     cli.rdma_write(msg)
-#     print("Write done.")
+#     # msg = b"Hello RDMA!"
+#     # cli.rdma_write(msg)
+#     # print("Write done.")
+
+#     # # 执行单边读
+#     # data = cli.rdma_read(len(msg))
+#     # print("Read data:", data)
+
+#     # 执行单边写（rdma_write 需要 bytes-like 数据）
+#     value = 123
+#     payload = int(value).to_bytes(8, byteorder="little", signed=False)
+#     cli.rdma_write(payload)
+#     print(f"Write done. value={value}")
 
 #     # 执行单边读
-#     data = cli.rdma_read(len(msg))
-#     print("Read data:", data)
+#     data = cli.rdma_read(8)
+#     read_value = int.from_bytes(data, byteorder="little", signed=False)
+#     print(f"Read data: raw={data} parsed={read_value}")
+
+#     old_value = cli.rdma_faa(remote_addr=cli.remote_info["addr"], add_value=10)
+#     print(f"FAA old value: {old_value}")
+
+#     data = cli.rdma_read(8)
+#     faa_read_value = int.from_bytes(data, byteorder="little", signed=False)
+#     print(f"Read data after FAA: raw={data} parsed={faa_read_value}")

--- a/lightx2v/disagg/rdma_server.py
+++ b/lightx2v/disagg/rdma_server.py
@@ -31,6 +31,7 @@ class AccessFlag:
     LOCAL_WRITE = e.IBV_ACCESS_LOCAL_WRITE
     REMOTE_WRITE = e.IBV_ACCESS_REMOTE_WRITE
     REMOTE_READ = e.IBV_ACCESS_REMOTE_READ
+    REMOTE_ATOMIC = e.IBV_ACCESS_REMOTE_ATOMIC
 
 
 class RDMAServer:
@@ -74,7 +75,11 @@ class RDMAServer:
 
         # 关键：注册一块内存用于被远程访问
         # buffer_size 可配置，允许远程写入 (REMOTE_WRITE) 和远程读取 (REMOTE_READ)
-        self.mr = MR(self.pd, self.buffer_size, AccessFlag.LOCAL_WRITE | AccessFlag.REMOTE_WRITE | AccessFlag.REMOTE_READ)
+        self.mr = MR(
+            self.pd,
+            self.buffer_size,
+            AccessFlag.LOCAL_WRITE | AccessFlag.REMOTE_WRITE | AccessFlag.REMOTE_READ | AccessFlag.REMOTE_ATOMIC,
+        )
 
         # 初始化缓冲区数据 (例如全为 0)
         zeros = b"\x00" * self.buffer_size
@@ -185,7 +190,7 @@ class RDMAServer:
     def _modify_qp_to_rts(self, qp, remote_info, local_psn):
         # Follow the standard RC flow: INIT -> RTR -> RTS.
         init_attr = QPAttr(port_num=self.port_num)
-        init_attr.qp_access_flags = AccessFlag.LOCAL_WRITE | AccessFlag.REMOTE_WRITE | AccessFlag.REMOTE_READ
+        init_attr.qp_access_flags = AccessFlag.LOCAL_WRITE | AccessFlag.REMOTE_WRITE | AccessFlag.REMOTE_READ | AccessFlag.REMOTE_ATOMIC
         qp.to_init(init_attr)
 
         rtr_attr = QPAttr(port_num=self.port_num)

--- a/lightx2v/disagg/services/controller.py
+++ b/lightx2v/disagg/services/controller.py
@@ -1,5 +1,12 @@
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Mapping
 from pathlib import Path
 from threading import Event, Lock, Thread
+from typing import Any
 
 from lightx2v.disagg.conn import MONITOR_POLLING_PORT, REQUEST_POLLING_PORT, ReqManager
 from lightx2v.disagg.monitor import Monitor
@@ -27,6 +34,226 @@ class ControllerService(BaseService):
         self._rdma_handshake_thread_request: Thread | None = None
         self._rdma_handshake_thread_phase1: Thread | None = None
         self._rdma_handshake_thread_phase2: Thread | None = None
+        self._instance_lock = Lock()
+        self._free_gpus: set[int] = set()
+        self._managed_instances: dict[str, dict[str, Any]] = {}
+        self.started_instances: list[tuple[str, str]] = []
+        self._runtime_config: dict[str, Any] | None = None
+        self._bootstrap_addr: str = "127.0.0.1"
+        self._gpu_reuse_block_until: dict[int, float] = {}
+        self._gpu_reuse_grace_seconds: float = 5.0
+        self._shutting_down: bool = False
+
+    def _is_tcp_port_open(self, host: str, port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            return sock.connect_ex((host, port)) == 0
+
+    def _wait_for_tcp_port_state(self, host: str, port: int, should_be_open: bool, timeout_seconds: float) -> bool:
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            is_open = self._is_tcp_port_open(host, port)
+            if is_open == should_be_open:
+                return True
+            time.sleep(0.1)
+        return self._is_tcp_port_open(host, port) == should_be_open
+
+    def _to_plain(self, value: Any) -> Any:
+        """Recursively convert config containers (e.g. LockableDict) to built-in Python types."""
+        if isinstance(value, Mapping):
+            return {k: self._to_plain(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._to_plain(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self._to_plain(v) for v in value)
+        if isinstance(value, set):
+            return {self._to_plain(v) for v in value}
+        return value
+
+    def _monitor_node_from_instance_address(self, instance_address: str) -> str:
+        host, port_str = instance_address.rsplit(":", 1)
+        rank = int(port_str) - REQUEST_POLLING_PORT
+        return f"tcp://{host}:{MONITOR_POLLING_PORT + rank}"
+
+    def _instance_address_from_monitor_node(self, monitor_node: str) -> str:
+        host_port = monitor_node
+        if host_port.startswith("tcp://"):
+            host_port = host_port[len("tcp://") :]
+        host, port_str = host_port.rsplit(":", 1)
+        rank = int(port_str) - MONITOR_POLLING_PORT
+        return f"{host}:{REQUEST_POLLING_PORT + rank}"
+
+    def _init_gpu_pool(self, config: dict):
+        disagg_cfg = config.get("disagg_config") if isinstance(config.get("disagg_config"), dict) else {}
+        total_ranks = int(config.get("ranks", disagg_cfg.get("ranks", 8)))
+        if total_ranks <= 0:
+            raise ValueError("ranks must be positive")
+
+        self._free_gpus = set(range(total_ranks))
+
+    def create_instance(self, instance_type: str) -> str:
+        """Create one service instance on an idle GPU and add it to scheduling pool."""
+        if instance_type not in {"encoder", "transformer", "decoder"}:
+            raise ValueError("instance_type must be one of: encoder, transformer, decoder")
+        if self._runtime_config is None:
+            raise RuntimeError("controller runtime config is not initialized")
+
+        with self._instance_lock:
+            if not self._free_gpus:
+                raise RuntimeError("no idle GPU available")
+
+            now = time.time()
+            gpu_id: int | None = None
+            for candidate_gpu in sorted(self._free_gpus):
+                if now < self._gpu_reuse_block_until.get(candidate_gpu, 0.0):
+                    continue
+
+                monitor_port = MONITOR_POLLING_PORT + candidate_gpu
+                if self._is_tcp_port_open(self._bootstrap_addr, monitor_port):
+                    self.logger.warning(
+                        "Skip gpu=%s for %s creation because monitor port %s is still in use",
+                        candidate_gpu,
+                        instance_type,
+                        monitor_port,
+                    )
+                    continue
+
+                gpu_id = candidate_gpu
+                break
+
+            if gpu_id is None:
+                raise RuntimeError(f"no idle GPU available for {instance_type}: all candidates cooling down or port is in use")
+
+            instance_cfg = self._to_plain(self._runtime_config)
+            instance_cfg["disagg_mode"] = instance_type
+            if instance_type == "encoder":
+                instance_cfg["encoder_engine_rank"] = gpu_id
+            elif instance_type == "transformer":
+                instance_cfg["transformer_engine_rank"] = gpu_id
+            else:
+                instance_cfg["decoder_engine_rank"] = gpu_id
+
+            model_path = instance_cfg.get("model_path")
+            config_json = instance_cfg.get("config_json")
+            if not model_path or not config_json:
+                raise RuntimeError("model_path and config_json are required to launch service subprocess")
+
+            cmd = [
+                sys.executable,
+                "-m",
+                "lightx2v.disagg.examples.run_service",
+                "--service",
+                instance_type,
+                "--engine_rank",
+                str(gpu_id),
+                "--model_cls",
+                str(instance_cfg.get("model_cls", "wan2.1")),
+                "--task",
+                str(instance_cfg.get("task", "t2v")),
+                "--model_path",
+                str(model_path),
+                "--config_json",
+                str(config_json),
+                "--seed",
+                str(instance_cfg.get("seed", 42)),
+                "--prompt",
+                str(instance_cfg.get("prompt", "")),
+                "--negative_prompt",
+                str(instance_cfg.get("negative_prompt", "")),
+                "--save_result_path",
+                str(instance_cfg.get("save_path", "")),
+            ]
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+            process = subprocess.Popen(cmd, env=env)
+
+            monitor_port = MONITOR_POLLING_PORT + gpu_id
+            if not self._wait_for_tcp_port_state(self._bootstrap_addr, monitor_port, should_be_open=True, timeout_seconds=8.0):
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=3.0)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                raise RuntimeError(f"service {instance_type} on gpu={gpu_id} failed to expose monitor port {monitor_port}")
+
+            instance_address = f"{self._bootstrap_addr}:{REQUEST_POLLING_PORT + gpu_id}"
+            self._free_gpus.remove(gpu_id)
+            self.add_instance(instance_type, instance_address)
+            monitor_node = f"tcp://{self._bootstrap_addr}:{MONITOR_POLLING_PORT + gpu_id}"
+            if monitor_node not in self.monitor.nodes:
+                self.monitor.nodes.append(monitor_node)
+            self._managed_instances[instance_address] = {
+                "instance_type": instance_type,
+                "gpu_id": gpu_id,
+                "process": process,
+            }
+            self.started_instances.append((instance_type, instance_address))
+            self.logger.info(
+                "Created %s instance on gpu=%s pid=%s address=%s",
+                instance_type,
+                gpu_id,
+                process.pid,
+                instance_address,
+            )
+            return instance_address
+
+    def reclaim_instance(self, instance_type: str, instance_address: str | None = None) -> str:
+        """Reclaim one managed instance and return its GPU back to idle pool."""
+        if instance_type not in {"encoder", "transformer", "decoder"}:
+            raise ValueError("instance_type must be one of: encoder, transformer, decoder")
+
+        with self._instance_lock:
+            target_address = instance_address
+            if target_address is None:
+                candidates = [addr for addr, meta in self._managed_instances.items() if meta.get("instance_type") == instance_type]
+                if not candidates:
+                    raise RuntimeError(f"no managed {instance_type} instance to reclaim")
+                target_address = candidates[-1]
+
+            meta = self._managed_instances.get(target_address)
+            if meta is None:
+                raise RuntimeError(f"instance not managed by controller: {target_address}")
+            if meta.get("instance_type") != instance_type:
+                raise RuntimeError(f"instance type mismatch for {target_address}: expected={instance_type} got={meta.get('instance_type')}")
+
+            process = meta.get("process")
+            gpu_id = int(meta.get("gpu_id"))
+
+            self.remove_instance(instance_type, target_address)
+            monitor_node = self._monitor_node_from_instance_address(target_address)
+            if monitor_node in self.monitor.nodes:
+                self.monitor.nodes.remove(monitor_node)
+
+            if process is not None and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=1.0)
+
+            monitor_port = MONITOR_POLLING_PORT + gpu_id
+            if not self._wait_for_tcp_port_state(self._bootstrap_addr, monitor_port, should_be_open=False, timeout_seconds=5.0):
+                self.logger.warning(
+                    "Monitor port still open after reclaim: service=%s gpu=%s port=%s",
+                    instance_type,
+                    gpu_id,
+                    monitor_port,
+                )
+
+            self._free_gpus.add(gpu_id)
+            self._gpu_reuse_block_until[gpu_id] = time.time() + self._gpu_reuse_grace_seconds
+            self._managed_instances.pop(target_address, None)
+            if (instance_type, target_address) in self.started_instances:
+                self.started_instances.remove((instance_type, target_address))
+            self.logger.info(
+                "Reclaimed %s instance from gpu=%s address=%s",
+                instance_type,
+                gpu_id,
+                target_address,
+            )
+            return target_address
 
     def _init_request_rdma_buffer(self, bootstrap_addr: str, config: dict):
         slots = int(config.get("rdma_buffer_slots", "128"))
@@ -149,16 +376,21 @@ class ControllerService(BaseService):
         self.logger.info("Request enqueued to encoder request RDMA buffer")
 
     def run(self, config):
-        """Initialize instances, send requests, wait for decoder save_path callbacks, then exit."""
+        """Initialize controller buffers, send requests, wait for decoder save_path callbacks, then exit."""
         if config is None:
             raise ValueError("config cannot be None")
+
+        self._shutting_down = False
 
         bootstrap_addr = config.get("data_bootstrap_addr", "127.0.0.1")
         encoder_engine_rank = config.get("encoder_engine_rank", 0)
         transformer_engine_rank = config.get("transformer_engine_rank", 1)
         decoder_engine_rank = config.get("decoder_engine_rank", 2)
-        request_count = int(config.get("request_count", 2))
+        request_count = int(config.get("request_count", 10))
         result_port = int(config.get("controller_result_port", REQUEST_POLLING_PORT - 1))
+        self._bootstrap_addr = str(bootstrap_addr)
+        self._runtime_config = self._to_plain(config)
+        self._init_gpu_pool(config)
 
         self.encoder_policy = RoundRobinPolicy()
         self.transformer_policy = RoundRobinPolicy()
@@ -166,12 +398,8 @@ class ControllerService(BaseService):
 
         self._init_request_rdma_buffer(bootstrap_addr, config)
 
-        self.add_instance("encoder", f"{bootstrap_addr}:{REQUEST_POLLING_PORT + encoder_engine_rank}")
-        self.add_instance(
-            "transformer",
-            f"{bootstrap_addr}:{REQUEST_POLLING_PORT + transformer_engine_rank}",
-        )
-        self.add_instance("decoder", f"{bootstrap_addr}:{REQUEST_POLLING_PORT + decoder_engine_rank}")
+        for instance_type in ("encoder", "transformer", "decoder"):
+            address = self.create_instance(instance_type)
 
         monitor_nodes = [
             f"tcp://{bootstrap_addr}:{MONITOR_POLLING_PORT + encoder_engine_rank}",
@@ -181,10 +409,114 @@ class ControllerService(BaseService):
         self.monitor.nodes = monitor_nodes
 
         monitor_stop_event = Event()
+        scale_out_threshold = 80.0
+        scale_in_threshold = 20.0
+        scale_cooldown_seconds = 30.0
+        last_scale_ts: dict[str, float] = {
+            "encoder": 0.0,
+            "transformer": 0.0,
+            "decoder": 0.0,
+        }
 
         def _monitor_callback(results):
+            if self._shutting_down:
+                return
+
+            service_metrics: dict[str, list[dict[str, Any]]] = {
+                "encoder": [],
+                "transformer": [],
+                "decoder": [],
+            }
+
             for item in results:
                 self.logger.info("monitor: %s", item)
+                if not isinstance(item, dict):
+                    continue
+
+                service_type = str(item.get("service_type", ""))
+                if service_type not in {"encoder", "transformer", "decoder"}:
+                    continue
+
+                if item.get("status") != "ok":
+                    continue
+
+                try:
+                    gpu_utilization = float(item.get("gpu_utilization", 0.0))
+                except (TypeError, ValueError):
+                    continue
+
+                monitor_address = str(item.get("address", ""))
+                if not monitor_address:
+                    continue
+
+                queue_total_pending = item.get("queue_total_pending", None)
+                try:
+                    queue_total_pending_int = int(queue_total_pending) if queue_total_pending is not None else -1
+                except (TypeError, ValueError):
+                    queue_total_pending_int = -1
+
+                all_queues_empty = bool(item.get("all_queues_empty", False))
+
+                service_metrics[service_type].append(
+                    {
+                        "gpu_utilization": gpu_utilization,
+                        "monitor_address": monitor_address,
+                        "queue_total_pending": queue_total_pending_int,
+                        "all_queues_empty": all_queues_empty,
+                    }
+                )
+
+            for service_type, metrics in service_metrics.items():
+                if not metrics:
+                    continue
+
+                now = time.time()
+                avg_gpu_utilization = sum(float(metric["gpu_utilization"]) for metric in metrics) / len(metrics)
+
+                if avg_gpu_utilization > scale_out_threshold and now - last_scale_ts[service_type] >= scale_cooldown_seconds:
+                    try:
+                        new_address = self.create_instance(service_type)
+                        last_scale_ts[service_type] = now
+                        self.logger.info(
+                            "Auto-scale out triggered: service=%s avg_gpu_utilization=%.2f new_instance=%s",
+                            service_type,
+                            avg_gpu_utilization,
+                            new_address,
+                        )
+                    except Exception as exc:
+                        self.logger.warning(
+                            "Auto-scale out skipped for service=%s avg_gpu_utilization=%.2f reason=%s",
+                            service_type,
+                            avg_gpu_utilization,
+                            exc,
+                        )
+
+                low_metric = min(metrics, key=lambda metric: float(metric["gpu_utilization"]))
+                low_utilization = float(low_metric["gpu_utilization"])
+                low_monitor_address = str(low_metric["monitor_address"])
+                with self._instance_lock:
+                    service_instance_count = sum(1 for meta in self._managed_instances.values() if meta.get("instance_type") == service_type)
+
+                queues_empty_for_service = bool(low_metric.get("all_queues_empty", False)) and int(low_metric.get("queue_total_pending", -1)) == 0
+
+                if low_utilization < scale_in_threshold and service_instance_count > 1 and queues_empty_for_service and now - last_scale_ts[service_type] >= scale_cooldown_seconds:
+                    try:
+                        target_instance_address = self._instance_address_from_monitor_node(low_monitor_address)
+                        self.reclaim_instance(service_type, target_instance_address)
+                        last_scale_ts[service_type] = now
+                        self.logger.info(
+                            "Auto-scale in triggered: service=%s low_gpu_utilization=%.2f reclaimed_instance=%s",
+                            service_type,
+                            low_utilization,
+                            target_instance_address,
+                        )
+                    except Exception as exc:
+                        self.logger.warning(
+                            "Auto-scale in skipped for service=%s low_gpu_utilization=%.2f reason=%s",
+                            service_type,
+                            low_utilization,
+                            exc,
+                        )
 
         monitor_thread = Thread(
             target=self.monitor.run_forever,
@@ -196,7 +528,7 @@ class ControllerService(BaseService):
             name="controller-monitor",
             daemon=True,
         )
-        # monitor_thread.start()
+        monitor_thread.start()
 
         base_save_path = config.get("save_path")
         expected_rooms: set[int] = set()
@@ -210,11 +542,16 @@ class ControllerService(BaseService):
                 request_config["controller_result_port"] = result_port
                 if base_save_path:
                     save_path = Path(base_save_path)
-                    request_config["save_path"] = str(save_path.with_name(f"{save_path.stem}{i + 1}{save_path.suffix}"))
+                    request_config["save_path"] = str(save_path.with_name(f"{save_path.stem}{i}{save_path.suffix}"))
                 # TODO: use queue to receive request from client and dispatch, currently we just send the same request multiple times for testing
                 with self._lock:
                     current_request = request_config
                 self.send_request(current_request)
+                self.logger.info(
+                    "Dispatched request room=%s save_path=%s",
+                    i,
+                    request_config.get("save_path"),
+                )
 
                 expected_rooms.add(i)
 
@@ -262,6 +599,12 @@ class ControllerService(BaseService):
 
             self.logger.info("All decoder results received. Controller exiting.")
         finally:
-            pass
-            # monitor_stop_event.set()
-            # monitor_thread.join(timeout=1.0)
+            self._shutting_down = True
+            monitor_stop_event.set()
+            monitor_thread.join(timeout=2.0)
+
+            for instance_type, address in reversed(list(self.started_instances)):
+                try:
+                    self.reclaim_instance(instance_type, address)
+                except Exception:
+                    self.logger.exception("Failed to reclaim %s instance address=%s", instance_type, address)

--- a/lightx2v/disagg/services/decoder.py
+++ b/lightx2v/disagg/services/decoder.py
@@ -3,7 +3,7 @@ import json
 import threading
 import time
 from collections import deque
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 
@@ -48,6 +48,13 @@ class DecoderService(BaseService):
             gpu_id=self.decoder_engine_rank,
             bind_address=f"tcp://{self.config.get('data_bootstrap_addr', '127.0.0.1')}:{MONITOR_POLLING_PORT + self.decoder_engine_rank}",
         )
+        self._queue_metrics_lock = threading.Lock()
+        self._queue_metrics: dict[str, Any] = {
+            "queue_sizes": {},
+            "queue_total_pending": 0,
+            "all_queues_empty": True,
+        }
+        self.reporter.set_extra_metrics_provider(self._get_queue_metrics)
         self._reporter_thread: Optional[threading.Thread] = threading.Thread(
             target=self.reporter.serve_forever,
             name="decoder-reporter",
@@ -55,6 +62,28 @@ class DecoderService(BaseService):
         )
         self._reporter_thread.start()
         self.load_models()
+
+    def _get_queue_metrics(self) -> dict[str, Any]:
+        with self._queue_metrics_lock:
+            queue_sizes = dict(self._queue_metrics.get("queue_sizes", {}))
+            return {
+                "queue_sizes": queue_sizes,
+                "queue_total_pending": int(self._queue_metrics.get("queue_total_pending", 0)),
+                "all_queues_empty": bool(self._queue_metrics.get("all_queues_empty", True)),
+            }
+
+    def _update_queue_metrics(self, queue_sizes: dict[str, int], transfer_sizes: Optional[dict[str, int]] = None):
+        merged_sizes = {k: int(v) for k, v in queue_sizes.items()}
+        if transfer_sizes is not None:
+            for key, value in transfer_sizes.items():
+                merged_sizes[f"transfer_{key}"] = int(value)
+        total_pending = sum(max(v, 0) for v in merged_sizes.values())
+        with self._queue_metrics_lock:
+            self._queue_metrics = {
+                "queue_sizes": merged_sizes,
+                "queue_total_pending": total_pending,
+                "all_queues_empty": total_pending == 0,
+            }
 
     def _ensure_phase2_request_buffer(self) -> bool:
         if self._phase2_rdma_buffer is not None:
@@ -92,10 +121,6 @@ class DecoderService(BaseService):
         self._phase2_handshake_port = int(self.config.get("rdma_phase2_handshake_port", self._phase2_handshake_port))
         self._phase2_slots = shared_slots
         self._phase2_slot_size = shared_slot_size
-
-        self.encoder_engine_rank = int(self.config.get("encoder_engine_rank", 0))
-        self.transformer_engine_rank = int(self.config.get("transformer_engine_rank", 1))
-        self.decoder_engine_rank = int(self.config.get("decoder_engine_rank", 2))
 
         if "seed" in self.config:
             seed_all(self.config["seed"])
@@ -257,6 +282,19 @@ class DecoderService(BaseService):
         exec_queue = deque()
 
         while True:
+            transfer_sizes = self.data_mgr.get_backlog_counts() if self.data_mgr is not None else {"request_pool": 0, "waiting_pool": 0}
+            self._update_queue_metrics(
+                {
+                    "req_queue": len(req_queue),
+                    "waiting_queue": len(waiting_queue),
+                    "exec_queue": len(exec_queue),
+                },
+                {
+                    "request_pool": int(transfer_sizes.get("request_pool", 0)),
+                    "waiting_pool": int(transfer_sizes.get("waiting_pool", 0)),
+                },
+            )
+
             if self._phase2_rdma_buffer is None:
                 try:
                     self._ensure_phase2_request_buffer()
@@ -268,9 +306,10 @@ class DecoderService(BaseService):
                 if packet is not None:
                     if isinstance(packet, dict) and "request_config" in packet:
                         config = dict(packet.get("request_config") or {})
-                        config["transformer_node_address"] = packet.get("transformer_node_address", config.get("transformer_node_address", "127.0.0.1"))
+                        config["transformer_node_address"] = packet.get("transformer_node_address", "127.0.0.1")
                     else:
                         config = packet
+                    self.logger.info("Received request config from RDMA buffer: %s", {k: v for k, v in config.items()})
                     req_queue.append(config)
 
             if req_queue:
@@ -310,7 +349,7 @@ class DecoderService(BaseService):
                 room, config = exec_queue.popleft()
                 try:
                     save_path = self.process(config)
-                    callback_host = str(config.get("controller_result_host", config.get("data_bootstrap_addr", "127.0.0.1")))
+                    callback_host = str(config.get("controller_result_host", "127.0.0.1"))
                     callback_port = int(config.get("controller_result_port")) if config.get("controller_result_port") is not None else None
                     if callback_port is not None:
                         self.req_mgr.send(
@@ -324,7 +363,7 @@ class DecoderService(BaseService):
                         )
                 except Exception:
                     self.logger.exception("Failed to process request for room=%s", room)
-                    callback_host = str(config.get("controller_result_host", config.get("data_bootstrap_addr", "127.0.0.1")))
+                    callback_host = str(config.get("controller_result_host", "127.0.0.1"))
                     callback_port = int(config.get("controller_result_port")) if config.get("controller_result_port") is not None else None
                     if callback_port is not None:
                         self.req_mgr.send(

--- a/lightx2v/disagg/services/encoder.py
+++ b/lightx2v/disagg/services/encoder.py
@@ -3,7 +3,7 @@ import json
 import threading
 import time
 from collections import deque
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -63,6 +63,13 @@ class EncoderService(BaseService):
             gpu_id=self.encoder_engine_rank,
             bind_address=f"tcp://{self.config.get('data_bootstrap_addr', '127.0.0.1')}:{MONITOR_POLLING_PORT + self.encoder_engine_rank}",
         )
+        self._queue_metrics_lock = threading.Lock()
+        self._queue_metrics: dict[str, Any] = {
+            "queue_sizes": {},
+            "queue_total_pending": 0,
+            "all_queues_empty": True,
+        }
+        self.reporter.set_extra_metrics_provider(self._get_queue_metrics)
         self._reporter_thread: Optional[threading.Thread] = threading.Thread(
             target=self.reporter.serve_forever,
             name="encoder-reporter",
@@ -70,6 +77,28 @@ class EncoderService(BaseService):
         )
         self._reporter_thread.start()
         self.load_models()
+
+    def _get_queue_metrics(self) -> dict[str, Any]:
+        with self._queue_metrics_lock:
+            queue_sizes = dict(self._queue_metrics.get("queue_sizes", {}))
+            return {
+                "queue_sizes": queue_sizes,
+                "queue_total_pending": int(self._queue_metrics.get("queue_total_pending", 0)),
+                "all_queues_empty": bool(self._queue_metrics.get("all_queues_empty", True)),
+            }
+
+    def _update_queue_metrics(self, queue_sizes: dict[str, int], transfer_sizes: Optional[dict[str, int]] = None):
+        merged_sizes = {k: int(v) for k, v in queue_sizes.items()}
+        if transfer_sizes is not None:
+            for key, value in transfer_sizes.items():
+                merged_sizes[f"transfer_{key}"] = int(value)
+        total_pending = sum(max(v, 0) for v in merged_sizes.values())
+        with self._queue_metrics_lock:
+            self._queue_metrics = {
+                "queue_sizes": merged_sizes,
+                "queue_total_pending": total_pending,
+                "all_queues_empty": total_pending == 0,
+            }
 
     def _ensure_request_buffer(self) -> bool:
         if self._request_rdma_buffer is not None:
@@ -167,9 +196,6 @@ class EncoderService(BaseService):
         self._phase1_handshake_port = int(self.config.get("rdma_phase1_handshake_port", self._phase1_handshake_port))
         self._phase1_slots = shared_slots
         self._phase1_slot_size = shared_slot_size
-        self.encoder_engine_rank = int(self.config.get("encoder_engine_rank", 0))
-        self.transformer_engine_rank = int(self.config.get("transformer_engine_rank", 1))
-        self.decoder_engine_rank = int(self.config.get("decoder_engine_rank", 2))
 
         # Seed everything if seed is in config
         if "seed" in self.config:
@@ -513,6 +539,19 @@ class EncoderService(BaseService):
         complete_queue: Dict[int, dict] = {}
 
         while True:
+            transfer_sizes = self.data_mgr.get_backlog_counts() if self.data_mgr is not None else {"request_pool": 0, "waiting_pool": 0}
+            self._update_queue_metrics(
+                {
+                    "req_queue": len(req_queue),
+                    "exec_queue": len(exec_queue),
+                    "complete_queue": len(complete_queue),
+                },
+                {
+                    "request_pool": int(transfer_sizes.get("request_pool", 0)),
+                    "waiting_pool": int(transfer_sizes.get("waiting_pool", 0)),
+                },
+            )
+
             if self._request_rdma_buffer is None:
                 try:
                     self._ensure_request_buffer()
@@ -522,7 +561,7 @@ class EncoderService(BaseService):
             if self._request_rdma_buffer is not None:
                 config = self._request_rdma_buffer.consume()
                 if config is not None:
-                    self.logger.info("Received request config from RDMA buffer: %s", {k: v for k, v in config.items() if not k.endswith("_path")})
+                    self.logger.info("Received request config from RDMA buffer: %s", {k: v for k, v in config.items()})
                     req_queue.append(config)
 
             if req_queue:

--- a/lightx2v/disagg/services/transformer.py
+++ b/lightx2v/disagg/services/transformer.py
@@ -3,7 +3,7 @@ import json
 import threading
 import time
 from collections import deque
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import numpy as np
 import torch
@@ -61,6 +61,13 @@ class TransformerService(BaseService):
             gpu_id=self.transformer_engine_rank,
             bind_address=f"tcp://{self.config.get('data_bootstrap_addr', '127.0.0.1')}:{MONITOR_POLLING_PORT + self.transformer_engine_rank}",
         )
+        self._queue_metrics_lock = threading.Lock()
+        self._queue_metrics: dict[str, Any] = {
+            "queue_sizes": {},
+            "queue_total_pending": 0,
+            "all_queues_empty": True,
+        }
+        self.reporter.set_extra_metrics_provider(self._get_queue_metrics)
         self._reporter_thread: Optional[threading.Thread] = threading.Thread(
             target=self.reporter.serve_forever,
             name="transformer-reporter",
@@ -68,6 +75,36 @@ class TransformerService(BaseService):
         )
         self._reporter_thread.start()
         self.load_models()
+
+    def _get_queue_metrics(self) -> dict[str, Any]:
+        with self._queue_metrics_lock:
+            queue_sizes = dict(self._queue_metrics.get("queue_sizes", {}))
+            return {
+                "queue_sizes": queue_sizes,
+                "queue_total_pending": int(self._queue_metrics.get("queue_total_pending", 0)),
+                "all_queues_empty": bool(self._queue_metrics.get("all_queues_empty", True)),
+            }
+
+    def _update_queue_metrics(
+        self,
+        queue_sizes: dict[str, int],
+        phase1_transfer_sizes: Optional[dict[str, int]] = None,
+        phase2_transfer_sizes: Optional[dict[str, int]] = None,
+    ):
+        merged_sizes = {k: int(v) for k, v in queue_sizes.items()}
+        if phase1_transfer_sizes is not None:
+            for key, value in phase1_transfer_sizes.items():
+                merged_sizes[f"phase1_{key}"] = int(value)
+        if phase2_transfer_sizes is not None:
+            for key, value in phase2_transfer_sizes.items():
+                merged_sizes[f"phase2_{key}"] = int(value)
+        total_pending = sum(max(v, 0) for v in merged_sizes.values())
+        with self._queue_metrics_lock:
+            self._queue_metrics = {
+                "queue_sizes": merged_sizes,
+                "queue_total_pending": total_pending,
+                "all_queues_empty": total_pending == 0,
+            }
 
     def _ensure_phase1_request_buffer(self) -> bool:
         if self._phase1_rdma_buffer is not None:
@@ -137,9 +174,6 @@ class TransformerService(BaseService):
         self._phase2_handshake_port = int(self.config.get("rdma_phase2_handshake_port", self._phase2_handshake_port))
         self._phase2_slots = shared_slots
         self._phase2_slot_size = shared_slot_size
-        self.encoder_engine_rank = int(self.config.get("encoder_engine_rank", 0))
-        self.transformer_engine_rank = int(self.config.get("transformer_engine_rank", 1))
-        self.decoder_engine_rank = int(self.config.get("decoder_engine_rank", 2))
 
         # Set global seed if present in config, though specific process calls might reuse it
         if "seed" in self.config:
@@ -516,20 +550,40 @@ class TransformerService(BaseService):
         complete_queue: dict[int, dict] = {}
 
         while True:
+            phase1_transfer_sizes = self.data_mgr1.get_backlog_counts() if self.data_mgr1 is not None else {"request_pool": 0, "waiting_pool": 0}
+            phase2_transfer_sizes = self.data_mgr2.get_backlog_counts() if self.data_mgr2 is not None else {"request_pool": 0, "waiting_pool": 0}
+            self._update_queue_metrics(
+                {
+                    "req_queue": len(req_queue),
+                    "waiting_queue": len(waiting_queue),
+                    "exec_queue": len(exec_queue),
+                    "complete_queue": len(complete_queue),
+                },
+                {
+                    "request_pool": int(phase1_transfer_sizes.get("request_pool", 0)),
+                    "waiting_pool": int(phase1_transfer_sizes.get("waiting_pool", 0)),
+                },
+                {
+                    "request_pool": int(phase2_transfer_sizes.get("request_pool", 0)),
+                    "waiting_pool": int(phase2_transfer_sizes.get("waiting_pool", 0)),
+                },
+            )
+
             if self._phase1_rdma_buffer is None:
                 try:
                     self._ensure_phase1_request_buffer()
                 except Exception:
                     self.logger.exception("Failed to connect phase1 request RDMA buffer, will retry")
 
-            if self._phase1_rdma_buffer is not None:
+            if self._phase1_rdma_buffer is not None and len(req_queue) + len(waiting_queue) < 2:
                 packet = self._phase1_rdma_buffer.consume()
                 if packet is not None:
                     if isinstance(packet, dict) and "request_config" in packet:
                         config = dict(packet.get("request_config") or {})
-                        config["encoder_node_address"] = packet.get("encoder_node_address", config.get("encoder_node_address", "127.0.0.1"))
+                        config["encoder_node_address"] = packet.get("encoder_node_address", "127.0.0.1")
                     else:
                         config = packet
+                    self.logger.info("%s Received request config from RDMA buffer: %s", self.transformer_engine_rank, {k: v for k, v in config.items()})
                     req_queue.append(config)
 
             if req_queue:

--- a/scripts/disagg/kill_service.sh
+++ b/scripts/disagg/kill_service.sh
@@ -3,7 +3,19 @@
 set -euo pipefail
 
 SCRIPT_NAME="run_wan_t2v_service.sh"
-PORTS=(7788 7789 7790 12788 12789 12790 17788 17789 17790 27788 27789 27790)
+
+list_port=(5566 7788 12788 17788 27788)
+
+n=10
+list_n=($(seq 0 $((n-1))))
+
+PORTS=(5555 12787)
+
+for a in "${list_port[@]}"; do
+    for b in "${list_n[@]}"; do
+        PORTS+=($((a + b)))
+    done
+done
 
 kill_pid_gracefully() {
     local pid="$1"

--- a/scripts/disagg/run_wan_t2v_service.sh
+++ b/scripts/disagg/run_wan_t2v_service.sh
@@ -23,14 +23,17 @@ transformer_cfg=${lightx2v_path}/configs/disagg/wan_t2v_disagg_transformer.json
 decoder_cfg=${lightx2v_path}/configs/disagg/wan_t2v_disagg_decoder.json
 
 seed=42
+request_count=10
 prompt="Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
 negative_prompt="镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
 save_result_path=${lightx2v_path}/save_results/test_disagg.mp4
-save_result_path_1=${save_result_path%.mp4}1.mp4
-save_result_path_2=${save_result_path%.mp4}2.mp4
+output_files=()
+for ((i=1; i<=request_count; i++)); do
+	output_files+=("${save_result_path%.mp4}${i}.mp4")
+done
 
 # Remove old outputs so wait loop reflects current run status.
-rm -f "${save_result_path_1}" "${save_result_path_2}"
+rm -f "${output_files[@]}"
 
 cleanup() {
 	local pids=("${encoder_pid:-}" "${transformer_pid:-}" "${decoder_pid:-}" "${controller_pid:-}")
@@ -86,54 +89,63 @@ wait_for_port 127.0.0.1 ${rdma_request_port} 60
 wait_for_port 127.0.0.1 ${rdma_phase1_port} 60
 wait_for_port 127.0.0.1 ${rdma_phase2_port} 60
 
-CUDA_VISIBLE_DEVICES=0 python -m lightx2v.disagg.examples.run_service \
-	--service encoder \
-	--model_cls wan2.1 \
-	--task t2v \
-	--model_path ${model_path} \
-	--config_json ${encoder_cfg} \
-	--seed ${seed} \
-	--prompt "${prompt}" \
-	--negative_prompt "${negative_prompt}" \
-	--save_result_path ${save_result_path} \
-	> ${lightx2v_path}/save_results/disagg_encoder.log 2>&1 &
-encoder_pid=$!
+# NOTE: Kept for rollback. Controller now creates encoder/transformer/decoder internally.
+# CUDA_VISIBLE_DEVICES=0 python -m lightx2v.disagg.examples.run_service \
+# 	--service encoder \
+# 	--model_cls wan2.1 \
+# 	--task t2v \
+# 	--model_path ${model_path} \
+# 	--config_json ${encoder_cfg} \
+# 	--seed ${seed} \
+# 	--prompt "${prompt}" \
+# 	--negative_prompt "${negative_prompt}" \
+# 	--save_result_path ${save_result_path} \
+# 	> ${lightx2v_path}/save_results/disagg_encoder.log 2>&1 &
+# encoder_pid=$!
 
-CUDA_VISIBLE_DEVICES=1 python -m lightx2v.disagg.examples.run_service \
-	--service transformer \
-	--model_cls wan2.1 \
-	--task t2v \
-	--model_path ${model_path} \
-	--config_json ${transformer_cfg} \
-	--seed ${seed} \
-	--prompt "${prompt}" \
-	--negative_prompt "${negative_prompt}" \
-	--save_result_path ${save_result_path} \
-	> ${lightx2v_path}/save_results/disagg_transformer.log 2>&1 &
-transformer_pid=$!
+# CUDA_VISIBLE_DEVICES=1 python -m lightx2v.disagg.examples.run_service \
+# 	--service transformer \
+# 	--model_cls wan2.1 \
+# 	--task t2v \
+# 	--model_path ${model_path} \
+# 	--config_json ${transformer_cfg} \
+# 	--seed ${seed} \
+# 	--prompt "${prompt}" \
+# 	--negative_prompt "${negative_prompt}" \
+# 	--save_result_path ${save_result_path} \
+# 	> ${lightx2v_path}/save_results/disagg_transformer.log 2>&1 &
+# transformer_pid=$!
 
-CUDA_VISIBLE_DEVICES=2 python -m lightx2v.disagg.examples.run_service \
-	--service decoder \
-	--model_cls wan2.1 \
-	--task t2v \
-	--model_path ${model_path} \
-	--config_json ${decoder_cfg} \
-	--seed ${seed} \
-	--prompt "${prompt}" \
-	--negative_prompt "${negative_prompt}" \
-	--save_result_path ${save_result_path} \
-	> ${lightx2v_path}/save_results/disagg_decoder.log 2>&1 &
-decoder_pid=$!
+# CUDA_VISIBLE_DEVICES=2 python -m lightx2v.disagg.examples.run_service \
+# 	--service decoder \
+# 	--model_cls wan2.1 \
+# 	--task t2v \
+# 	--model_path ${model_path} \
+# 	--config_json ${decoder_cfg} \
+# 	--seed ${seed} \
+# 	--prompt "${prompt}" \
+# 	--negative_prompt "${negative_prompt}" \
+# 	--save_result_path ${save_result_path} \
+# 	> ${lightx2v_path}/save_results/disagg_decoder.log 2>&1 &
+# decoder_pid=$!
 
 # Give background services time to flush and finish queued requests.
 
-echo "Waiting for output videos: ${save_result_path_1}, ${save_result_path_2}"
+echo "Waiting for output videos: ${output_files[*]}"
 wait_seconds=0
-max_wait_seconds=1200
+max_wait_seconds=$((600 * request_count))
 
 while true; do
-	if [[ -f "${save_result_path_1}" && -f "${save_result_path_2}" ]]; then
-		echo "Both output videos are generated."
+	all_generated=1
+	for file in "${output_files[@]}"; do
+		if [[ ! -f "${file}" ]]; then
+			all_generated=0
+			break
+		fi
+	done
+
+	if (( all_generated )); then
+		echo "All ${request_count} output videos are generated."
 		break
 	fi
 


### PR DESCRIPTION
This pull request introduces several significant enhancements and new features across the disaggregated service framework, primarily focusing on improved RDMA atomic operation support, dynamic instance management in the controller, and monitoring extensibility. The most impactful changes include full support for RDMA atomic verbs (fetch-and-add and compare-and-swap), controller logic for dynamic GPU/instance lifecycle management, and new hooks for reporting custom metrics. Additionally, there are improvements to configuration flexibility and command-line overrides.

**RDMA atomic operations and server/client enhancements:**

- Added true remote atomic fetch-and-add (`rdma_faa`) and compare-and-swap (`rdma_cas`) operations to `RDMAClient`, including support for the corresponding RDMA opcodes and access flags. Both client and server now register memory regions with `REMOTE_ATOMIC` access, and QP attributes are updated accordingly. This enables real atomic operations over RDMA, replacing previous best-effort shims. [[1]](diffhunk://#diff-9c1f36194d190da562de1f49ff4ba94664585a6da84ce1e2ff1d0c2d86f73b57R32-R40) [[2]](diffhunk://#diff-9c1f36194d190da562de1f49ff4ba94664585a6da84ce1e2ff1d0c2d86f73b57L103-R106) [[3]](diffhunk://#diff-9c1f36194d190da562de1f49ff4ba94664585a6da84ce1e2ff1d0c2d86f73b57L211-L220) [[4]](diffhunk://#diff-0779ab6de78bbe4d7b59fdd1cbb513817d0f6b06460bc917301942c7fe468d5aR34) [[5]](diffhunk://#diff-0779ab6de78bbe4d7b59fdd1cbb513817d0f6b06460bc917301942c7fe468d5aL77-R82) [[6]](diffhunk://#diff-0779ab6de78bbe4d7b59fdd1cbb513817d0f6b06460bc917301942c7fe468d5aL188-R193)

- Updated example/test code to demonstrate usage of the new atomic RDMA operations, including writing, reading, fetch-and-add, and compare-and-swap.

**Controller instance lifecycle and scheduling:**

- Implemented dynamic GPU/instance management in the controller, including:
    - Per-GPU scheduling, cooldown/reuse logic, and idle pool management.
    - Methods to create and reclaim encoder/transformer/decoder service instances as subprocesses, with robust port/state checks and error handling.
    - Support for launching subprocesses with correct CUDA device visibility and configuration.

- Added helper methods for mapping between instance addresses and monitor nodes, and for recursively converting configuration objects to plain Python types.

**Monitoring and metrics extensibility:**

- Added support for registering an extra metrics provider in the `Monitor` class, allowing injection of custom metrics into the monitoring output in a thread-safe manner. [[1]](diffhunk://#diff-3be59feff48858582c62fbd8a0f8a82bc8347f169d84ab318a53d487ef4fd4a2R29-R34) [[2]](diffhunk://#diff-3be59feff48858582c62fbd8a0f8a82bc8347f169d84ab318a53d487ef4fd4a2R64-R70)

**Configuration and CLI improvements:**

- Added a `ranks` field to the disaggregation config for explicit rank/GPU count configuration.
- Introduced an `--engine_rank` command-line argument to override engine rank for service roles, and logic to apply this override in `run_service.py`. [[1]](diffhunk://#diff-e899b06a09638f9c64d626185b83935aa21518ca52654d40130d40499497b507R52-R57) [[2]](diffhunk://#diff-e899b06a09638f9c64d626185b83935aa21518ca52654d40130d40499497b507R119-R122)

**Other improvements:**

- Miscellaneous: Added missing imports and typing annotations in the controller for robustness.

These changes collectively enable more robust, flexible, and scalable operation of the disaggregated video service platform.