### PR TITLE
Fix LTX-2.3 checkpoint paths

### DIFF
--- a/configs/ltx2/ltx2_3.json
+++ b/configs/ltx2/ltx2_3.json
@@ -14,7 +14,7 @@
     "audio_mel_bins":16,
     "double_precision_rope": true,
     "use_tiling_vae": false,
-    "dit_original_ckpt": "Lightricks/LTX-2.3ltx-2.3-22b-dev.safetensors",
+    "dit_original_ckpt": "Lightricks/LTX-2.3/ltx-2.3-22b-dev.safetensors",
     "caption_proj_before_connector": true,
     "cross_attention_adaln": true,
     "apply_gated_attention": true,

--- a/configs/ltx2/ltx2_3_distill_offload.json
+++ b/configs/ltx2/ltx2_3_distill_offload.json
@@ -15,7 +15,7 @@
     "audio_fps": 24000,
     "audio_mel_bins":16,
     "double_precision_rope": true,
-    "dit_original_ckpt": "Lightricks/LTX-2.3ltx-2.3-22b-distilled.safetensors",
+    "dit_original_ckpt": "Lightricks/LTX-2.3/ltx-2.3-22b-distilled.safetensors",
     "skip_fp8_block_index" : [0, 43, 44, 45, 46, 47],
     "distilled_sigma_values": [1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0],
     "caption_proj_before_connector": true,

--- a/configs/ltx2/ltx2_3_distill_upsample_offload.json
+++ b/configs/ltx2/ltx2_3_distill_upsample_offload.json
@@ -15,13 +15,13 @@
     "audio_fps": 24000,
     "audio_mel_bins":16,
     "double_precision_rope": true,
-    "dit_original_ckpt": "Lightricks/LTX-2.3ltx-2.3-22b-distilled.safetensors",
+    "dit_original_ckpt": "Lightricks/LTX-2.3/ltx-2.3-22b-distilled.safetensors",
     "skip_fp8_block_index" : [0, 43, 44, 45, 46, 47],
     "distilled_sigma_values": [1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0],
     "caption_proj_before_connector": true,
     "cross_attention_adaln": true,
     "apply_gated_attention": true,
     "use_upsampler": true,
-    "upsampler_original_ckpt": "Lightricks/LTX-2.3ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
+    "upsampler_original_ckpt": "Lightricks/LTX-2.3/ltx-2.3-spatial-upscaler-x2-1.1.safetensors",
     "distilled_sigma_values_upsample": [0.909375, 0.725, 0.421875, 0.0]
 }

--- a/configs/ltx2/ltx2_3_offload.json
+++ b/configs/ltx2/ltx2_3_offload.json
@@ -16,7 +16,7 @@
     "audio_mel_bins":16,
     "double_precision_rope": true,
     "use_tiling_vae": false,
-    "dit_original_ckpt": "Lightricks/LTX-2.3ltx-2.3-22b-dev.safetensors",
+    "dit_original_ckpt": "Lightricks/LTX-2.3/ltx-2.3-22b-dev.safetensors",
     "caption_proj_before_connector": true,
     "cross_attention_adaln": true,
     "apply_gated_attention": true,


### PR DESCRIPTION
## Summary
  This PR fixes the LTX-2.3 config checkpoint paths.

## Changes

  - fix invalid `dit_original_ckpt` paths in:
    - `configs/ltx2/ltx2_3.json`
    - `configs/ltx2/ltx2_3_offload.json`
    - `configs/ltx2/ltx2_3_distill_offload.json`
    - `configs/ltx2/ltx2_3_distill_upsample_offload.json`
  - fix invalid `upsampler_original_ckpt` path in:
    - `configs/ltx2/ltx2_3_distill_upsample_offload.json`

## Why
The previous LTX-2.3 config paths were missing a `/` in the checkpoint location, which would cause path validation / model loading to fail.