### PR TITLE
fix: release transformer weights after infer when cpu_offload is on (flux2 + qwen_image)

### DIFF
--- a/lightx2v/models/networks/flux2/model.py
+++ b/lightx2v/models/networks/flux2/model.py
@@ -191,6 +191,9 @@ class Flux2KleinTransformerModel(_Flux2TransformerModelBase):
             )
             self.scheduler.noise_pred = noise_pred
 
+        if self.cpu_offload:
+            self.to_cpu()
+
 
 class Flux2DevTransformerModel(_Flux2TransformerModelBase):
     """Flux2 Dev transformer: single forward pass with embedded guidance (no CFG)."""
@@ -220,3 +223,6 @@ class Flux2DevTransformerModel(_Flux2TransformerModelBase):
             img_ids=img_ids,
         )
         self.scheduler.noise_pred = noise_pred
+
+        if self.cpu_offload:
+            self.to_cpu()

--- a/lightx2v/models/networks/qwen_image/model.py
+++ b/lightx2v/models/networks/qwen_image/model.py
@@ -143,3 +143,10 @@ class QwenImageTransformerModel(BaseTransformerModel):
             if self.config["task"] == "i2i":
                 noise_pred = noise_pred[:, : latents.size(1)]
             self.scheduler.noise_pred = noise_pred
+
+        if self.cpu_offload:
+            if self.offload_granularity == "model" and self.scheduler.step_index == self.scheduler.infer_steps - 1:
+                self.to_cpu()
+            elif self.offload_granularity != "model":
+                self.pre_weight.to_cpu()
+                self.post_weight.to_cpu()


### PR DESCRIPTION
## Problem

`Flux2KleinTransformerModel.infer`, `Flux2DevTransformerModel.infer`, and `QwenImageTransformerModel.infer` all call `self.to_cuda()` (or partial swaps on `pre_weight`/`post_weight`) at the start of an inference step, but never swap weights back to CPU at the end of a step. Once the first step's `to_cuda()` runs, the transformer weights stay GPU-resident permanently, which defeats the purpose of `cpu_offload` and OOMs memory-tight cards on the next text-encoder swap-in.

Concrete repro: `flux2_klein` with FLUX.2-Klein-9B on a 32 GB Blackwell card. Text encoder is 16 GB bf16, DiT is 17 GB bf16. First call works because the TE is on CPU during DiT load. Second call's `text_encoder.to(AI_DEVICE)` OOMs because DiT (17 GB) was never released:

```
File "lightx2v/models/input_encoders/hf/flux2/qwen3_model.py", line 48, in infer
    self.text_encoder.to(AI_DEVICE)
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 32.00 MiB.
GPU 0 has a total capacity of 31.35 GiB of which 31.12 MiB is free.
Including non-PyTorch memory, this process has 30.96 GiB memory in use.
```

PR #1034 added a `lazy_load=true` mode that side-steps this by deleting and disk-reloading TE/DiT/VAE per call, but that's ~30s/call from disk reads, vs ~16s warm with this fix on the same hardware.

## What this PR does

Adds the symmetric end-of-step swap-to-CPU in both files. Mirrors the block at the *start* of each `infer()` exactly, so semantics are: every weight that gets moved to GPU at step start gets moved back to CPU at step end (or, for `offload_granularity == \"model\"`, at the last step).

This matches the canonical pattern already in `ZImageTransformerModel.infer` (`z_image/model.py:140-146`) and `WanTransformerModel.infer`. Survey:

| Model | \`to_cuda\` at start | \`to_cpu\` at end |
|---|---|---|
| \`z_image/model.py\` | ✅ | ✅ |
| \`wan/model.py\` | ✅ | ✅ |
| \`flux2/model.py\` | ✅ | ❌ → ✅ (this PR) |
| \`qwen_image/model.py\` | ✅ | ❌ → ✅ (this PR) |

## Compatibility with PR #1034 (lazy_load)

Additive — does not touch the \`lazy_load\` paths. Users running \`lazy_load=true\` will see the new \`to_cpu()\` call before the runner deletes & reloads the transformer next call; the operation is a no-op on already-released weights and adds at most a single attribute walk.

## Testing

Validated on \`flux2_klein\` with FLUX.2-Klein-9B on RTX 5090 32 GB, \`offload_granularity=phase\`, \`cpu_offload=true\`, 4 steps, torch_sdpa attn, rope split, multi-image i2i (2 reference images):

- Before: 1st call succeeds (~65s), 2nd call returns 500 OOM at \`text_encoder.to(AI_DEVICE)\` with \`30.96 GiB / 31.35 GiB in use\`.
- After: 3 sequential calls all succeed (65s cold, 16s × 2 warm), no OOM, peak GPU usage stays under 25 GiB between calls.

## Notes

- \`qwen_image\`'s \`transformer_weights\` does not currently expose a \`non_block_weights_to_cuda/to_cpu\` pair the way \`z_image\` does, so the qwen_image fix only covers what its start-of-infer touches. Adding the non-block-weights pair would close the remaining gap but is out of scope.
- A wan2.2_moe carve-out is not relevant here (z_image excludes it because of a model-cls-specific reload pattern — neither flux2 nor qwen_image have the equivalent path).