### PR TITLE
Fix INT8 Triton GEMM review follow-ups for #896

### DIFF
--- a/lightx2v/common/ops/mm/triton_kernels.py
+++ b/lightx2v/common/ops/mm/triton_kernels.py
@@ -1,8 +1,12 @@
 import torch
-from triton import Config, autotune, cdiv, jit, next_power_of_2
+from triton import Config, autotune, cdiv, heuristics, jit, next_power_of_2
 from triton import language as tl
 
 _ordered_datatypes = [torch.int8, torch.float16, torch.bfloat16, torch.float32]
+
+
+def _is_even_k(args):
+    return args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0
 
 
 @jit
@@ -96,6 +100,7 @@ def get_higher_dtype(a, b):
     ],
     key=["M", "N", "K"],
 )
+@heuristics({"EVEN_K": _is_even_k})
 @jit
 def int8_gemm_bias_kernel(
     A,
@@ -164,12 +169,12 @@ def int8_gemm_bias_kernel(
     acc = acc.to(tl.float32)
     a_scales_ptr = A_SCALES + pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     b_scales_ptr = B_SCALES + pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    a_scales = tl.load(a_scales_ptr)  # [BM]
-    b_scales = tl.load(b_scales_ptr)  # [BN]
+    a_scales = tl.load(a_scales_ptr, mask=rm < M, other=0.0)  # [BM]
+    b_scales = tl.load(b_scales_ptr, mask=rn < N, other=0.0)  # [BN]
     # [BM, BN] * [BM, 1] * [1, BN]
 
     bias_ptr = BIAS + pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    bias = tl.load(bias_ptr)
+    bias = tl.load(bias_ptr, mask=rn < N, other=0.0)
     if fuse_gelu:
         acc = gelu(((acc * a_scales[:, None]) * b_scales[None, :]) + bias[None, :])
     else:
@@ -211,7 +216,7 @@ def int8_gemm_bias_triton(a, b, bias, a_scales, b_scales, fuse_gelu=False, outpu
 
     # allocates output
     if output_dtype is None:
-        output_dtype = ab_dtype
+        output_dtype = torch.float16
 
     c = torch.empty((M, N), device=device, dtype=output_dtype)
 
@@ -262,7 +267,6 @@ def int8_gemm_bias_triton(a, b, bias, a_scales, b_scales, fuse_gelu=False, outpu
         acc_dtype=acc_dtype,  #
         fuse_gelu=fuse_gelu,
         GROUP_M=8,
-        EVEN_K=True,
         AB_DTYPE=ab_dtype,
     )
     return c.view(*out_shape)
@@ -277,6 +281,7 @@ def int8_gemm_bias_triton(a, b, bias, a_scales, b_scales, fuse_gelu=False, outpu
     ],
     key=["M", "N", "K"],
 )
+@heuristics({"EVEN_K": _is_even_k})
 @jit
 def int8_gemm_kernel(
     A,
@@ -344,8 +349,8 @@ def int8_gemm_kernel(
     acc = acc.to(tl.float32)
     a_scales_ptr = A_SCALES + pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     b_scales_ptr = B_SCALES + pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    a_scales = tl.load(a_scales_ptr)  # [BM]
-    b_scales = tl.load(b_scales_ptr)  # [BN]
+    a_scales = tl.load(a_scales_ptr, mask=rm < M, other=0.0)  # [BM]
+    b_scales = tl.load(b_scales_ptr, mask=rn < N, other=0.0)  # [BN]
     # [BM, BN] * [BM, 1] * [1, BN]
     if fuse_gelu:
         acc = gelu((acc * a_scales[:, None]) * b_scales[None, :])
@@ -389,7 +394,7 @@ def int8_gemm_triton(a, b, a_scales, b_scales, fuse_gelu=False, output_dtype=Non
 
     # allocates output
     if output_dtype is None:
-        output_dtype = ab_dtype
+        output_dtype = torch.float16
 
     c = torch.empty((M, N), device=device, dtype=output_dtype)
 
@@ -438,7 +443,6 @@ def int8_gemm_triton(a, b, a_scales, b_scales, fuse_gelu=False, output_dtype=Non
         c.stride(1),  #
         acc_dtype=acc_dtype,  #
         fuse_gelu=fuse_gelu,
-        EVEN_K=True,
         GROUP_M=8,
         AB_DTYPE=ab_dtype,
     )

--- a/test_cases/test_int8_triton_kernels.py
+++ b/test_cases/test_int8_triton_kernels.py
@@ -1,0 +1,177 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+import torch
+
+_DTYPE_TOLERANCES = {
+    torch.float32: {"rtol": 1e-5, "atol": 1e-3},
+    torch.float16: {"rtol": 1e-3, "atol": 5e-1},
+    torch.bfloat16: {"rtol": 1e-2, "atol": 2.0},
+}
+
+
+def _load_triton_kernels():
+    module_path = Path(__file__).resolve().parents[1] / "lightx2v" / "common" / "ops" / "mm" / "triton_kernels.py"
+    spec = importlib.util.spec_from_file_location("triton_kernels_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ones_case(m, n, k):
+    a = torch.ones((m, k), device="cuda", dtype=torch.int8)
+    b = torch.ones((n, k), device="cuda", dtype=torch.int8)
+    a_scales = torch.ones(m, device="cuda", dtype=torch.float32)
+    b_scales = torch.ones(n, device="cuda", dtype=torch.float32)
+    return a, b, a_scales, b_scales
+
+
+def _random_case(m, n, k):
+    generator = torch.Generator()
+    generator.manual_seed(896)
+    a = torch.randint(-2, 3, (m, k), generator=generator, dtype=torch.int8).cuda()
+    b = torch.randint(-2, 3, (n, k), generator=generator, dtype=torch.int8).cuda()
+    a_scales = ((torch.arange(m, device="cuda", dtype=torch.float32) % 5) + 1) / 8
+    b_scales = ((torch.arange(n, device="cuda", dtype=torch.float32) % 7) + 1) / 7
+    return a, b, a_scales, b_scales
+
+
+def _reference(a, b, a_scales, b_scales, bias=None):
+    out = (a.float() @ b.float().t()) * a_scales[:, None] * b_scales[None, :]
+    if bias is not None:
+        out = out + bias[None, :]
+    return out
+
+
+def _assert_close_to_reference(out, expected, dtype, rtol=0, atol=0):
+    torch.cuda.synchronize()
+    assert out.dtype == dtype
+    assert out.shape == expected.shape
+    torch.testing.assert_close(out.float(), expected, rtol=rtol, atol=atol)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for Triton INT8 GEMM tests")
+class TestInt8TritonKernels(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.triton_kernels = _load_triton_kernels()
+
+    def test_int8_gemm_default_output_dtype_is_float16_and_does_not_overflow(self):
+        a, b, a_scales, b_scales = _ones_case(128, 128, 128)
+        expected = _reference(a, b, a_scales, b_scales)
+
+        out = self.triton_kernels.int8_gemm_triton(a, b, a_scales, b_scales)
+
+        _assert_close_to_reference(out, expected, torch.float16)
+
+    def test_int8_gemm_bias_default_output_dtype_is_float16_and_does_not_overflow(self):
+        a, b, a_scales, b_scales = _ones_case(128, 128, 128)
+        bias = torch.zeros(128, device="cuda", dtype=torch.float32)
+        expected = _reference(a, b, a_scales, b_scales, bias)
+
+        out = self.triton_kernels.int8_gemm_bias_triton(a, b, bias, a_scales, b_scales)
+
+        _assert_close_to_reference(out, expected, torch.float16)
+
+    def test_int8_gemm_explicit_output_dtype_is_preserved(self):
+        for dtype in [torch.bfloat16, torch.float16]:
+            for with_bias in [False, True]:
+                with self.subTest(dtype=dtype, with_bias=with_bias):
+                    a, b, a_scales, b_scales = _ones_case(128, 128, 128)
+                    bias = torch.zeros(128, device="cuda", dtype=torch.float32) if with_bias else None
+                    expected = _reference(a, b, a_scales, b_scales, bias)
+
+                    if with_bias:
+                        out = self.triton_kernels.int8_gemm_bias_triton(a, b, bias, a_scales, b_scales, output_dtype=dtype)
+                    else:
+                        out = self.triton_kernels.int8_gemm_triton(a, b, a_scales, b_scales, output_dtype=dtype)
+
+                    _assert_close_to_reference(out, expected, dtype)
+
+    def test_int8_gemm_handles_k_tail_and_block_k_64_multiples(self):
+        for k in [64, 127, 129, 192]:
+            for with_bias in [False, True]:
+                with self.subTest(k=k, with_bias=with_bias):
+                    a, b, a_scales, b_scales = _ones_case(128, 128, k)
+                    bias = None
+                    if with_bias:
+                        bias = (torch.arange(128, device="cuda", dtype=torch.float32) % 5) - 2
+                    expected = _reference(a, b, a_scales, b_scales, bias)
+
+                    if with_bias:
+                        out = self.triton_kernels.int8_gemm_bias_triton(
+                            a,
+                            b,
+                            bias,
+                            a_scales,
+                            b_scales,
+                            output_dtype=torch.bfloat16,
+                        )
+                    else:
+                        out = self.triton_kernels.int8_gemm_triton(
+                            a,
+                            b,
+                            a_scales,
+                            b_scales,
+                            output_dtype=torch.bfloat16,
+                        )
+
+                    _assert_close_to_reference(out, expected, torch.bfloat16)
+
+    def test_int8_gemm_random_scales_bias_and_tail_shapes(self):
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            for with_bias in [False, True]:
+                with self.subTest(dtype=dtype, with_bias=with_bias):
+                    m, n, k = 130, 129, 127
+                    a, b, a_scales, b_scales = _random_case(m, n, k)
+                    bias = None
+                    if with_bias:
+                        bias = ((torch.arange(n, device="cuda", dtype=torch.float32) % 11) - 5) / 6
+                    expected = _reference(a, b, a_scales, b_scales, bias)
+                    tolerances = _DTYPE_TOLERANCES[dtype]
+
+                    if with_bias:
+                        out = self.triton_kernels.int8_gemm_bias_triton(
+                            a,
+                            b,
+                            bias,
+                            a_scales,
+                            b_scales,
+                            output_dtype=dtype,
+                        )
+                    else:
+                        out = self.triton_kernels.int8_gemm_triton(
+                            a,
+                            b,
+                            a_scales,
+                            b_scales,
+                            output_dtype=dtype,
+                        )
+
+                    _assert_close_to_reference(out, expected, dtype, **tolerances)
+
+    def test_int8_gemm_handles_non_tile_mn(self):
+        a, b, a_scales, b_scales = _ones_case(130, 129, 128)
+        expected = _reference(a, b, a_scales, b_scales)
+
+        out = self.triton_kernels.int8_gemm_triton(a, b, a_scales, b_scales, output_dtype=torch.bfloat16)
+
+        _assert_close_to_reference(out, expected, torch.bfloat16)
+
+    def test_int8_gemm_bias_uses_valid_scale_indices_for_non_tile_mn(self):
+        m, n, k = 130, 129, 128
+        a = torch.ones((m, k), device="cuda", dtype=torch.int8)
+        b = torch.ones((n, k), device="cuda", dtype=torch.int8)
+        a_scales = (torch.arange(m, device="cuda", dtype=torch.float32) % 5) + 1
+        b_scales = (torch.arange(n, device="cuda", dtype=torch.float32) % 7) + 1
+        bias = (torch.arange(n, device="cuda", dtype=torch.float32) % 3) + 1
+        expected = _reference(a, b, a_scales, b_scales, bias)
+
+        out = self.triton_kernels.int8_gemm_bias_triton(a, b, bias, a_scales, b_scales, output_dtype=torch.float32)
+
+        _assert_close_to_reference(out, expected, torch.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep the #896 correctness fix and tighten the Triton `EVEN_K` decision per autotune config with `triton.heuristics`
- keep masked scale / bias loads for non-tile `M/N` safety
- extend CUDA coverage for bias/no-bias, `K=64/127/129/192`, non-tile `M/N`, and random scale / bias cases

## Details
- compute `EVEN_K` as `K % (BLOCK_K * SPLIT_K) == 0` inside the INT8 Triton kernels instead of hard-coding the wrapper decision against `128`
- preserve the corrected default output dtype of `torch.float16`
- add dtype-aware tolerances for random correctness tests

## Validation
- `conda run -n exp_env env CUDA_VISIBLE_DEVICES=1 python -m pytest -q test_cases/test_int8_triton_kernels.py`
- `git diff --check`
- `pre-commit run --files lightx2v/common/ops/mm/triton_kernels.py test_cases/test_int8_triton_kernels.py`
- local performance sanity against `main` for aligned `K=128` shapes showed no meaningful regression
