### PR TITLE
[Feat] stabilize BAGEL image generation support

### DIFF
--- a/configs/bagel/bagel_i2i.json
+++ b/configs/bagel/bagel_i2i.json
@@ -1,0 +1,33 @@
+{
+    "infer_steps": 50,
+    "inference_hyper": {
+        "cfg_text_scale": 4.0,
+        "cfg_img_scale": 2.0,
+        "cfg_interval": [0.0, 1.0],
+        "timestep_shift": 3.0,
+        "num_timesteps": 50,
+        "cfg_renorm_min": 0.0,
+        "cfg_renorm_type": "text_channel"
+    },
+    "think": false,
+    "understanding_output": false,
+    "do_sample": false,
+    "text_temperature": 0.3,
+    "max_think_token_n": 1000,
+    "interpolate_pos": false,
+    "visual_gen": true,
+    "visual_und": true,
+    "vit_max_num_patch_per_side": 70,
+    "connector_act": "gelu_pytorch_tanh",
+    "latent_patch_size": 2,
+    "max_latent_size_update": 64,
+    "i2i_max_image_size": 1024,
+    "llm_config_update": {
+        "dtype": "bfloat16",
+        "freeze_und": false,
+        "is_causal": true,
+        "layer_module": "Qwen2MoTDecoderLayer",
+        "rope_scaling": null,
+        "sliding_window": null
+    }
+}

--- a/examples/bagel/README.md
+++ b/examples/bagel/README.md
@@ -1,15 +1,15 @@
-# BAGEL T2I
+# BAGEL Image Generation
 
-This example covers the first LightX2V BAGEL integration scope: text-to-image generation with `ByteDance-Seed/BAGEL-7B-MoT`.
+This example covers the LightX2V BAGEL image generation scope for `ByteDance-Seed/BAGEL-7B-MoT`: text-to-image and single-image editing.
 
 ## Model
 
 Download the model to a local directory. If the Hugging Face mirror is available in your region, prefer:
 
 ```bash
-mkdir -p /data1/lyxu18/models/ByteDance-Seed
+mkdir -p /path/to/models/ByteDance-Seed
 HF_ENDPOINT=https://hf-mirror.com hf download ByteDance-Seed/BAGEL-7B-MoT \
-  --local-dir /data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --local-dir /path/to/models/ByteDance-Seed/BAGEL-7B-MoT \
   --max-workers 8
 ```
 
@@ -21,13 +21,13 @@ The model directory must contain `config.json`, `ema.safetensors`, `ae.safetenso
 - PyTorch compatible with the current LightX2V environment.
 - `flash-attn` installed for the same CUDA/PyTorch build.
 
-If `flash-attn`, `ema.safetensors`, `ae.safetensors`, or required config fields are missing, the BAGEL runner raises a direct error before generation.
+If `flash-attn`, `ema.safetensors`, `ae.safetensors`, ViT weights for I2I, or required config fields are missing, the BAGEL runner raises a direct error before generation.
 
-## Run
+## Text To Image
 
 ```bash
-export lightx2v_path=/data1/lyxu18/opensource_proj/LightX2V
-export model_path=/data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT
+export lightx2v_path=/path/to/LightX2V
+export model_path=/path/to/BAGEL-7B-MoT
 
 bash scripts/bagel/run_bagel_t2i.sh
 ```
@@ -38,7 +38,7 @@ Equivalent direct command:
 python -m lightx2v.infer \
   --model_cls bagel \
   --task t2i \
-  --model_path /data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --model_path /path/to/BAGEL-7B-MoT \
   --config_json configs/bagel/bagel_t2i.json \
   --prompt "A small cabin beside a lake at sunrise, cinematic lighting" \
   --aspect_ratio 1:1 \
@@ -66,7 +66,7 @@ Custom shape example:
 python -m lightx2v.infer \
   --model_cls bagel \
   --task t2i \
-  --model_path /data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --model_path /path/to/BAGEL-7B-MoT \
   --config_json configs/bagel/bagel_t2i.json \
   --prompt "A glass greenhouse in a snowy garden" \
   --target_shape 576 1024 \
@@ -74,21 +74,64 @@ python -m lightx2v.infer \
   --seed 42
 ```
 
+## Image Editing
+
+I2I supports a single input image. The runner converts it to RGB, resizes it to a BAGEL-aligned output shape, writes VAE and ViT image context, then applies the edit prompt.
+
+```bash
+MODEL_PATH=/path/to/BAGEL-7B-MoT \
+IMAGE_PATH=assets/inputs/imgs/img_0.jpg \
+PROMPT="Change the scene to golden hour while preserving the main subject." \
+bash scripts/bagel/run_bagel_i2i.sh
+```
+
+Equivalent direct command:
+
+```bash
+python -m lightx2v.infer \
+  --model_cls bagel \
+  --task i2i \
+  --model_path /path/to/BAGEL-7B-MoT \
+  --config_json configs/bagel/bagel_i2i.json \
+  --image_path assets/inputs/imgs/img_0.jpg \
+  --prompt "Change the scene to golden hour while preserving the main subject." \
+  --save_result_path save_results/bagel_i2i.png \
+  --seed 42
+```
+
+For I2I, `target_shape [H W]` overrides the automatic size. Without `target_shape`, LightX2V preserves the input aspect ratio, limits the long edge to 1024, and aligns both dimensions to BAGEL latent downsample. `aspect_ratio` is ignored for I2I to avoid changing the input image shape unexpectedly.
+
+Target shape example:
+
+```bash
+python -m lightx2v.infer \
+  --model_cls bagel \
+  --task i2i \
+  --model_path /path/to/BAGEL-7B-MoT \
+  --config_json configs/bagel/bagel_i2i.json \
+  --image_path assets/inputs/imgs/img_0.jpg \
+  --prompt "Make it look like a watercolor illustration." \
+  --target_shape 576 1024 \
+  --save_result_path save_results/bagel_i2i_576x1024.png \
+  --seed 42
+```
+
 ## Current Scope
 
-Supported in this v1:
+Supported:
 
 - `python -m lightx2v.infer --model_cls bagel --task t2i`
+- `python -m lightx2v.infer --model_cls bagel --task i2i`
 - PNG saving
 - `seed`
-- `aspect_ratio`
+- T2I `aspect_ratio`
 - `target_shape`
 - service in-memory image return through `return_result_tensor=True`
 
-Not supported in this v1:
+Not supported:
 
-- image-to-image
-- image editing
+- mask edit
+- multiple input images
 - visual understanding
 - thinking text output
 - NF4 or INT8 quantization

--- a/examples/bagel/README.md
+++ b/examples/bagel/README.md
@@ -1,0 +1,95 @@
+# BAGEL T2I
+
+This example covers the first LightX2V BAGEL integration scope: text-to-image generation with `ByteDance-Seed/BAGEL-7B-MoT`.
+
+## Model
+
+Download the model to a local directory. If the Hugging Face mirror is available in your region, prefer:
+
+```bash
+mkdir -p /data1/lyxu18/models/ByteDance-Seed
+HF_ENDPOINT=https://hf-mirror.com hf download ByteDance-Seed/BAGEL-7B-MoT \
+  --local-dir /data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --max-workers 8
+```
+
+The model directory must contain `config.json`, `ema.safetensors`, `ae.safetensors`, tokenizer files, and the other files from the BAGEL-7B-MoT repository.
+
+## Requirements
+
+- CUDA GPU environment with enough memory for BAGEL-7B-MoT.
+- PyTorch compatible with the current LightX2V environment.
+- `flash-attn` installed for the same CUDA/PyTorch build.
+
+If `flash-attn`, `ema.safetensors`, `ae.safetensors`, or required config fields are missing, the BAGEL runner raises a direct error before generation.
+
+## Run
+
+```bash
+export lightx2v_path=/data1/lyxu18/opensource_proj/LightX2V
+export model_path=/data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT
+
+bash scripts/bagel/run_bagel_t2i.sh
+```
+
+Equivalent direct command:
+
+```bash
+python -m lightx2v.infer \
+  --model_cls bagel \
+  --task t2i \
+  --model_path /data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --config_json configs/bagel/bagel_t2i.json \
+  --prompt "A small cabin beside a lake at sunrise, cinematic lighting" \
+  --aspect_ratio 1:1 \
+  --save_result_path save_results/bagel_t2i.png \
+  --seed 42
+```
+
+## Shape Options
+
+`target_shape` has priority over `aspect_ratio`. It is `[H W]`, must contain positive integers, and each dimension must be divisible by BAGEL latent downsample.
+
+Supported `aspect_ratio` presets:
+
+| aspect_ratio | output shape |
+| --- | --- |
+| `1:1` | `1024x1024` |
+| `4:3` | `768x1024` |
+| `3:4` | `1024x768` |
+| `16:9` | `576x1024` |
+| `9:16` | `1024x576` |
+
+Custom shape example:
+
+```bash
+python -m lightx2v.infer \
+  --model_cls bagel \
+  --task t2i \
+  --model_path /data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --config_json configs/bagel/bagel_t2i.json \
+  --prompt "A glass greenhouse in a snowy garden" \
+  --target_shape 576 1024 \
+  --save_result_path save_results/bagel_t2i_576x1024.png \
+  --seed 42
+```
+
+## Current Scope
+
+Supported in this v1:
+
+- `python -m lightx2v.infer --model_cls bagel --task t2i`
+- PNG saving
+- `seed`
+- `aspect_ratio`
+- `target_shape`
+- service in-memory image return through `return_result_tensor=True`
+
+Not supported in this v1:
+
+- image-to-image
+- image editing
+- visual understanding
+- thinking text output
+- NF4 or INT8 quantization
+- multi-GPU dispatch

--- a/lightx2v/models/networks/bagel/infer/pre_infer.py
+++ b/lightx2v/models/networks/bagel/infer/pre_infer.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 from loguru import logger
+from transformers.activations import ACT2FN
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 
 from lightx2v.utils.envs import *
@@ -96,6 +97,7 @@ class BagelPreInfer:
     def __init__(self, config, llm_config):
         self.config = config
         self.rotary_emb = Qwen2RotaryEmbedding(config=llm_config)
+        self.connector_activation = ACT2FN[config.get("connector_act", "gelu_pytorch_tanh")]
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler
@@ -116,4 +118,11 @@ class BagelPreInfer:
     def vae2llm(self, weights, x):
         x = x.to(AI_DEVICE).to(torch.bfloat16)
         x = weights.vae2llm.apply(x)
+        return x
+
+    def connector(self, weights, x):
+        x = x.to(AI_DEVICE).to(torch.bfloat16)
+        x = weights.fc1.apply(x)
+        x = self.connector_activation(x)
+        x = weights.fc2.apply(x)
         return x

--- a/lightx2v/models/networks/bagel/infer/transformer_infer.py
+++ b/lightx2v/models/networks/bagel/infer/transformer_infer.py
@@ -54,6 +54,8 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
 
 class BagelTransformerInfer(BaseTransformerInfer):
     def __init__(self, config, llm_config):
