### PR TITLE
add last_frame_path in server

### DIFF
--- a/lightx2v/server/api/tasks/video.py
+++ b/lightx2v/server/api/tasks/video.py
@@ -42,6 +42,7 @@ async def create_video_task(message: VideoTaskRequest):
 @router.post("/form", response_model=TaskResponse)
 async def create_video_task_form(
     image_file: UploadFile = File(...),
+    last_frame_file: UploadFile = File(...),
     prompt: str = Form(default=""),
     save_result_path: str = Form(default=""),
     use_prompt_enhancer: bool = Form(default=False),
@@ -74,6 +75,10 @@ async def create_video_task_form(
     if image_file and image_file.filename:
         image_path = await save_file_async(image_file, services.file_service.input_image_dir)
 
+    last_frame_path = ""
+    if last_frame_file and last_frame_file.filename:
+        last_frame_path = await save_file_async(last_frame_file, services.file_service.input_image_dir)
+
     audio_path = ""
     if audio_file and audio_file.filename:
         audio_path = await save_file_async(audio_file, services.file_service.input_audio_dir)
@@ -82,6 +87,7 @@ async def create_video_task_form(
         prompt=prompt,
         use_prompt_enhancer=use_prompt_enhancer,
         negative_prompt=negative_prompt,
+        last_frame_path=last_frame_path,
         image_path=image_path,
         num_fragments=num_fragments,
         save_result_path=save_result_path,

--- a/lightx2v/server/api/tasks/video.py
+++ b/lightx2v/server/api/tasks/video.py
@@ -42,7 +42,7 @@ async def create_video_task(message: VideoTaskRequest):
 @router.post("/form", response_model=TaskResponse)
 async def create_video_task_form(
     image_file: UploadFile = File(...),
-    last_frame_file: UploadFile = File(...),
+    last_frame_file: UploadFile = File(None),
     prompt: str = Form(default=""),
     save_result_path: str = Form(default=""),
     use_prompt_enhancer: bool = Form(default=False),

--- a/lightx2v/server/schema.py
+++ b/lightx2v/server/schema.py
@@ -33,6 +33,7 @@ class BaseTaskRequest(DisaggOverrideRequest):
     use_prompt_enhancer: bool = Field(False, description="Whether to use prompt enhancer")
     negative_prompt: str = Field("", description="Negative prompt")
     image_path: str = Field("", description="Base64 encoded image or URL")
+    last_frame_path: str = Field("", description="Last frame image path (base64, or local path)")
     image_mask_path: str = Field("", description="Mask image path (supports URL, base64, or local path)")
     save_result_path: str = Field("", description="Save result path (optional, defaults to task_id, suffix auto-detected)")
     presigned_url: str = Field("", description="Optional presigned URL for uploading final sync result")


### PR DESCRIPTION
## Summary

Add `last_frame_path` support to video generation API, enabling users to specify an end frame image for video generation tasks (e.g., image-to-video with both start and end frame conditioning).

## Changes

### `lightx2v/server/api.py`
- Added `last_frame_file: UploadFile` parameter to `/form` endpoint
- Handle upload and saving of `last_frame_file` to `input_image_dir`
- Pass resolved `last_frame_path` into task request construction

### `lightx2v/server/schema.py`
- Added `last_frame_path` field to `BaseTaskRequest` schema
  - Supports base64 encoded image or local file path
  - Defaults to empty string (optional field)

## Motivation

Some video generation models (e.g., Wan) support **first-frame + last-frame conditioning**, allowing users to control both the start and end of the generated video. This PR exposes that capability through the server API so clients can submit both `image_file` (start frame) and `last_frame_file` (end frame) in a single multipart form request.

## API Changes

### `/form` endpoint — new form field

| Field | Type | Required | Description |
|---|---|---|---|
| `last_frame_file` | `UploadFile` | No | End frame image file for video generation |

### `BaseTaskRequest` — new schema field

| Field | Type | Default | Description |
|---|---|---|---|
| `last_frame_path` | `str` | `""` | Last frame image path (base64 or local path) |