+        if flash_attn_varlen_func is None:
+            raise ImportError("BAGEL T2I requires flash-attn (`flash_attn`). Install a flash-attn build compatible with your CUDA/PyTorch environment before running BAGEL.")
         self.config = config
         self.llm_config = llm_config
         self.num_layers = llm_config["num_hidden_layers"]

--- a/lightx2v/models/networks/bagel/infer/transformer_infer.py
+++ b/lightx2v/models/networks/bagel/infer/transformer_infer.py
@@ -291,7 +291,7 @@ class BagelTransformerInfer(BaseTransformerInfer):
     ):
         for layer_idx, block_weight in enumerate(block_weights):
             if enable_taylorseer:
-                assert NotImplementedError
+                raise NotImplementedError("TaylorSeer is not implemented for BAGEL transformer inference.")
             packed_query_sequence, past_key_values = self.decoder_layer(
                 block_weight=block_weight,
                 packed_query_sequence=packed_query_sequence,

--- a/lightx2v/models/networks/bagel/model.py
+++ b/lightx2v/models/networks/bagel/model.py
@@ -491,6 +491,7 @@ class BagelModel:
         packed_sequence = packed_text_embedding.new_zeros((int(packed_seqlens.sum().item()), self.hidden_size))
         packed_sequence[packed_text_indexes.to(AI_DEVICE)] = packed_text_embedding
 
+        padded_images = padded_images.to(device=AI_DEVICE, dtype=torch.bfloat16)
         padded_latent = vae_model.encode(padded_images)
 
         p = self.latent_patch_size

--- a/lightx2v/models/networks/bagel/model.py
+++ b/lightx2v/models/networks/bagel/model.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 
 import torch
 from PIL import Image
+from loguru import logger
 from torch.nn import functional as F
 
 from lightx2v.models.networks.bagel.data_utils import add_special_tokens
@@ -17,6 +18,7 @@ from lightx2v.models.networks.bagel.tokenization_qwen2 import Qwen2Tokenizer
 from lightx2v.models.networks.bagel.weights.post_weights import Qwen2PostWeights
 from lightx2v.models.networks.bagel.weights.pre_weights import Qwen2PreWeights
 from lightx2v.models.networks.bagel.weights.transformer_weights import Qwen2TransformerWeights
+from lightx2v.models.runners.bagel.t2i_utils import validate_bagel_model_assets
 from lightx2v.utils.envs import *
 from lightx2v.utils.utils import *
 
@@ -35,6 +37,7 @@ class BagelModel:
     def __init__(self, config):
         self.config = config
         self.model_path = config["model_path"]
+        self._validate_config()
         # init llm config
         llm_config = self.config["llm_config"]
         with self.config.temporarily_unlocked():
@@ -58,6 +61,9 @@ class BagelModel:
         self._init_weights()
         self._init_infer()
         self._init_modules()
+
+    def _validate_config(self):
+        validate_bagel_model_assets(self.config, self.model_path)
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler
@@ -88,7 +94,10 @@ class BagelModel:
         self.pre_weight = self.pre_weight_class(self.config)
         self.transformer_weights = self.transformer_weight_class(self.config, self.llm_config)
         self.post_weight = self.post_weight_class(self.config)
-        weight_dict = safetensors.torch.load_file(os.path.join(self.config["model_path"], "ema.safetensors"), device=AI_DEVICE)
+        weight_path = os.path.join(self.config["model_path"], "ema.safetensors")
+        if not os.path.exists(weight_path):
+            raise FileNotFoundError(f"BAGEL transformer weights not found: {weight_path}")
+        weight_dict = safetensors.torch.load_file(weight_path, device=AI_DEVICE)
         self._apply_weights(weight_dict)
 
     def _init_infer(self):
@@ -264,9 +273,16 @@ class BagelModel:
 
     @torch.no_grad()
     def prepare_inputs(self, input_info, scheduler):
-        gen_context = self.transformer_infer.gen_context
-        cfg_text_context = self.transformer_infer.cfg_text_context
-        cfg_img_context = self.transformer_infer.cfg_img_context
+        gen_context = self.init_gen_context()
+        cfg_text_context = deepcopy(gen_context)
+        cfg_img_context = deepcopy(gen_context)
+        self.transformer_infer.gen_context = gen_context
+        self.transformer_infer.cfg_text_context = cfg_text_context
+        self.transformer_infer.cfg_img_context = cfg_img_context
+
+        image_shape = tuple(input_info.image_shapes) if input_info.image_shapes else (1024, 1024)
+        if len(image_shape) != 2:
+            raise ValueError(f"BAGEL image_shapes must be a 2D image shape (H, W), got: {input_info.image_shapes}")
 
         input_lists = [input_info.prompt]
         output_list = []
@@ -307,8 +323,9 @@ class BagelModel:
         generation_input = scheduler.prepare_vae_latent(
             curr_kvlens=kv_lens,
             curr_rope=ropes,
-            image_sizes=[(1024, 1024)],
+            image_sizes=[image_shape],
             new_token_ids=self.new_token_ids,
+            seed=input_info.seed,
         )
 
         # text cfg
@@ -318,7 +335,7 @@ class BagelModel:
         generation_input_cfg_text = scheduler.prepare_vae_latent_cfg(
             curr_kvlens=kv_lens_cfg,
             curr_rope=ropes_cfg,
-            image_sizes=[(1024, 1024)],
+            image_sizes=[image_shape],
         )
 
         # img cfg
@@ -328,7 +345,7 @@ class BagelModel:
         generation_input_cfg_img = scheduler.prepare_vae_latent_cfg(
             curr_kvlens=kv_lens_cfg,
             curr_rope=ropes_cfg,
-            image_sizes=[(1024, 1024)],
+            image_sizes=[image_shape],
         )
 
         scheduler.generation_input = generation_input
@@ -363,6 +380,8 @@ class BagelModel:
             cfg_text_past_key_values=cfg_text_past_key_values,
             cfg_img_past_key_values=cfg_img_past_key_values,
         )
+        if output_list:
+            logger.info(f"BAGEL thinking/text output is not returned by T2I v1: {output_list}")
         return bagel_inputs, scheduler
 
     @staticmethod

--- a/lightx2v/models/networks/bagel/model.py
+++ b/lightx2v/models/networks/bagel/model.py
@@ -8,16 +8,18 @@ from PIL import Image
 from loguru import logger
 from torch.nn import functional as F
 
-from lightx2v.models.networks.bagel.data_utils import add_special_tokens
+from lightx2v.models.networks.bagel.data_utils import add_special_tokens, patchify
 from lightx2v.models.networks.bagel.infer.post_infer import BagelPostInfer
 from lightx2v.models.networks.bagel.infer.pre_infer import BagelPreInfer
 from lightx2v.models.networks.bagel.infer.transformer_infer import BagelTransformerInfer
 from lightx2v.models.networks.bagel.model_io import BagelInputs, NaiveCache, cache_init
 from lightx2v.models.networks.bagel.modeling_utils import PositionEmbedding
 from lightx2v.models.networks.bagel.tokenization_qwen2 import Qwen2Tokenizer
+from lightx2v.models.networks.bagel.vision import load_bagel_vit_model
 from lightx2v.models.networks.bagel.weights.post_weights import Qwen2PostWeights
 from lightx2v.models.networks.bagel.weights.pre_weights import Qwen2PreWeights
 from lightx2v.models.networks.bagel.weights.transformer_weights import Qwen2TransformerWeights
+from lightx2v.models.runners.bagel.i2i_utils import pil_to_bagel_tensor, resize_pil_for_vit
 from lightx2v.models.runners.bagel.t2i_utils import validate_bagel_model_assets
 from lightx2v.utils.envs import *
 from lightx2v.utils.utils import *
@@ -53,6 +55,7 @@ class BagelModel:
         self.text_temperature = config.get("text_temperature", 0.3)
         self.max_think_token_n = config.get("max_think_token_n", 1000)
         self.enable_taylorseer = False
+        self.enable_vision_context = config.get("task", "t2i") == "i2i"
 
         self.cpu_offload = config.get("cpu_offload", False)
         self.offload_granularity = self.config.get("offload_granularity", "block")
@@ -85,6 +88,8 @@ class BagelModel:
         self.pre_weight.load(self.original_weight_dict)
         self.transformer_weights.load(self.original_weight_dict)
         self.post_weight.load(self.original_weight_dict)
+        if self.enable_vision_context:
+            self.vit_model = load_bagel_vit_model(self.config, self.original_weight_dict)
 
         del self.original_weight_dict
         torch.cuda.empty_cache()
@@ -121,6 +126,12 @@ class BagelModel:
             self.max_latent_size = self.config["max_latent_size_update"]
             self.latent_pos_embed = PositionEmbedding(self.max_latent_size, self.hidden_size)
             self.frequency_embedding_size = 256
+
+        if self.enable_vision_context:
+            self.vit_patch_size = self.config["vit_config"]["patch_size"]
+            self.vit_max_num_patch_per_side = self.config["vit_max_num_patch_per_side"]
+            self.vit_hidden_size = self.config["vit_config"]["hidden_size"]
+            self.vit_pos_embed = PositionEmbedding(self.vit_max_num_patch_per_side, self.hidden_size)
 
     def init_gen_context(self):
         gen_context = {
@@ -268,11 +279,299 @@ class BagelModel:
 
         return gen_context
 
-    def gen_text(self):
-        assert NotImplementedError
+    def prepare_vit_images(self, curr_kvlens, curr_rope, images, new_token_ids):
+        packed_vit_token_indexes = list()
+        vit_token_seqlens, packed_vit_tokens, packed_vit_position_ids = list(), list(), list()
+        packed_text_ids, packed_text_indexes = list(), list()
+        packed_seqlens, packed_position_ids, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
+
+        query_curr = curr = 0
+        newlens, new_rope = list(), list()
+        for image, curr_kvlen, curr_position_id in zip(images, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_text_ids.append(new_token_ids["start_of_image"])
+            packed_text_indexes.append(query_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            image_tensor = pil_to_bagel_tensor(resize_pil_for_vit(image))
+            vit_position_ids = self.scheduler.get_flattened_position_ids(
+                image_tensor.size(1),
+                image_tensor.size(2),
+                self.vit_patch_size,
+                max_num_patches_per_side=self.vit_max_num_patch_per_side,
+            )
+            vit_tokens = patchify(image_tensor, self.vit_patch_size)
+            packed_vit_tokens.append(vit_tokens)
+            num_img_tokens = vit_tokens.shape[0]
+            packed_vit_position_ids.append(vit_position_ids)
+            vit_token_seqlens.append(num_img_tokens)
+            packed_vit_token_indexes.extend(range(query_curr, query_curr + num_img_tokens))
+            packed_indexes.extend(range(curr, curr + num_img_tokens))
+            curr += num_img_tokens
+            query_curr += num_img_tokens
+
+            packed_text_ids.append(new_token_ids["end_of_image"])
+            packed_text_indexes.append(query_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))
+            packed_seqlens.append(num_img_tokens + 2)
+            newlens.append(curr_kvlen + num_img_tokens + 2)
+            new_rope.append(curr_position_id + 1)
+
+        generation_input = {
+            "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "vit_token_seqlens": torch.tensor(vit_token_seqlens, dtype=torch.int),
+            "packed_vit_tokens": torch.cat(packed_vit_tokens, dim=0),
+            "packed_vit_position_ids": torch.cat(packed_vit_position_ids, dim=0),
+            "packed_vit_token_indexes": torch.tensor(packed_vit_token_indexes, dtype=torch.long),
+            "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+        }
+
+        return generation_input, newlens, new_rope
+
+    @torch.no_grad
+    def forward_cache_update_vit(
+        self,
+        past_key_values: NaiveCache,
+        packed_text_ids: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_vit_tokens: torch.Tensor,
+        packed_vit_token_indexes: torch.LongTensor,
+        packed_vit_position_ids: torch.LongTensor,
+        vit_token_seqlens: torch.IntTensor,
+        packed_position_ids: torch.LongTensor,
+        packed_seqlens: torch.IntTensor,
+        packed_indexes: torch.LongTensor,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+    ):
+        packed_text_embedding = self.pre_infer.embed_tokens(self.pre_weight, packed_text_ids)
+        packed_sequence = packed_text_embedding.new_zeros((int(packed_seqlens.sum().item()), self.hidden_size))
+        packed_sequence[packed_text_indexes.to(AI_DEVICE)] = packed_text_embedding
+
+        cu_seqlens = torch.nn.functional.pad(torch.cumsum(vit_token_seqlens, dim=0), (1, 0)).to(AI_DEVICE, dtype=torch.int32)
+        max_seqlen = torch.max(vit_token_seqlens).item()
+        packed_vit_token_embed = self.vit_model(
+            packed_pixel_values=packed_vit_tokens,
+            packed_flattened_position_ids=packed_vit_position_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        packed_vit_token_embed = self.pre_infer.connector(self.pre_weight, packed_vit_token_embed)
+        pos_emb = self.vit_pos_embed(packed_vit_position_ids).to(AI_DEVICE).to(torch.bfloat16)
+        packed_vit_token_embed = packed_vit_token_embed + pos_emb
+        if packed_vit_token_embed.dtype != packed_sequence.dtype:
+            packed_vit_token_embed = packed_vit_token_embed.to(packed_sequence.dtype)
+        packed_sequence[packed_vit_token_indexes.to(AI_DEVICE)] = packed_vit_token_embed
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs = {"mode": "und"}
+
+        output = self.forward_inference(
+            packed_query_sequence=packed_sequence,
+            query_lens=packed_seqlens,
+            packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
+            past_key_values=past_key_values,
+            packed_key_value_indexes=packed_key_value_indexes,
+            key_values_lens=key_values_lens,
+            update_past_key_values=True,
+            is_causal=False,
+            **extra_inputs,
+        )
+        return output[1]
+
+    def prepare_vae_images(self, curr_kvlens, curr_rope, images, new_token_ids, timestep=0):
+        patchified_vae_latent_shapes, packed_vae_position_ids = list(), list()
+        packed_vae_token_indexes = list()
+        packed_text_ids, packed_text_indexes = list(), list()
+        packed_seqlens, packed_position_ids, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
+
+        query_curr = curr = 0
+        vae_image_tensors = list()
+        newlens, new_rope = list(), list()
+        for image, curr_kvlen, curr_position_id in zip(images, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_text_ids.append(new_token_ids["start_of_image"])
+            packed_text_indexes.append(query_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            image_tensor = pil_to_bagel_tensor(image)
+            vae_image_tensors.append(image_tensor)
+            vae_position_ids = self.scheduler.get_flattened_position_ids(
+                image_tensor.size(1),
+                image_tensor.size(2),
+                self.latent_downsample,
+                max_num_patches_per_side=self.max_latent_size,
+            )
+            packed_vae_position_ids.append(vae_position_ids)
+            height, width = image_tensor.shape[1:]
+            h = height // self.latent_downsample
+            w = width // self.latent_downsample
+            patchified_vae_latent_shapes.append((h, w))
+
+            num_img_tokens = w * h
+            packed_vae_token_indexes.extend(range(query_curr, query_curr + num_img_tokens))
+            packed_indexes.extend(range(curr, curr + num_img_tokens))
+            curr += num_img_tokens
+            query_curr += num_img_tokens
+
+            packed_text_ids.append(new_token_ids["end_of_image"])
+            packed_text_indexes.append(query_curr)
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
+            packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))
+            packed_seqlens.append(num_img_tokens + 2)
+            newlens.append(curr_kvlen + num_img_tokens + 2)
+            new_rope.append(curr_position_id + 1)
+
+        image_sizes = [item.shape for item in vae_image_tensors]
+        max_image_size = [max(item) for item in list(zip(*image_sizes))]
+        padded_images = torch.zeros(size=(len(vae_image_tensors), *max_image_size))
+        for i, image_tensor in enumerate(vae_image_tensors):
+            padded_images[i, :, : image_tensor.shape[1], : image_tensor.shape[2]] = image_tensor
+
+        generation_input = {
+            "padded_images": padded_images,
+            "patchified_vae_latent_shapes": patchified_vae_latent_shapes,
+            "packed_vae_position_ids": torch.cat(packed_vae_position_ids, dim=0),
+            "packed_timesteps": torch.tensor([timestep]),
+            "packed_vae_token_indexes": torch.tensor(packed_vae_token_indexes, dtype=torch.long),
+            "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+        }
+
+        return generation_input, newlens, new_rope
+
+    @torch.no_grad
+    def forward_cache_update_vae(
+        self,
+        vae_model,
+        past_key_values: NaiveCache,
+        padded_images: torch.Tensor,
+        patchified_vae_latent_shapes: list,
+        packed_vae_position_ids: torch.LongTensor,
+        packed_timesteps: torch.Tensor,
+        packed_vae_token_indexes: torch.LongTensor,
+        packed_text_ids: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_position_ids: torch.LongTensor,
+        packed_seqlens: torch.IntTensor,
+        packed_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+        packed_key_value_indexes: torch.Tensor,
+    ):
+        packed_text_embedding = self.pre_infer.embed_tokens(self.pre_weight, packed_text_ids)
+        packed_sequence = packed_text_embedding.new_zeros((int(packed_seqlens.sum().item()), self.hidden_size))
+        packed_sequence[packed_text_indexes.to(AI_DEVICE)] = packed_text_embedding
+
+        padded_latent = vae_model.encode(padded_images)
+
+        p = self.latent_patch_size
+        packed_latent = list()
+        for latent, (h, w) in zip(padded_latent, patchified_vae_latent_shapes):
+            latent = latent[:, : h * p, : w * p].reshape(self.latent_channel, h, p, w, p)
+            latent = torch.einsum("chpwq->hwpqc", latent).reshape(-1, p * p * self.latent_channel)
+            packed_latent.append(latent)
+        packed_latent = torch.cat(packed_latent, dim=0)
+
+        packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids).to(AI_DEVICE).to(torch.bfloat16)
+        packed_timestep_embeds = self.time_embedder(self.pre_weight, packed_timesteps)
+        packed_latent = self.vae2llm(packed_latent) + packed_timestep_embeds + packed_pos_embed
+        if packed_latent.dtype != packed_sequence.dtype:
+            packed_latent = packed_latent.to(packed_sequence.dtype)
+        packed_sequence[packed_vae_token_indexes.to(AI_DEVICE)] = packed_latent
+
+        extra_inputs = {}
+        if self.use_moe:
+            extra_inputs = {
+                "mode": "gen",
+                "packed_vae_token_indexes": packed_vae_token_indexes,
+                "packed_text_indexes": packed_text_indexes,
+            }
+
+        output = self.forward_inference(
+            packed_query_sequence=packed_sequence,
+            query_lens=packed_seqlens,
+            packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
+            past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
+            update_past_key_values=True,
+            is_causal=False,
+            **extra_inputs,
+        )
+        return output[1]
 
     @torch.no_grad()
-    def prepare_inputs(self, input_info, scheduler):
+    def update_context_image(self, image, gen_context, vae_model, vae=True, vit=True):
+        if not (vae or vit):
+            raise ValueError("BAGEL image context update requires at least one of VAE or ViT.")
+
+        past_key_values = gen_context["past_key_values"]
+        kv_lens = gen_context["kv_lens"]
+        ropes = gen_context["ropes"]
+
+        if vae:
+            if vae_model is None:
+                raise ValueError("BAGEL I2I requires a VAE model to encode image context.")
+            generation_input, kv_lens, ropes = self.prepare_vae_images(
+                curr_kvlens=kv_lens,
+                curr_rope=ropes,
+                images=[image],
+                new_token_ids=self.new_token_ids,
+            )
+            past_key_values = self.forward_cache_update_vae(vae_model, past_key_values, **generation_input)
+
+        if vit:
+            if not hasattr(self, "vit_model"):
+                raise ValueError("BAGEL I2I requires ViT weights (`vit_model.*`) from ema.safetensors.")
+            generation_input, kv_lens, ropes = self.prepare_vit_images(
+                curr_kvlens=kv_lens,
+                curr_rope=ropes,
+                images=[image],
+                new_token_ids=self.new_token_ids,
+            )
+            past_key_values = self.forward_cache_update_vit(past_key_values, **generation_input)
+
+        gen_context["kv_lens"] = kv_lens
+        gen_context["ropes"] = ropes
+        gen_context["past_key_values"] = past_key_values
+        return gen_context
+
+    def gen_text(self, *args, **kwargs):
+        raise NotImplementedError("BAGEL gen_text is not implemented in LightX2V.")
+
+    @torch.no_grad()
+    def prepare_inputs(self, input_info, scheduler, vae_model=None):
+        self.set_scheduler(scheduler)
         gen_context = self.init_gen_context()
         cfg_text_context = deepcopy(gen_context)
         cfg_img_context = deepcopy(gen_context)
@@ -284,7 +583,15 @@ class BagelModel:
         if len(image_shape) != 2:
             raise ValueError(f"BAGEL image_shapes must be a 2D image shape (H, W), got: {input_info.image_shapes}")
 
-        input_lists = [input_info.prompt]
+        task = self.config.get("task", "t2i")
+        input_lists = []
+        if task == "i2i":
+            input_image = getattr(input_info, "input_image", None)
+            if input_image is None:
+                raise ValueError("BAGEL I2I requires `input_image` prepared by BagelRunner.")
+            input_lists.append(input_image)
+        input_lists.append(input_info.prompt)
+
         output_list = []
         with torch.autocast(device_type="cuda", enabled=True, dtype=torch.bfloat16):
             if self.think:
@@ -295,20 +602,20 @@ class BagelModel:
                 gen_context = self.update_context_text(system_prompt, gen_context)
                 cfg_img_context = self.update_context_text(system_prompt, cfg_img_context)
             for input_term in input_lists:
-                if isinstance(input_term, str):  # True
+                if isinstance(input_term, str):
                     cfg_text_context = deepcopy(gen_context)
                     gen_context = self.update_context_text(input_term, gen_context)
                     cfg_img_context = self.update_context_text(input_term, cfg_img_context)
                 elif isinstance(input_term, Image.Image):
-                    assert NotImplementedError
+                    gen_context = self.update_context_image(input_term, gen_context, vae_model=vae_model, vae=not self.understanding_output, vit=True)
+                    image_shape = input_term.size[::-1]
+                    cfg_text_context = deepcopy(gen_context)
                 else:
                     raise ValueError(f"Unsupported input type: {type(input_term)}")
 
             max_think_token_n = 1000
             if self.understanding_output:
-                assert NotImplementedError
-                gen_text = self.gen_text(gen_context, do_sample=self.do_sample, temperature=self.text_temperature, max_length=max_think_token_n)
-                output_list.append(gen_text)
+                raise NotImplementedError("BAGEL visual understanding output is not implemented in LightX2V.")
             else:
                 if self.think:
                     gen_text = self.gen_text(gen_context, do_sample=self.do_sample, temperature=self.text_temperature, max_length=max_think_token_n)
@@ -381,7 +688,7 @@ class BagelModel:
             cfg_img_past_key_values=cfg_img_past_key_values,
         )
         if output_list:
-            logger.info(f"BAGEL thinking/text output is not returned by T2I v1: {output_list}")
+            logger.info(f"BAGEL thinking/text output is not returned by LightX2V BAGEL image generation: {output_list}")
         return bagel_inputs, scheduler
 
     @staticmethod
@@ -479,8 +786,8 @@ class BagelModel:
 
         if cfg_text_scale > 1.0:
             if self.enable_taylorseer:
-                self.cache_dic = inputs.model_pred_text_cache_dic
-                self.current = inputs.model_pred_text_current
+                self.scheduler.cache_dic = inputs.model_pred_text_cache_dic
+                self.scheduler.current = inputs.model_pred_text_current
 
             cfg_text_output = self.forward_inference(
                 packed_query_sequence=packed_sequence,
@@ -499,8 +806,8 @@ class BagelModel:
 
         if cfg_img_scale > 1.0:
             if self.enable_taylorseer:
-                self.cache_dic = inputs.model_pred_text_cache_dic
-                self.current = inputs.model_pred_text_current
+                self.scheduler.cache_dic = inputs.model_pred_img_cache_dic
+                self.scheduler.current = inputs.model_pred_img_current
 
             cfg_img_output = self.forward_inference(
                 packed_query_sequence=packed_sequence,
@@ -544,7 +851,7 @@ class BagelModel:
                     norm_v_t = torch.norm(v_t, dim=-1, keepdim=True)
                     norm_v_t_ = torch.norm(v_t_, dim=-1, keepdim=True)
                 else:
-                    raise NotImplementedError(f"{self.inference_hyper['cfg_renorm_min']} is not suppoprted")
+                    raise NotImplementedError(f"cfg_renorm_type={self.inference_hyper['cfg_renorm_type']!r} is not supported")
                 scale = (norm_v_t / (norm_v_t_ + 1e-8)).clamp(min=self.inference_hyper["cfg_renorm_min"], max=1.0)
                 v_t = v_t_ * scale
         else:

--- a/lightx2v/models/networks/bagel/vision.py
+++ b/lightx2v/models/networks/bagel/vision.py
@@ -1,0 +1,207 @@
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from transformers.activations import ACT2FN
+
+try:
+    import flash_attn  # noqa: F401
+    from flash_attn.flash_attn_interface import flash_attn_varlen_func
+except ImportError:
+    flash_attn_varlen_func = None
+
+
+@dataclass
+class BagelSiglipVisionConfig:
+    hidden_size: int = 1152
+    image_size: int = 980
+    intermediate_size: int = 4304
+    num_attention_heads: int = 16
+    num_hidden_layers: int = 26
+    patch_size: int = 14
+    num_channels: int = 3
+    hidden_act: str = "gelu_pytorch_tanh"
+    layer_norm_eps: float = 1e-6
+    attention_dropout: float = 0.0
+    rope: bool = False
+
+    @classmethod
+    def from_dict(cls, config):
+        values = dict(config)
+        values.pop("model_type", None)
+        allowed = cls.__dataclass_fields__
+        return cls(**{key: value for key, value in values.items() if key in allowed})
+
+
+class BagelSiglipVisionEmbeddings(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.patch_embedding = nn.Linear(config.num_channels * config.patch_size**2, config.hidden_size)
+        self.position_embedding = nn.Embedding((config.image_size // config.patch_size) ** 2, config.hidden_size)
+
+    def forward(self, packed_pixel_values, packed_flattened_position_ids):
+        embeddings = self.patch_embedding(packed_pixel_values)
+        embeddings = embeddings + self.position_embedding(packed_flattened_position_ids)
+        return embeddings
+
+
+class BagelSiglipAttention(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        if flash_attn_varlen_func is None:
+            raise ImportError("BAGEL I2I requires flash-attn (`flash_attn`) for the SigLIP vision encoder. Install a flash-attn build compatible with your CUDA/PyTorch environment.")
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(f"hidden_size must be divisible by num_attention_heads, got {self.embed_dim} and {self.num_heads}")
+
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def forward(self, hidden_states, cu_seqlens, max_seqlen):
+        total_q_len, _ = hidden_states.size()
+        query_states = self.q_proj(hidden_states).view(total_q_len, self.num_heads, self.head_dim)
+        key_states = self.k_proj(hidden_states).view(total_q_len, self.num_heads, self.head_dim)
+        value_states = self.v_proj(hidden_states).view(total_q_len, self.num_heads, self.head_dim)
+
+        attn_output = flash_attn_varlen_func(
+            query_states.to(torch.bfloat16),
+            key_states.to(torch.bfloat16),
+            value_states.to(torch.bfloat16),
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+            causal=False,
+        )
+        return self.out_proj(attn_output.reshape(total_q_len, -1))
+
+
+class BagelSiglipMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states):
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class BagelSiglipEncoderLayer(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.self_attn = BagelSiglipAttention(config)
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = BagelSiglipMLP(config)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, hidden_states, cu_seqlens, max_seqlen):
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class BagelSiglipEncoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.layers = nn.ModuleList([BagelSiglipEncoderLayer(config) for _ in range(config.num_hidden_layers)])
+
+    def forward(self, inputs_embeds, cu_seqlens, max_seqlen):
+        hidden_states = inputs_embeds
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        return hidden_states
+
+
+class BagelSiglipVisionTransformer(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.embeddings = BagelSiglipVisionEmbeddings(config)
+        self.encoder = BagelSiglipEncoder(config)
+        self.post_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, packed_pixel_values, packed_flattened_position_ids, cu_seqlens, max_seqlen):
+        hidden_states = self.embeddings(
+            packed_pixel_values=packed_pixel_values,
+            packed_flattened_position_ids=packed_flattened_position_ids,
+        )
+        hidden_states = self.encoder(hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        return self.post_layernorm(hidden_states)
+
+
+class BagelSiglipVisionModel(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.vision_model = BagelSiglipVisionTransformer(config)
+
+    def forward(self, packed_pixel_values, packed_flattened_position_ids, cu_seqlens, max_seqlen):
+        device = next(self.parameters()).device
+        dtype = next(self.parameters()).dtype
+        return self.vision_model(
+            packed_pixel_values=packed_pixel_values.to(device=device, dtype=dtype),
+            packed_flattened_position_ids=packed_flattened_position_ids.to(device),
+            cu_seqlens=cu_seqlens.to(device=device, dtype=torch.int32),
+            max_seqlen=max_seqlen,
+        )
+
+
+def infer_bagel_vit_layer_count(weight_dict):
+    prefix = "vit_model.vision_model.encoder.layers."
+    layer_ids = set()
+    for key in weight_dict:
+        if key.startswith(prefix):
+            layer_ids.add(int(key[len(prefix) :].split(".", 1)[0]))
+    if not layer_ids:
+        raise ValueError("BAGEL ema.safetensors is missing ViT encoder weights (`vit_model.vision_model.encoder.layers.*`) required for task='i2i'.")
+    return max(layer_ids) + 1
+
+
+def extract_bagel_vit_state_dict(weight_dict):
+    state_dict = {key[len("vit_model.") :]: value for key, value in weight_dict.items() if key.startswith("vit_model.")}
+    if not state_dict:
+        raise ValueError("BAGEL ema.safetensors is missing ViT weights (`vit_model.*`) required for task='i2i'.")
+    return state_dict
+
+
+def build_bagel_vit_config(config, weight_dict=None):
+    if "vit_config" not in config:
+        raise ValueError("BAGEL I2I requires `vit_config` from the BAGEL model config.")
+    vit_config = BagelSiglipVisionConfig.from_dict(config["vit_config"])
+    vit_config.rope = False
+    if weight_dict is not None:
+        vit_config.num_hidden_layers = infer_bagel_vit_layer_count(weight_dict)
+    elif vit_config.num_hidden_layers == 27:
+        # BAGEL's published config.json reports 27 layers, while the official checkpoint
+        # ships 26 SigLIP encoder blocks. Keep the fallback aligned with the checkpoint.
+        vit_config.num_hidden_layers = 26
+    return vit_config
+
+
+def load_bagel_vit_model(config, weight_dict):
+    vit_state_dict = extract_bagel_vit_state_dict(weight_dict)
+    vit_config = build_bagel_vit_config(config, weight_dict=weight_dict)
+    model = BagelSiglipVisionModel(vit_config)
+    missing, unexpected = model.load_state_dict(vit_state_dict, strict=False, assign=True)
+    if missing:
+        raise ValueError(f"BAGEL ViT weights are incomplete for task='i2i'; missing key(s): {missing[:8]}")
+    if unexpected:
+        raise ValueError(f"BAGEL ViT weights do not match the local SigLIP encoder; unexpected key(s): {unexpected[:8]}")
+    model.eval()
+    model.requires_grad_(False)
+    return model

--- a/lightx2v/models/runners/bagel/bagel_runner.py
+++ b/lightx2v/models/runners/bagel/bagel_runner.py
@@ -1,9 +1,12 @@
 import gc
+import os
 
 import torch
+import torch.distributed as dist
 from loguru import logger
 
 from lightx2v.models.networks.bagel.model import BagelModel
+from lightx2v.models.runners.bagel.t2i_utils import get_bagel_latent_downsample, resolve_bagel_t2i_image_shape
 from lightx2v.models.runners.default_runner import DefaultRunner
 from lightx2v.models.schedulers.bagel.scheduler import BagelScheduler
 from lightx2v.models.video_encoders.hf.bagel.vae import BagelVae
@@ -14,6 +17,10 @@ from lightx2v.utils.registry_factory import RUNNER_REGISTER
 from lightx2v_platform.base.global_var import AI_DEVICE
 
 torch_device_module = getattr(torch, AI_DEVICE)
+
+
+def _has_save_path(input_info):
+    return bool(getattr(input_info, "save_result_path", None))
 
 
 @RUNNER_REGISTER("bagel")
@@ -46,7 +53,11 @@ class BagelRunner(DefaultRunner):
         self.run_dit = self._run_dit_local
 
     def set_image_shapes(self):
-        self.input_info.image_shapes = (1024, 1024)
+        image_shape = resolve_bagel_t2i_image_shape(self.input_info, self.config)
+        self.input_info.image_shapes = image_shape
+        self.input_info.target_shape = list(image_shape)
+        logger.info(f"BAGEL T2I image shape: {image_shape[0]}x{image_shape[1]}")
+        return image_shape
 
     def run(self, total_steps=None):
         if total_steps is None:
@@ -74,6 +85,11 @@ class BagelRunner(DefaultRunner):
         latents, generator = self.run(total_steps)
         return latents, generator
 
+    def _refresh_scheduler_from_config(self):
+        self.scheduler.infer_steps = int(self.config.get("infer_steps", self.scheduler.infer_steps))
+        self.scheduler.timestep_shift = self.config["inference_hyper"]["timestep_shift"]
+        self.scheduler.set_timesteps()
+
     @ProfilingContext4DebugL1("Run VAE Decoder", recorder_mode=GET_RECORDER_MODE(), metrics_func=monitor_cli.lightx2v_run_vae_decode_duration, metrics_labels=["DefaultRunner"])
     def run_vae_decoder(self, latents, decode_info):
         if self.config.get("lazy_load", False) or self.config.get("unload_modules", False):
@@ -85,38 +101,68 @@ class BagelRunner(DefaultRunner):
             gc.collect()
         return images
 
+    def _build_decode_info(self, image_shape):
+        return {
+            "packed_seqlens": self.inputs.generation_input["packed_seqlens"],
+            "image_shape": image_shape,
+            "latent_downsample": get_bagel_latent_downsample(self.config),
+            "latent_channel": self.config["vae_config"]["z_channels"],
+            "latent_patch_size": self.config["latent_patch_size"],
+        }
+
+    def _save_images(self, images, input_info, log_prefix="Image saved"):
+        if dist.is_initialized() and dist.get_rank() != 0:
+            return
+        if input_info.return_result_tensor:
+            return
+        if not _has_save_path(input_info):
+            return
+
+        image_prefix, image_suffix = os.path.splitext(input_info.save_result_path)
+        image_suffix = image_suffix.lstrip(".") or "png"
+        if isinstance(images[0], list) and len(images[0]) > 1:
+            for idx, image in enumerate(images[0]):
+                out_path = f"{image_prefix}_{idx:05d}.{image_suffix}"
+                image.save(out_path)
+                logger.info(f"{log_prefix}: {out_path}")
+        else:
+            out_path = f"{image_prefix}.{image_suffix}"
+            images[0].save(out_path)
+            logger.info(f"{log_prefix}: {out_path}")
+
+    def _finalize_pipeline_outputs(self, input_info, images, latents=None, generator=None):
+        if latents is not None:
+            del latents
+        if generator is not None:
+            del generator
+        torch_device_module.empty_cache()
+        gc.collect()
+
+        if input_info.return_result_tensor:
+            return {"images": images}
+        if _has_save_path(input_info):
+            return {"images": None}
+        return {"images": images}
+
     def run_pipeline(self, input_info):
+        if self.config["task"] != "t2i":
+            raise NotImplementedError("BAGEL v1 support in LightX2V currently only implements task='t2i'")
+
         self.input_info = input_info
         logger.info(f"input_info: {self.input_info}")
+        if getattr(self.input_info, "negative_prompt", ""):
+            logger.warning("BAGEL T2I v1 does not use negative_prompt; the value will be ignored.")
+
+        self._refresh_scheduler_from_config()
+        image_shape = self.set_image_shapes()
 
         self.inputs, self.scheduler = self.model.prepare_inputs(self.input_info, self.scheduler)
         self.model.set_scheduler(self.scheduler)
 
-        self.set_image_shapes()
         latents, generator = self.run_dit()
-        decode_info = {
-            "packed_seqlens": self.inputs.generation_input["packed_seqlens"],
-            "image_shape": [1024, 1024],
-            "latent_downsample": 16,
-            "latent_channel": 16,
-            "latent_patch_size": 2,
-        }
+        decode_info = self._build_decode_info(image_shape)
         images = self.run_vae_decoder(latents, decode_info)
         self.end_run()
 
-        if isinstance(images[0], list) and len(images[0]) > 1:
-            image_prefix = f"{input_info.save_result_path}".split(".")[0]
-            for idx, image in enumerate(images[0]):
-                image.save(f"{image_prefix}_{idx}.png")
-                logger.info(f"Image saved: {image_prefix}_{idx}.png")
-        else:
-            image = images[0]
-            image.save(f"{input_info.save_result_path}")
-            logger.info(f"Image saved: {input_info.save_result_path}")
-
-        del latents, generator
-        torch_device_module.empty_cache()
-        gc.collect()
-
-        # Return (images, audio) - audio is None for default runner
-        return images, None
+        self._save_images(images, input_info)
+        return self._finalize_pipeline_outputs(input_info, images, latents=latents, generator=generator)

--- a/lightx2v/models/runners/bagel/bagel_runner.py
+++ b/lightx2v/models/runners/bagel/bagel_runner.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 from loguru import logger
 
 from lightx2v.models.networks.bagel.model import BagelModel
+from lightx2v.models.runners.bagel.i2i_utils import load_bagel_i2i_input_image, resize_pil_to_shape, resolve_bagel_i2i_image_shape
 from lightx2v.models.runners.bagel.t2i_utils import get_bagel_latent_downsample, resolve_bagel_t2i_image_shape
 from lightx2v.models.runners.default_runner import DefaultRunner
 from lightx2v.models.schedulers.bagel.scheduler import BagelScheduler
@@ -52,12 +53,32 @@ class BagelRunner(DefaultRunner):
             assert self.config.get("cpu_offload", False)
         self.run_dit = self._run_dit_local
 
-    def set_image_shapes(self):
+    def set_t2i_image_shapes(self):
         image_shape = resolve_bagel_t2i_image_shape(self.input_info, self.config)
         self.input_info.image_shapes = image_shape
         self.input_info.target_shape = list(image_shape)
         logger.info(f"BAGEL T2I image shape: {image_shape[0]}x{image_shape[1]}")
         return image_shape
+
+    def set_i2i_image_shapes(self):
+        input_image = load_bagel_i2i_input_image(self.input_info.image_path)
+        image_shape = resolve_bagel_i2i_image_shape(self.input_info, self.config, input_image.size)
+        processed_image = resize_pil_to_shape(input_image, image_shape)
+
+        self.input_info.input_image = processed_image
+        self.input_info.image_shapes = image_shape
+        self.input_info.target_shape = list(image_shape)
+        self.input_info.original_size = [input_image.size[1], input_image.size[0]]
+        self.input_info.processed_image_size = list(image_shape)
+        if getattr(self.input_info, "aspect_ratio", ""):
+            logger.warning("BAGEL I2I MVP ignores aspect_ratio and preserves the input image aspect ratio unless target_shape is set.")
+        logger.info(f"BAGEL I2I image shape: {image_shape[0]}x{image_shape[1]} from input {input_image.size[1]}x{input_image.size[0]}")
+        return image_shape
+
+    def set_image_shapes(self):
+        if self.config["task"] == "i2i":
+            return self.set_i2i_image_shapes()
+        return self.set_t2i_image_shapes()
 
     def run(self, total_steps=None):
         if total_steps is None:
@@ -86,7 +107,8 @@ class BagelRunner(DefaultRunner):
         return latents, generator
 
     def _refresh_scheduler_from_config(self):
-        self.scheduler.infer_steps = int(self.config.get("infer_steps", self.scheduler.infer_steps))
+        infer_steps = self.config.get("infer_steps", self.config["inference_hyper"].get("num_timesteps", self.scheduler.infer_steps))
+        self.scheduler.infer_steps = int(infer_steps)
         self.scheduler.timestep_shift = self.config["inference_hyper"]["timestep_shift"]
         self.scheduler.set_timesteps()
 
@@ -145,19 +167,19 @@ class BagelRunner(DefaultRunner):
         return {"images": images}
 
     def run_pipeline(self, input_info):
-        if self.config["task"] != "t2i":
-            raise NotImplementedError("BAGEL v1 support in LightX2V currently only implements task='t2i'")
+        if self.config["task"] not in ["t2i", "i2i"]:
+            raise NotImplementedError("BAGEL image generation in LightX2V currently supports task='t2i' and task='i2i'")
 
         self.input_info = input_info
         logger.info(f"input_info: {self.input_info}")
         if getattr(self.input_info, "negative_prompt", ""):
-            logger.warning("BAGEL T2I v1 does not use negative_prompt; the value will be ignored.")
+            logger.warning("BAGEL image generation MVP does not use negative_prompt; the value will be ignored.")
 
         self._refresh_scheduler_from_config()
         image_shape = self.set_image_shapes()
 
-        self.inputs, self.scheduler = self.model.prepare_inputs(self.input_info, self.scheduler)
-        self.model.set_scheduler(self.scheduler)
+        vae_encoder = self.vae_decoder if self.config["task"] == "i2i" else None
+        self.inputs, self.scheduler = self.model.prepare_inputs(self.input_info, self.scheduler, vae_model=vae_encoder)
 
         latents, generator = self.run_dit()
         decode_info = self._build_decode_info(image_shape)

--- a/lightx2v/models/runners/bagel/i2i_utils.py
+++ b/lightx2v/models/runners/bagel/i2i_utils.py
@@ -1,0 +1,111 @@
+import os
+
+import numpy as np
+import torch
+from PIL import Image
+
+from lightx2v.models.networks.bagel.data_utils import pil_img2rgb
+from lightx2v.models.runners.bagel.t2i_utils import get_bagel_latent_downsample, get_config_value
+
+
+_BICUBIC = Image.Resampling.BICUBIC if hasattr(Image, "Resampling") else Image.BICUBIC
+
+
+def _validate_target_shape(target_shape, latent_downsample):
+    if len(target_shape) == 2:
+        try:
+            height, width = int(target_shape[0]), int(target_shape[1])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"BAGEL I2I target_shape must be two positive integers [H W], got: {target_shape}") from exc
+        if height <= 0 or width <= 0:
+            raise ValueError(f"BAGEL I2I target_shape must be positive [H W], got: {target_shape}")
+        if height % latent_downsample != 0 or width % latent_downsample != 0:
+            raise ValueError(f"BAGEL I2I target_shape must be divisible by latent downsample {latent_downsample}, got: {[height, width]}")
+        return (height, width)
+
+    if target_shape:
+        raise ValueError(f"BAGEL I2I target_shape must be [H W] when set, got: {target_shape}")
+    return None
+
+
+def _round_to_multiple(value, multiple):
+    return max(multiple, int(round(float(value) / multiple) * multiple))
+
+
+def resolve_bagel_i2i_image_shape(input_info, config, input_image_size):
+    latent_downsample = get_bagel_latent_downsample(config)
+    target_shape = getattr(input_info, "target_shape", None) or []
+    resolved = _validate_target_shape(target_shape, latent_downsample)
+    if resolved is not None:
+        return resolved
+
+    if len(input_image_size) != 2:
+        raise ValueError(f"BAGEL I2I input_image_size must be [W H], got: {input_image_size}")
+
+    width, height = int(input_image_size[0]), int(input_image_size[1])
+    if height <= 0 or width <= 0:
+        raise ValueError(f"BAGEL I2I input image size must be positive, got: {(width, height)}")
+
+    max_size = int(get_config_value(config, "i2i_max_image_size", 1024))
+    if max_size <= 0:
+        raise ValueError(f"BAGEL I2I i2i_max_image_size must be positive, got: {max_size}")
+
+    scale = min(1.0, max_size / max(width, height))
+    resolved_height = _round_to_multiple(height * scale, latent_downsample)
+    resolved_width = _round_to_multiple(width * scale, latent_downsample)
+    return (resolved_height, resolved_width)
+
+
+def load_bagel_i2i_input_image(image_path):
+    if not image_path:
+        raise ValueError("BAGEL I2I requires `image_path`.")
+    if isinstance(image_path, str) and "," in image_path:
+        raise NotImplementedError("BAGEL I2I MVP supports exactly one input image; comma-separated `image_path` values are not supported.")
+    if os.path.isdir(image_path):
+        raise NotImplementedError("BAGEL I2I MVP supports a single image file; directory `image_path` is not supported.")
+    if not os.path.exists(image_path):
+        raise FileNotFoundError(f"BAGEL I2I input image not found: {image_path}")
+
+    with Image.open(image_path) as image:
+        return pil_img2rgb(image.copy())
+
+
+def resize_pil_to_shape(image, image_shape):
+    height, width = image_shape
+    if image.size == (width, height):
+        return image
+    return image.resize((width, height), resample=_BICUBIC)
+
+
+def pil_to_bagel_tensor(image):
+    array = np.asarray(image, dtype=np.float32) / 255.0
+    tensor = torch.from_numpy(array).permute(2, 0, 1).contiguous()
+    return tensor.sub_(0.5).div_(0.5)
+
+
+def resize_pil_for_vit(image, max_size=980, min_size=224, stride=14, max_pixels=14 * 14 * 9 * 1024):
+    width, height = image.size
+    if height <= 0 or width <= 0:
+        raise ValueError(f"BAGEL ViT input image size must be positive, got: {(width, height)}")
+
+    def make_divisible(value):
+        return max(stride, int(round(value / stride) * stride))
+
+    def apply_scale(w, h, scale):
+        return make_divisible(round(w * scale)), make_divisible(round(h * scale))
+
+    scale = min(max_size / max(width, height), 1.0)
+    scale = max(scale, min_size / min(width, height))
+    new_width, new_height = apply_scale(width, height, scale)
+
+    if new_width * new_height > max_pixels:
+        scale = max_pixels / (new_width * new_height)
+        new_width, new_height = apply_scale(new_width, new_height, scale)
+
+    if max(new_width, new_height) > max_size:
+        scale = max_size / max(new_width, new_height)
+        new_width, new_height = apply_scale(new_width, new_height, scale)
+
+    if (new_width, new_height) == image.size:
+        return image
+    return image.resize((new_width, new_height), resample=_BICUBIC)

--- a/lightx2v/models/runners/bagel/i2i_utils.py
+++ b/lightx2v/models/runners/bagel/i2i_utils.py
@@ -7,7 +7,6 @@ from PIL import Image
 from lightx2v.models.networks.bagel.data_utils import pil_img2rgb
 from lightx2v.models.runners.bagel.t2i_utils import get_bagel_latent_downsample, get_config_value
 
-
 _BICUBIC = Image.Resampling.BICUBIC if hasattr(Image, "Resampling") else Image.BICUBIC
 
 

--- a/lightx2v/models/runners/bagel/i2i_utils.py
+++ b/lightx2v/models/runners/bagel/i2i_utils.py
@@ -98,7 +98,7 @@ def resize_pil_for_vit(image, max_size=980, min_size=224, stride=14, max_pixels=
     new_width, new_height = apply_scale(width, height, scale)
 
     if new_width * new_height > max_pixels:
-        scale = max_pixels / (new_width * new_height)
+        scale = (max_pixels / (new_width * new_height)) ** 0.5
         new_width, new_height = apply_scale(new_width, new_height, scale)
 
     if max(new_width, new_height) > max_size:

--- a/lightx2v/models/runners/bagel/t2i_utils.py
+++ b/lightx2v/models/runners/bagel/t2i_utils.py
@@ -1,0 +1,75 @@
+import os
+
+BAGEL_T2I_ASPECT_RATIOS = {
+    "1:1": (1024, 1024),
+    "4:3": (768, 1024),
+    "3:4": (1024, 768),
+    "16:9": (576, 1024),
+    "9:16": (1024, 576),
+}
+
+
+def get_config_value(config, key, default=None):
+    if hasattr(config, "get"):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def get_bagel_latent_downsample(config):
+    explicit = get_config_value(config, "latent_downsample", None)
+    if explicit is not None:
+        return int(explicit)
+
+    vae_config = get_config_value(config, "vae_config", None)
+    if vae_config is None:
+        raise ValueError("BAGEL config must include `vae_config.downsample` to resolve image shapes")
+
+    vae_downsample = get_config_value(vae_config, "downsample", None)
+    latent_patch_size = get_config_value(config, "latent_patch_size", None)
+    if vae_downsample is None or latent_patch_size is None:
+        raise ValueError("BAGEL config must include `vae_config.downsample` and `latent_patch_size` to resolve image shapes")
+    return int(vae_downsample) * int(latent_patch_size)
+
+
+def resolve_bagel_t2i_image_shape(input_info, config):
+    latent_downsample = get_bagel_latent_downsample(config)
+    target_shape = getattr(input_info, "target_shape", None) or []
+
+    if len(target_shape) == 2:
+        try:
+            height, width = int(target_shape[0]), int(target_shape[1])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"BAGEL target_shape must be two positive integers [H W], got: {target_shape}") from exc
+        if height <= 0 or width <= 0:
+            raise ValueError(f"BAGEL target_shape must be positive [H W], got: {target_shape}")
+        if height % latent_downsample != 0 or width % latent_downsample != 0:
+            raise ValueError(f"BAGEL target_shape must be divisible by latent downsample {latent_downsample}, got: {[height, width]}")
+        return (height, width)
+
+    if target_shape:
+        raise ValueError(f"BAGEL target_shape must be [H W] when set, got: {target_shape}")
+
+    aspect_ratio = getattr(input_info, "aspect_ratio", None) or get_config_value(config, "aspect_ratio", None) or "1:1"
+    if aspect_ratio not in BAGEL_T2I_ASPECT_RATIOS:
+        raise ValueError(f"Unsupported BAGEL aspect_ratio: {aspect_ratio}. Available: {sorted(BAGEL_T2I_ASPECT_RATIOS)}")
+    return BAGEL_T2I_ASPECT_RATIOS[aspect_ratio]
+
+
+def validate_bagel_model_assets(config, model_path):
+    required_keys = [
+        "llm_config",
+        "llm_config_update",
+        "inference_hyper",
+        "vae_config",
+        "latent_patch_size",
+        "max_latent_size_update",
+        "visual_gen",
+    ]
+    missing = [key for key in required_keys if key not in config]
+    if missing:
+        raise ValueError(f"BAGEL config missing required key(s): {missing}. Check model_path/config.json and configs/bagel/bagel_t2i.json.")
+
+    required_files = ["ema.safetensors", "ae.safetensors"]
+    missing_files = [name for name in required_files if not os.path.exists(os.path.join(model_path, name))]
+    if missing_files:
+        raise FileNotFoundError(f"BAGEL model_path is missing required file(s): {missing_files}. Expected ByteDance-Seed/BAGEL-7B-MoT layout under {model_path}.")

--- a/lightx2v/models/runners/bagel/t2i_utils.py
+++ b/lightx2v/models/runners/bagel/t2i_utils.py
@@ -66,8 +66,11 @@ def validate_bagel_model_assets(config, model_path):
         "visual_gen",
     ]
     missing = [key for key in required_keys if key not in config]
+    if get_config_value(config, "task", None) == "i2i":
+        i2i_required_keys = ["vit_config", "vit_max_num_patch_per_side", "connector_act", "visual_und"]
+        missing.extend([key for key in i2i_required_keys if key not in config])
     if missing:
-        raise ValueError(f"BAGEL config missing required key(s): {missing}. Check model_path/config.json and configs/bagel/bagel_t2i.json.")
+        raise ValueError(f"BAGEL config missing required key(s): {missing}. Check model_path/config.json and configs/bagel/bagel_t2i.json or configs/bagel/bagel_i2i.json.")
 
     required_files = ["ema.safetensors", "ae.safetensors"]
     missing_files = [name for name in required_files if not os.path.exists(os.path.join(model_path, name))]

--- a/lightx2v/models/schedulers/bagel/scheduler.py
+++ b/lightx2v/models/schedulers/bagel/scheduler.py
@@ -1,18 +1,6 @@
-import random
-
-import numpy as np
 import torch
 
 from lightx2v.models.schedulers.scheduler import BaseScheduler
-
-
-def set_seed(seed=42):
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    np.random.seed(seed)
-    random.seed(seed)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
 
 
 def get_flattened_position_ids_extrapolate(img_h, img_w, patch_size, max_num_patches_per_side):
@@ -59,13 +47,15 @@ class BagelScheduler(BaseScheduler):
         self.dts = timesteps[:-1] - timesteps[1:]
         self.timesteps = timesteps[:-1]
 
-    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids):
+    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids, seed=None):
         packed_text_ids, packed_text_indexes = list(), list()
         packed_vae_position_ids, packed_vae_token_indexes, packed_init_noises = list(), list(), list()
         packed_position_ids, packed_seqlens, packed_indexes = list(), list(), list()
         packed_key_value_indexes = list()
 
         query_curr = curr = 0
+        seed = int(seed if seed is not None else self.config.get("seed", 42))
+        self.generator = torch.Generator(device="cpu").manual_seed(seed)
 
         for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
             packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
@@ -82,8 +72,7 @@ class BagelScheduler(BaseScheduler):
             h, w = H // self.latent_downsample, W // self.latent_downsample
             num_image_tokens = h * w
 
-            set_seed()
-            packed_init_noises.append(torch.randn(num_image_tokens, self.latent_channel * self.latent_patch_size**2))
+            packed_init_noises.append(torch.randn(num_image_tokens, self.latent_channel * self.latent_patch_size**2, generator=self.generator))
 
             packed_vae_token_indexes.extend(range(query_curr, query_curr + num_image_tokens))
             packed_indexes.extend(range(curr, curr + num_image_tokens))

--- a/lightx2v/models/video_encoders/hf/bagel/vae.py
+++ b/lightx2v/models/video_encoders/hf/bagel/vae.py
@@ -15,6 +15,9 @@ class BagelVae:
         self.vae_model, self.vae_params = load_ae(vae_path)
         self.vae_model = self.vae_model
 
+    def encode(self, images):
+        return self.vae_model.encode(images)
+
     def decode(self, latents, decode_info):
         latents = latents.split((decode_info["packed_seqlens"] - 2).tolist())
 

--- a/lightx2v/models/video_encoders/hf/bagel/vae.py
+++ b/lightx2v/models/video_encoders/hf/bagel/vae.py
@@ -10,6 +10,8 @@ class BagelVae:
     def __init__(self, config):
         self.config = config
         vae_path = os.path.join(config["model_path"], "ae.safetensors")
+        if not os.path.exists(vae_path):
+            raise FileNotFoundError(f"BAGEL VAE weights not found: {vae_path}. Expected `ae.safetensors` in model_path.")
         self.vae_model, self.vae_params = load_ae(vae_path)
         self.vae_model = self.vae_model
 

--- a/lightx2v/utils/input_info.py
+++ b/lightx2v/utils/input_info.py
@@ -217,7 +217,7 @@ class I2IInputInfo:
     target_shape: list = field(default_factory=list)
     image_shapes: list = field(default_factory=list)
     txt_seq_lens: list = field(default_factory=list)  # [postive_txt_seq_len, negative_txt_seq_len]
-    processed_image_size: int = field(default_factory=list)
+    processed_image_size: list = field(default_factory=list)
     original_size: list = field(default_factory=list)
     aspect_ratio: str = field(default_factory=str)
 

--- a/scripts/bagel/run_bagel_i2i.sh
+++ b/scripts/bagel/run_bagel_i2i.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_PATH="${MODEL_PATH:-/path/to/BAGEL-7B-MoT}"
+IMAGE_PATH="${IMAGE_PATH:-assets/inputs/imgs/img_0.jpg}"
+PROMPT="${PROMPT:-Change the scene to golden hour while preserving the main subject.}"
+SAVE_PATH="${SAVE_PATH:-save_results/bagel_i2i.png}"
+
+python -m lightx2v.infer \
+  --model_cls bagel \
+  --task i2i \
+  --model_path "${MODEL_PATH}" \
+  --config_json configs/bagel/bagel_i2i.json \
+  --image_path "${IMAGE_PATH}" \
+  --prompt "${PROMPT}" \
+  --seed 42 \
+  --save_result_path "${SAVE_PATH}"

--- a/scripts/bagel/run_bagel_t2i.sh
+++ b/scripts/bagel/run_bagel_t2i.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# set path and first
-export lightx2v_path=/path/to/LightX2V
-export model_path=/path/to/ByteDance-Seed/BAGEL-7B-MoT
+# Override these environment variables when using a different checkout or model cache.
+export lightx2v_path=${lightx2v_path:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+export model_path=${model_path:-/data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT}
+export aspect_ratio=${aspect_ratio:-1:1}
 
 export CUDA_VISIBLE_DEVICES=0
 
@@ -15,6 +16,6 @@ python -m lightx2v.infer \
     --model_path $model_path \
     --config_json ${lightx2v_path}/configs/bagel/bagel_t2i.json \
     --prompt "A female cosplayer portraying an ethereal fairy or elf, wearing a flowing dress made of delicate fabrics in soft, mystical colors like emerald green and silver. She has pointed ears, a gentle, enchanting expression, and her outfit is adorned with sparkling jewels and intricate patterns. The background is a magical forest with glowing plants, mystical creatures, and a serene atmosphere." \
-    --negative_prompt " " \
+    --aspect_ratio "${aspect_ratio}" \
     --save_result_path ${lightx2v_path}/save_results/bagel_t2i.png \
     --seed 42

--- a/test_cases/test_bagel_t2i_support.py
+++ b/test_cases/test_bagel_t2i_support.py
@@ -6,6 +6,7 @@ import types
 import unittest
 
 import torch
+from PIL import Image
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
@@ -15,10 +16,18 @@ lightx2v_pkg = types.ModuleType("lightx2v")
 lightx2v_pkg.__path__ = [os.path.join(REPO_ROOT, "lightx2v")]
 sys.modules.setdefault("lightx2v", lightx2v_pkg)
 
+import lightx2v_platform.base.global_var as global_var
+
+if global_var.AI_DEVICE is None:
+    global_var.AI_DEVICE = "cuda"
+
 from lightx2v.models.networks.bagel.infer import transformer_infer
+from lightx2v.models.networks.bagel.model import BagelModel
+from lightx2v.models.networks.bagel.vision import build_bagel_vit_config, extract_bagel_vit_state_dict
+from lightx2v.models.runners.bagel.i2i_utils import resolve_bagel_i2i_image_shape
 from lightx2v.models.runners.bagel.t2i_utils import BAGEL_T2I_ASPECT_RATIOS, resolve_bagel_t2i_image_shape, validate_bagel_model_assets
 from lightx2v.models.schedulers.bagel.scheduler import BagelScheduler
-from lightx2v.utils.input_info import T2IInputInfo
+from lightx2v.utils.input_info import I2IInputInfo, T2IInputInfo
 from lightx2v.utils.lockable_dict import LockableDict
 
 
@@ -52,6 +61,28 @@ def make_bagel_config(model_path="."):
             "visual_gen": True,
         }
     )
+
+
+def make_bagel_i2i_config(model_path="."):
+    config = make_bagel_config(model_path=model_path)
+    config.update(
+        {
+            "task": "i2i",
+            "visual_und": True,
+            "vit_max_num_patch_per_side": 70,
+            "connector_act": "gelu_pytorch_tanh",
+            "vit_config": {
+                "hidden_size": 1152,
+                "image_size": 980,
+                "intermediate_size": 4304,
+                "num_attention_heads": 16,
+                "num_hidden_layers": 27,
+                "patch_size": 14,
+                "num_channels": 3,
+            },
+        }
+    )
+    return config
 
 
 class BagelT2ISupportTest(unittest.TestCase):
@@ -110,6 +141,96 @@ class BagelT2ISupportTest(unittest.TestCase):
         message = str(ctx.exception)
         self.assertIn("ema.safetensors", message)
         self.assertIn("ae.safetensors", message)
+
+    def test_i2i_target_shape_overrides_input_shape(self):
+        input_info = I2IInputInfo(target_shape=[576, 1024], aspect_ratio="1:1")
+        self.assertEqual(resolve_bagel_i2i_image_shape(input_info, make_bagel_i2i_config(), (640, 480)), (576, 1024))
+
+    def test_i2i_auto_shape_preserves_input_ratio_and_aligns(self):
+        self.assertEqual(resolve_bagel_i2i_image_shape(I2IInputInfo(), make_bagel_i2i_config(), (2000, 1000)), (512, 1024))
+        self.assertEqual(resolve_bagel_i2i_image_shape(I2IInputInfo(aspect_ratio="16:9"), make_bagel_i2i_config(), (641, 481)), (480, 640))
+
+    def test_i2i_invalid_shape_raises(self):
+        with self.assertRaisesRegex(ValueError, "divisible by latent downsample"):
+            resolve_bagel_i2i_image_shape(I2IInputInfo(target_shape=[577, 1024]), make_bagel_i2i_config(), (640, 480))
+
+    def test_i2i_missing_config_error_is_clear(self):
+        config = make_bagel_config()
+        config["task"] = "i2i"
+        with self.assertRaisesRegex(ValueError, "vit_config"):
+            validate_bagel_model_assets(config, ".")
+
+    def test_missing_vit_weights_error_is_clear(self):
+        with self.assertRaisesRegex(ValueError, "vit_model"):
+            extract_bagel_vit_state_dict({})
+
+    def test_vit_config_uses_checkpoint_layer_count(self):
+        weight_dict = {
+            "vit_model.vision_model.encoder.layers.0.layer_norm1.weight": torch.empty(1),
+            "vit_model.vision_model.encoder.layers.25.layer_norm1.weight": torch.empty(1),
+        }
+        vit_config = build_bagel_vit_config(make_bagel_i2i_config(), weight_dict=weight_dict)
+        self.assertEqual(vit_config.num_hidden_layers, 26)
+
+    def test_gen_text_raises_not_implemented(self):
+        model = BagelModel.__new__(BagelModel)
+        with self.assertRaisesRegex(NotImplementedError, "gen_text"):
+            model.gen_text(None)
+
+    def test_i2i_context_roles_match_mvp_plan(self):
+        model = BagelModel.__new__(BagelModel)
+        model.config = {"task": "i2i"}
+        model.think = False
+        model.understanding_output = False
+        model.do_sample = False
+        model.text_temperature = 0.3
+        model.enable_taylorseer = False
+        model.new_token_ids = {"start_of_image": 1, "end_of_image": 2}
+        model.transformer_infer = types.SimpleNamespace()
+
+        def init_gen_context():
+            return {"images": [], "texts": [], "past_key_values": "pkv", "kv_lens": [0], "ropes": [0]}
+
+        def update_context_text(text, context):
+            context = dict(context)
+            context["texts"] = list(context["texts"]) + [text]
+            return context
+
+        def update_context_image(image, context, vae_model, vae=True, vit=True):
+            context = dict(context)
+            context["images"] = list(context["images"]) + [image.size]
+            return context
+
+        class DummyScheduler:
+            infer_steps = 4
+
+            def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids, seed):
+                return {"packed_init_noises": torch.zeros(1), "image_sizes": image_sizes}
+
+            def prepare_vae_latent_cfg(self, curr_kvlens, curr_rope, image_sizes):
+                return {"cfg_image_sizes": image_sizes}
+
+        model.init_gen_context = init_gen_context
+        model.update_context_text = update_context_text
+        model.update_context_image = update_context_image
+        model.set_scheduler = lambda scheduler: None
+
+        input_info = I2IInputInfo(
+            seed=42,
+            prompt="make it blue",
+            image_shapes=[128, 128],
+        )
+        input_info.input_image = Image.new("RGB", (128, 128), "white")
+
+        bagel_inputs, scheduler = model.prepare_inputs(input_info, DummyScheduler(), vae_model=object())
+
+        self.assertEqual(bagel_inputs.gen_context["images"], [(128, 128)])
+        self.assertEqual(bagel_inputs.gen_context["texts"], ["make it blue"])
+        self.assertEqual(bagel_inputs.cfg_text_precontext["images"], [(128, 128)])
+        self.assertEqual(bagel_inputs.cfg_text_precontext["texts"], [])
+        self.assertEqual(bagel_inputs.cfg_img_precontext["images"], [])
+        self.assertEqual(bagel_inputs.cfg_img_precontext["texts"], ["make it blue"])
+        self.assertEqual(scheduler.latents.shape, torch.Size([1]))
 
 
 if __name__ == "__main__":

--- a/test_cases/test_bagel_t2i_support.py
+++ b/test_cases/test_bagel_t2i_support.py
@@ -1,0 +1,116 @@
+# ruff: noqa: E402, I001
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+import torch
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+lightx2v_pkg = types.ModuleType("lightx2v")
+lightx2v_pkg.__path__ = [os.path.join(REPO_ROOT, "lightx2v")]
+sys.modules.setdefault("lightx2v", lightx2v_pkg)
+
+from lightx2v.models.networks.bagel.infer import transformer_infer
+from lightx2v.models.runners.bagel.t2i_utils import BAGEL_T2I_ASPECT_RATIOS, resolve_bagel_t2i_image_shape, validate_bagel_model_assets
+from lightx2v.models.schedulers.bagel.scheduler import BagelScheduler
+from lightx2v.utils.input_info import T2IInputInfo
+from lightx2v.utils.lockable_dict import LockableDict
+
+
+def make_bagel_config(model_path="."):
+    return LockableDict(
+        {
+            "model_path": model_path,
+            "interpolate_pos": False,
+            "latent_patch_size": 2,
+            "max_latent_size_update": 64,
+            "vae_config": {"downsample": 8, "z_channels": 16},
+            "infer_steps": 4,
+            "inference_hyper": {
+                "cfg_text_scale": 4.0,
+                "cfg_img_scale": 1.0,
+                "cfg_interval": [0.4, 1.0],
+                "timestep_shift": 3.0,
+                "cfg_renorm_min": 0.0,
+                "cfg_renorm_type": "global",
+            },
+            "llm_config": {
+                "num_hidden_layers": 1,
+                "layer_module": "Qwen2MoTDecoderLayer",
+                "hidden_size": 16,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 2048,
+                "rope_scaling": None,
+            },
+            "llm_config_update": {},
+            "visual_gen": True,
+        }
+    )
+
+
+class BagelT2ISupportTest(unittest.TestCase):
+    def test_default_aspect_ratio(self):
+        self.assertEqual(resolve_bagel_t2i_image_shape(T2IInputInfo(), make_bagel_config()), (1024, 1024))
+
+    def test_official_aspect_ratios(self):
+        for aspect_ratio, expected_shape in BAGEL_T2I_ASPECT_RATIOS.items():
+            with self.subTest(aspect_ratio=aspect_ratio):
+                input_info = T2IInputInfo(aspect_ratio=aspect_ratio)
+                self.assertEqual(resolve_bagel_t2i_image_shape(input_info, make_bagel_config()), expected_shape)
+
+    def test_target_shape_overrides_aspect_ratio(self):
+        input_info = T2IInputInfo(aspect_ratio="16:9", target_shape=[1024, 1024])
+        self.assertEqual(resolve_bagel_t2i_image_shape(input_info, make_bagel_config()), (1024, 1024))
+
+    def test_invalid_target_shape_raises(self):
+        with self.assertRaisesRegex(ValueError, "divisible by latent downsample"):
+            resolve_bagel_t2i_image_shape(T2IInputInfo(target_shape=[577, 1024]), make_bagel_config())
+
+        with self.assertRaisesRegex(ValueError, "must be \\[H W\\]"):
+            resolve_bagel_t2i_image_shape(T2IInputInfo(target_shape=[1024]), make_bagel_config())
+
+    def test_invalid_aspect_ratio_raises(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported BAGEL aspect_ratio"):
+            resolve_bagel_t2i_image_shape(T2IInputInfo(aspect_ratio="2:1"), make_bagel_config())
+
+    def test_seed_controls_initial_noise(self):
+        scheduler = BagelScheduler(make_bagel_config())
+        kwargs = {
+            "curr_kvlens": [0],
+            "curr_rope": [0],
+            "image_sizes": [(16, 16)],
+            "new_token_ids": {"start_of_image": 1, "end_of_image": 2},
+        }
+        noise_a = scheduler.prepare_vae_latent(**kwargs, seed=123)["packed_init_noises"]
+        noise_b = scheduler.prepare_vae_latent(**kwargs, seed=123)["packed_init_noises"]
+        noise_c = scheduler.prepare_vae_latent(**kwargs, seed=124)["packed_init_noises"]
+
+        self.assertTrue(torch.equal(noise_a, noise_b))
+        self.assertFalse(torch.equal(noise_a, noise_c))
+
+    def test_missing_flash_attn_error_is_clear(self):
+        original_flash_attn_varlen_func = transformer_infer.flash_attn_varlen_func
+        transformer_infer.flash_attn_varlen_func = None
+        try:
+            with self.assertRaisesRegex(ImportError, "flash-attn"):
+                transformer_infer.BagelTransformerInfer({}, {})
+        finally:
+            transformer_infer.flash_attn_varlen_func = original_flash_attn_varlen_func
+
+    def test_missing_model_weights_error_is_clear(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(FileNotFoundError) as ctx:
+                validate_bagel_model_assets(make_bagel_config(model_path=tmpdir), tmpdir)
+        message = str(ctx.exception)
+        self.assertIn("ema.safetensors", message)
+        self.assertIn("ae.safetensors", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_cases/test_bagel_t2i_support.py
+++ b/test_cases/test_bagel_t2i_support.py
@@ -24,7 +24,7 @@ if global_var.AI_DEVICE is None:
 from lightx2v.models.networks.bagel.infer import transformer_infer
 from lightx2v.models.networks.bagel.model import BagelModel
 from lightx2v.models.networks.bagel.vision import build_bagel_vit_config, extract_bagel_vit_state_dict
-from lightx2v.models.runners.bagel.i2i_utils import resolve_bagel_i2i_image_shape
+from lightx2v.models.runners.bagel.i2i_utils import resolve_bagel_i2i_image_shape, resize_pil_for_vit
 from lightx2v.models.runners.bagel.t2i_utils import BAGEL_T2I_ASPECT_RATIOS, resolve_bagel_t2i_image_shape, validate_bagel_model_assets
 from lightx2v.models.schedulers.bagel.scheduler import BagelScheduler
 from lightx2v.utils.input_info import I2IInputInfo, T2IInputInfo
@@ -231,6 +231,17 @@ class BagelT2ISupportTest(unittest.TestCase):
         self.assertEqual(bagel_inputs.cfg_img_precontext["images"], [])
         self.assertEqual(bagel_inputs.cfg_img_precontext["texts"], ["make it blue"])
         self.assertEqual(scheduler.latents.shape, torch.Size([1]))
+
+    def test_resize_pil_for_vit_respects_stride_and_max_pixels(self):
+        image = Image.new("RGB", (1920, 1080), "white")
+        resized = resize_pil_for_vit(image)
+        width, height = resized.size
+
+        self.assertEqual(width % 14, 0)
+        self.assertEqual(height % 14, 0)
+        self.assertLessEqual(width, 980)
+        self.assertLessEqual(height, 980)
+        self.assertLessEqual(width * height, 14 * 14 * 9 * 1024)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stabilize BAGEL text-to-image inference so `--model_cls bagel --task t2i` supports dynamic output shapes, request-scoped seed control, PNG saving, and in-memory image return for service usage
- add BAGEL single-image editing MVP so `--model_cls bagel --task i2i --image_path ... --prompt ...` works with VAE + ViT image context, dynamic shape handling, PNG saving, and `return_result_tensor=True`
- tighten follow-up review fixes around unsupported-path errors, seed handling, TaylorSeer cache plumbing, and I2I context semantics tests

## What changed
- add BAGEL output-shape helpers for T2I/I2I, including official T2I aspect ratios and I2I target-shape/input-ratio handling
- remove hard-coded BAGEL decode/generation image shapes and pass request-resolved shapes through runner, scheduler, and VAE decode
- add BAGEL I2I image preprocessing and context updates: single-image load/resize, VAE encode path, SigLIP vision encoder loading from `ema.safetensors`, connector projection, and image KV-context updates
- keep BAGEL service behavior aligned with LightX2V by returning `{"images": images}` when `return_result_tensor=True` and warning when `negative_prompt`/I2I `aspect_ratio` are ignored
- add `configs/bagel/bagel_i2i.json`, `scripts/bagel/run_bagel_i2i.sh`, and expand `examples/bagel/README.md` with model setup, supported params, and current scope
- improve validation and diagnostics for missing `flash_attn`, missing BAGEL weights/config fields, unsupported text/understanding paths, and TaylorSeer cache routing
- extend tests to cover T2I/I2I shape parsing, seed-controlled initial noise, ViT config/weight validation, and I2I context role semantics

## Validation
- `conda run -n exp_env python -m py_compile lightx2v/models/runners/bagel/bagel_runner.py lightx2v/models/runners/bagel/t2i_utils.py lightx2v/models/runners/bagel/i2i_utils.py lightx2v/models/networks/bagel/model.py lightx2v/models/networks/bagel/vision.py lightx2v/models/networks/bagel/infer/pre_infer.py lightx2v/models/networks/bagel/infer/transformer_infer.py lightx2v/models/video_encoders/hf/bagel/vae.py lightx2v/models/schedulers/bagel/scheduler.py`
- `conda run -n exp_env python test_cases/test_bagel_t2i_support.py`
- `conda run -n exp_env pre-commit run --all-files`
- `git diff --check`
- real BAGEL T2I smoke test with `/data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT`: `--target_shape 256 256`, output PNG `(256, 256)`
- real BAGEL I2I smoke tests with `/data1/lyxu18/models/ByteDance-Seed/BAGEL-7B-MoT`:
- `--target_shape 256 256`, output PNG `(256, 256)`
- `--target_shape 576 1024`, output PNG `(1024, 576)`
- no `target_shape` on a `640x418` input, output PNG `(640, 416)`
- `--return_result_tensor` I2I path verified in `exp_env` without save-to-disk dependency

## Scope
- supported in this PR: BAGEL T2I stabilization and single-image I2I/image-editing MVP
- intentionally not included: mask edit, multi-image input, visual understanding output, thinking text return, NF4/INT8 quantization, and multi-GPU dispatch
