### PR TITLE
[codex] add ERNIE image diffusers runner

### DIFF
--- a/configs/ernie_image/ernie_image_t2i.json
+++ b/configs/ernie_image/ernie_image_t2i.json
@@ -1,0 +1,10 @@
+{
+    "infer_steps": 50,
+    "aspect_ratio": "1:1",
+    "target_height": 1024,
+    "target_width": 1024,
+    "cpu_offload": true,
+    "enable_cfg": true,
+    "sample_guide_scale": 4.0,
+    "use_pe": true
+}

--- a/configs/ernie_image/ernie_image_turbo_t2i.json
+++ b/configs/ernie_image/ernie_image_turbo_t2i.json
@@ -1,0 +1,10 @@
+{
+    "infer_steps": 8,
+    "aspect_ratio": "1:1",
+    "target_height": 1024,
+    "target_width": 1024,
+    "cpu_offload": true,
+    "enable_cfg": false,
+    "sample_guide_scale": 1.0,
+    "use_pe": true
+}

--- a/configs/model_pipeline.json
+++ b/configs/model_pipeline.json
@@ -119,6 +119,14 @@
                         "outputs": ["output_image"]
                     }
                 }
+            },
+            "ernie-image": {
+                "single_stage": {
+                    "pipeline": {
+                        "inputs": [],
+                        "outputs": ["output_image"]
+                    }
+                }
             }
         },
         "s2v": {
@@ -212,6 +220,7 @@
                 "flf2v-wan2.2-14B-480P-single_stage-pipeline": 3600,
                 "flf2v-wan2.2-14B-480P-multi_stage-segment_dit": 3600,
                 "i2i-qwen-image-single_stage-pipeline": 3600,
+                "t2i-ernie-image-single_stage-pipeline": 3600,
                 "animate-wan2.2_animate-single_stage-pipeline": 3600
             },
             "worker_avg_window": 20,

--- a/lightx2v/infer.py
+++ b/lightx2v/infer.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from lightx2v.common.ops import *
 from lightx2v.models.runners.bagel.bagel_runner import BagelRunner  # noqa: F401
+from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner  # noqa: F401
 from lightx2v.models.runners.hunyuan3d.hunyuan3d_shape_runner import Hunyuan3DShapeRunner  # noqa: F401
 
 # from lightx2v.models.runners.flux2.flux2_runner import Flux2DevRunner, Flux2KleinRunner  # noqa: F401
@@ -72,6 +73,7 @@ def main():
             "wan2.2_moe_distill",
             "wan2.2_moe_vace",
             "qwen_image",
+            "ernie_image",
             "longcat_image",
             "wan2.2_animate",
             "hunyuan_video_1.5",

--- a/lightx2v/models/input_encoders/hf/ernie_image/__init__.py
+++ b/lightx2v/models/input_encoders/hf/ernie_image/__init__.py
@@ -1,0 +1,3 @@
+from .text_encoder import ErnieImageTextEncoder
+
+__all__ = ["ErnieImageTextEncoder"]

--- a/lightx2v/models/input_encoders/hf/ernie_image/text_encoder.py
+++ b/lightx2v/models/input_encoders/hf/ernie_image/text_encoder.py
@@ -1,0 +1,71 @@
+class ErnieImageTextEncoder:
+    def __init__(self, config, components, diffusers_cpu_offload=False):
+        self.config = config
+        self.components = components
+        self.pipe = getattr(components, "pipeline", components)
+        self.diffusers_cpu_offload = diffusers_cpu_offload
+        self.revised_prompts = None
+
+    def _normalize_prompt(self, prompt):
+        if prompt is None:
+            raise ValueError("ERNIE-Image requires input_info.prompt.")
+        if isinstance(prompt, str):
+            return [prompt]
+        return list(prompt)
+
+    @staticmethod
+    def _normalize_negative_prompt(negative_prompt, batch_size):
+        if negative_prompt is None:
+            negative_prompt = ""
+        if isinstance(negative_prompt, str):
+            return [negative_prompt] * batch_size
+        negative_prompt = list(negative_prompt)
+        if len(negative_prompt) != batch_size:
+            raise ValueError(f"negative_prompt must have same length as prompt ({batch_size})")
+        return negative_prompt
+
+    def _enhance_prompts(self, prompt, device, width, height, use_pe):
+        self.revised_prompts = None
+        if not use_pe:
+            return prompt
+        has_prompt_enhancer = getattr(
+            self.components,
+            "has_prompt_enhancer",
+            getattr(self.pipe, "pe", None) is not None and getattr(self.pipe, "pe_tokenizer", None) is not None,
+        )
+        if not has_prompt_enhancer:
+            return prompt
+
+        if hasattr(self.components, "enhance_prompt_with_pe"):
+            revised = [self.components.enhance_prompt_with_pe(p, device, width=width, height=height) for p in prompt]
+        else:
+            revised = [self.pipe._enhance_prompt_with_pe(p, device, width=width, height=height) for p in prompt]
+        self.revised_prompts = list(revised)
+        return revised
+
+    def encode(self, generation_kwargs, device, dtype, do_classifier_free_guidance):
+        prompt = self._normalize_prompt(generation_kwargs["prompt"])
+        width = generation_kwargs["width"]
+        height = generation_kwargs["height"]
+        use_pe = generation_kwargs["use_pe"]
+        num_images_per_prompt = int(generation_kwargs.get("num_images_per_prompt", 1))
+
+        prompt = self._enhance_prompts(prompt, device, width, height, use_pe)
+        batch_size = len(prompt)
+        negative_prompt = self._normalize_negative_prompt(generation_kwargs["negative_prompt"], batch_size)
+
+        text_hiddens = self.components.encode_prompt(prompt, device, num_images_per_prompt)
+        if do_classifier_free_guidance:
+            uncond_text_hiddens = self.components.encode_prompt(negative_prompt, device, num_images_per_prompt)
+            text_hiddens = list(uncond_text_hiddens) + list(text_hiddens)
+
+        if hasattr(self.components, "pad_text"):
+            text_bth, text_lens = self.components.pad_text(text_hiddens, device, dtype)
+        else:
+            text_bth, text_lens = self.pipe._pad_text(
+                text_hiddens=text_hiddens,
+                device=device,
+                dtype=dtype,
+                text_in_dim=self.pipe.transformer.config.text_in_dim,
+            )
+        return batch_size, text_bth, text_lens

--- a/lightx2v/models/networks/ernie_image/__init__.py
+++ b/lightx2v/models/networks/ernie_image/__init__.py
@@ -1,0 +1,3 @@
+from .model import ErnieImageTransformerModel
+
+__all__ = ["ErnieImageTransformerModel"]

--- a/lightx2v/models/networks/ernie_image/model.py
+++ b/lightx2v/models/networks/ernie_image/model.py
@@ -1,0 +1,59 @@
+import torch
+
+
+class ErnieImageTransformerModel:
+    def __init__(self, config, transformer, diffusers_cpu_offload=False):
+        self.config = config
+        self.transformer = transformer
+        self.diffusers_cpu_offload = diffusers_cpu_offload
+        self.scheduler = None
+
+    @property
+    def dtype(self):
+        return getattr(self.transformer, "dtype", None)
+
+    def set_scheduler(self, scheduler):
+        self.scheduler = scheduler
+
+    @staticmethod
+    def _timestep_batch(timestep, batch_size, device, dtype):
+        timestep_value = timestep.item() if hasattr(timestep, "item") else timestep
+        return torch.full((batch_size,), timestep_value, device=device, dtype=dtype)
+
+    def infer(self, inputs):
+        if self.scheduler is None:
+            raise ValueError("ERNIE-Image transformer requires a scheduler before inference.")
+        if self.scheduler.latents is None:
+            raise ValueError("ERNIE-Image scheduler latents are not prepared.")
+
+        latents = self.scheduler.latents
+        do_cfg = inputs["do_classifier_free_guidance"]
+        total_batch_size = int(inputs["total_batch_size"])
+
+        if do_cfg:
+            latent_model_input = torch.cat([latents, latents], dim=0)
+            timestep_batch_size = total_batch_size * 2
+        else:
+            latent_model_input = latents
+            timestep_batch_size = total_batch_size
+
+        timestep_batch = self._timestep_batch(
+            inputs["timestep"],
+            timestep_batch_size,
+            inputs["device"],
+            inputs["dtype"],
+        )
+        pred = self.transformer(
+            hidden_states=latent_model_input,
+            timestep=timestep_batch,
+            text_bth=inputs["text_bth"],
+            text_lens=inputs["text_lens"],
+            return_dict=False,
+        )[0]
+
+        if do_cfg:
+            pred_uncond, pred_cond = pred.chunk(2, dim=0)
+            pred = pred_uncond + float(inputs["guidance_scale"]) * (pred_cond - pred_uncond)
+
+        self.scheduler.noise_pred = pred
+        return pred

--- a/lightx2v/models/runners/ernie_image/__init__.py
+++ b/lightx2v/models/runners/ernie_image/__init__.py
@@ -1,0 +1,1 @@
+from .ernie_image_runner import ErnieImageRunner

--- a/lightx2v/models/runners/ernie_image/components.py
+++ b/lightx2v/models/runners/ernie_image/components.py
@@ -1,0 +1,70 @@
+class ErnieImagePipelineComponents:
+    def __init__(self, pipeline):
+        self.pipeline = pipeline
+
+    @classmethod
+    def from_pretrained(cls, model_path, pretrained_kwargs, target_device, cpu_offload=False):
+        try:
+            from diffusers import ErnieImagePipeline
+        except ImportError as exc:
+            raise ImportError("ERNIE-Image requires a Diffusers release with ErnieImagePipeline support.") from exc
+
+        pipeline = ErnieImagePipeline.from_pretrained(model_path, **pretrained_kwargs)
+        if cpu_offload:
+            pipeline.enable_model_cpu_offload()
+        else:
+            pipeline.to(target_device)
+        return cls(pipeline)
+
+    @property
+    def transformer(self):
+        return self.pipeline.transformer
+
+    @property
+    def scheduler(self):
+        return self.pipeline.scheduler
+
+    @property
+    def vae(self):
+        return self.pipeline.vae
+
+    @property
+    def vae_scale_factor(self):
+        return self.pipeline.vae_scale_factor
+
+    @property
+    def execution_device(self):
+        return getattr(self.pipeline, "_execution_device", None)
+
+    @property
+    def text_in_dim(self):
+        return self.transformer.config.text_in_dim
+
+    @property
+    def has_prompt_enhancer(self):
+        return getattr(self.pipeline, "pe", None) is not None and getattr(self.pipeline, "pe_tokenizer", None) is not None
+
+    def enhance_prompt_with_pe(self, prompt, device, width, height):
+        return self.pipeline._enhance_prompt_with_pe(prompt, device, width=width, height=height)
+
+    def encode_prompt(self, prompt, device, num_images_per_prompt):
+        return self.pipeline.encode_prompt(prompt, device, num_images_per_prompt)
+
+    def pad_text(self, text_hiddens, device, dtype):
+        return self.pipeline._pad_text(
+            text_hiddens=text_hiddens,
+            device=device,
+            dtype=dtype,
+            text_in_dim=self.text_in_dim,
+        )
+
+    @property
+    def unpatchify_latents(self):
+        return getattr(self.pipeline, "_unpatchify_latents", None)
+
+    def maybe_free_model_hooks(self):
+        if hasattr(self.pipeline, "maybe_free_model_hooks"):
+            self.pipeline.maybe_free_model_hooks()
+
+    def run_pipeline_call(self, kwargs):
+        return self.pipeline(**kwargs)

--- a/lightx2v/models/runners/ernie_image/ernie_image_runner.py
+++ b/lightx2v/models/runners/ernie_image/ernie_image_runner.py
@@ -1,0 +1,375 @@
+import gc
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from loguru import logger
+
+from lightx2v.models.input_encoders.hf.ernie_image.text_encoder import ErnieImageTextEncoder
+from lightx2v.models.networks.ernie_image.model import ErnieImageTransformerModel
+from lightx2v.models.runners.base_runner import BaseRunner
+from lightx2v.models.runners.ernie_image.components import ErnieImagePipelineComponents
+from lightx2v.models.schedulers.ernie_image.scheduler import ErnieImageScheduler
+from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
+from lightx2v.utils.envs import GET_DTYPE
+from lightx2v.utils.registry_factory import RUNNER_REGISTER
+from lightx2v_platform.base.global_var import AI_DEVICE
+
+ERNIE_IMAGE_ASPECT_RATIOS = {
+    "1:1": (1024, 1024),
+    "16:9": (720, 1280),
+    "9:16": (1280, 720),
+    "4:3": (896, 1152),
+    "3:4": (1152, 896),
+    "3:2": (832, 1248),
+    "2:3": (1248, 832),
+}
+
+
+def _truthy(value):
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _validate_image_shape(height, width):
+    if height <= 0 or width <= 0:
+        raise ValueError(f"ERNIE-Image height and width must be positive, got {height}x{width}.")
+    if height % 16 != 0 or width % 16 != 0:
+        raise ValueError(f"ERNIE-Image height and width must be divisible by 16, got {height}x{width}.")
+
+
+def resolve_ernie_image_shape(input_info, config):
+    target_shape = getattr(input_info, "target_shape", None)
+    if target_shape:
+        if len(target_shape) != 2:
+            raise ValueError(f"ERNIE-Image target_shape must be [height, width], got {target_shape}.")
+        height, width = int(target_shape[0]), int(target_shape[1])
+        _validate_image_shape(height, width)
+        return height, width
+
+    target_height = config.get("target_height")
+    target_width = config.get("target_width")
+    if target_height and target_width:
+        height, width = int(target_height), int(target_width)
+        _validate_image_shape(height, width)
+        return height, width
+
+    aspect_ratio = getattr(input_info, "aspect_ratio", None) or config.get("aspect_ratio", "1:1")
+    if not aspect_ratio:
+        aspect_ratio = "1:1"
+    if aspect_ratio not in ERNIE_IMAGE_ASPECT_RATIOS:
+        supported = ", ".join(sorted(ERNIE_IMAGE_ASPECT_RATIOS))
+        raise ValueError(f"Unsupported ERNIE-Image aspect_ratio '{aspect_ratio}'. Supported ratios: {supported}.")
+
+    height, width = ERNIE_IMAGE_ASPECT_RATIOS[aspect_ratio]
+    _validate_image_shape(height, width)
+    return height, width
+
+
+@RUNNER_REGISTER("ernie_image")
+class ErnieImageRunner(BaseRunner):
+    model_cpu_offload_seq = "pe->text_encoder->transformer->vae"
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.components = None
+        self.pipe = None
+        self.model = None
+        self.text_encoder = None
+        self.vae = None
+        self.scheduler = None
+        self.progress_callback = None
+
+    def set_config(self, config_modify):
+        logger.info(f"modify config: {config_modify}")
+        if hasattr(self.config, "temporarily_unlocked"):
+            with self.config.temporarily_unlocked():
+                self.config.update(config_modify)
+        else:
+            self.config.update(config_modify)
+
+    def set_progress_callback(self, callback):
+        self.progress_callback = callback
+
+    def init_modules(self):
+        logger.info("Initializing ERNIE-Image Diffusers runner modules...")
+        if not self.config.get("lazy_load", False) and not self.config.get("unload_modules", False):
+            self.load_model()
+        elif self.config.get("lazy_load", False):
+            assert self.config.get("cpu_offload", False), "ERNIE-Image lazy_load requires cpu_offload."
+
+        if hasattr(self.config, "lock"):
+            self.config.lock()
+
+    def _get_target_device(self):
+        if AI_DEVICE is not None:
+            return AI_DEVICE
+        if torch.cuda.is_available():
+            return "cuda"
+        return "cpu"
+
+    def _from_pretrained_kwargs(self):
+        kwargs = {"torch_dtype": GET_DTYPE()}
+        for key in ("revision", "variant", "cache_dir", "local_files_only"):
+            value = self.config.get(key)
+            if value is not None:
+                kwargs[key] = value
+        return kwargs
+
+    def load_model(self):
+        logger.info(f"Loading ERNIE-Image pipeline from {self.config['model_path']}")
+        self.components = ErnieImagePipelineComponents.from_pretrained(
+            self.config["model_path"],
+            self._from_pretrained_kwargs(),
+            target_device=self._get_target_device(),
+            cpu_offload=self.config.get("cpu_offload", False),
+        )
+        self.pipe = self.components.pipeline
+        self.text_encoder = self.load_text_encoder()
+        self.scheduler = self.load_scheduler()
+        self.model = self.load_transformer()
+        self.model.set_scheduler(self.scheduler)
+        self.vae = self.load_vae()
+        return self.pipe
+
+    def load_transformer(self):
+        model = ErnieImageTransformerModel(
+            self.config,
+            self.components.transformer,
+            diffusers_cpu_offload=self.config.get("cpu_offload", False),
+        )
+        if self.scheduler is not None:
+            model.set_scheduler(self.scheduler)
+        return model
+
+    def load_text_encoder(self):
+        return ErnieImageTextEncoder(
+            self.config,
+            self.components,
+            diffusers_cpu_offload=self.config.get("cpu_offload", False),
+        )
+
+    def load_scheduler(self):
+        return ErnieImageScheduler(self.config, self.components.scheduler)
+
+    def load_vae(self):
+        return AutoencoderKLErnieImageVAE(
+            self.config,
+            self.components.vae,
+            unpatchify_latents=self.components.unpatchify_latents,
+            diffusers_cpu_offload=self.config.get("cpu_offload", False),
+        )
+
+    def _ensure_pipe(self):
+        if self.pipe is None:
+            self.load_model()
+        else:
+            if self.text_encoder is None:
+                self.text_encoder = self.load_text_encoder()
+            if self.scheduler is None:
+                self.scheduler = self.load_scheduler()
+            if self.model is None:
+                self.model = self.load_transformer()
+            if self.model.scheduler is not self.scheduler:
+                self.model.set_scheduler(self.scheduler)
+            if self.vae is None:
+                self.vae = self.load_vae()
+
+    def _make_generator(self, seed):
+        if seed is None:
+            return None
+        return torch.Generator(device="cpu").manual_seed(int(seed))
+
+    def _wrap_progress_callback(self):
+        total_steps = max(int(self.config.get("infer_steps", self.config.get("num_inference_steps", 50))), 1)
+
+        def _callback_on_step_end(pipe, step, timestep, callback_kwargs):
+            del pipe, timestep
+            self.progress_callback(((step + 1) / total_steps) * 100, 100)
+            return callback_kwargs
+
+        return _callback_on_step_end
+
+    def _build_generation_kwargs(self, input_info):
+        height, width = resolve_ernie_image_shape(input_info, self.config)
+        kwargs = {
+            "prompt": input_info.prompt,
+            "negative_prompt": getattr(input_info, "negative_prompt", ""),
+            "height": height,
+            "width": width,
+            "num_inference_steps": int(self.config.get("infer_steps", self.config.get("num_inference_steps", 50))),
+            "guidance_scale": float(self.config.get("sample_guide_scale", self.config.get("guidance_scale", 4.0))),
+            "seed": getattr(input_info, "seed", None),
+            "use_pe": _truthy(self.config.get("use_pe", True)),
+            "output_type": self.config.get("output_type", "pil"),
+        }
+
+        for key in ("num_images_per_prompt", "callback_on_step_end_tensor_inputs"):
+            value = self.config.get(key)
+            if value is not None:
+                kwargs[key] = value
+
+        return kwargs
+
+    def _build_pipeline_kwargs(self, input_info):
+        kwargs = self._build_generation_kwargs(input_info)
+        seed = kwargs.pop("seed", None)
+        kwargs["generator"] = self._make_generator(seed)
+        if self.progress_callback is not None:
+            kwargs["callback_on_step_end"] = self._wrap_progress_callback()
+
+        return kwargs
+
+    def _execution_device(self):
+        device = self.components.execution_device
+        if device is not None:
+            return device
+        return torch.device(self._get_target_device())
+
+    def _encode_prompts(self, generation_kwargs, device, dtype):
+        if self.text_encoder is None:
+            self.text_encoder = self.load_text_encoder()
+        return self.text_encoder.encode(
+            generation_kwargs,
+            device,
+            dtype,
+            do_classifier_free_guidance=self._do_classifier_free_guidance(generation_kwargs),
+        )
+
+    def _do_classifier_free_guidance(self, generation_kwargs):
+        return float(generation_kwargs["guidance_scale"]) > 1.0
+
+    def run_vae_decoder(self, latents, output_type):
+        if self.vae is None:
+            self.vae = self.load_vae()
+        return self.vae.decode(latents, output_type=output_type)
+
+    def run_scheduler_step(self, pred, timestep, latents=None):
+        if self.scheduler is None:
+            self.scheduler = self.load_scheduler()
+        return self.scheduler.step(pred, timestep, latents)
+
+    def _run_decomposed_pipeline(self, input_info):
+        generation_kwargs = self._build_generation_kwargs(input_info)
+        device = self._execution_device()
+        if self.model is None:
+            self.model = self.load_transformer()
+        dtype = self.model.dtype or GET_DTYPE()
+        num_inference_steps = int(generation_kwargs["num_inference_steps"])
+        guidance_scale = float(generation_kwargs["guidance_scale"])
+        num_images_per_prompt = int(generation_kwargs.get("num_images_per_prompt", 1))
+
+        batch_size, text_bth, text_lens = self._encode_prompts(generation_kwargs, device, dtype)
+        total_batch_size = batch_size * num_images_per_prompt
+
+        latent_height = generation_kwargs["height"] // self.components.vae_scale_factor
+        latent_width = generation_kwargs["width"] // self.components.vae_scale_factor
+        latent_channels = self.components.transformer.config.in_channels
+        latent_shape = (total_batch_size, latent_channels, latent_height, latent_width)
+
+        if self.scheduler is None:
+            self.scheduler = self.load_scheduler()
+        if self.model.scheduler is not self.scheduler:
+            self.model.set_scheduler(self.scheduler)
+        timesteps = self.scheduler.prepare(
+            num_inference_steps,
+            device,
+            latent_shape=latent_shape,
+            dtype=dtype,
+            seed=generation_kwargs["seed"],
+        )
+        latents = self.scheduler.latents
+
+        do_cfg = self._do_classifier_free_guidance(generation_kwargs)
+        with torch.no_grad():
+            for step_index, timestep in enumerate(timesteps):
+                self.scheduler.step_pre(step_index)
+                self.model.infer(
+                    {
+                        "timestep": timestep,
+                        "text_bth": text_bth,
+                        "text_lens": text_lens,
+                        "device": device,
+                        "dtype": dtype,
+                        "total_batch_size": total_batch_size,
+                        "guidance_scale": guidance_scale,
+                        "do_classifier_free_guidance": do_cfg,
+                    }
+                )
+
+                latents = self.run_scheduler_step(self.scheduler.noise_pred, timestep)
+
+                if self.progress_callback:
+                    self.progress_callback(((step_index + 1) / num_inference_steps) * 100, 100)
+
+        images = self.run_vae_decoder(latents, generation_kwargs["output_type"])
+        self.components.maybe_free_model_hooks()
+        return images
+
+    def _run_diffusers_pipeline(self, input_info):
+        output = self.components.run_pipeline_call(self._build_pipeline_kwargs(input_info))
+        if isinstance(output, torch.Tensor):
+            return output
+        return output.images
+
+    def _unload_pipe(self):
+        if self.components is None:
+            self.pipe = None
+            self.model = None
+            self.text_encoder = None
+            self.vae = None
+            self.scheduler = None
+            return
+        self.components = None
+        self.model = None
+        self.text_encoder = None
+        self.vae = None
+        self.scheduler = None
+        del self.pipe
+        self.pipe = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def _save_images(self, images, save_result_path):
+        if dist.is_initialized() and dist.get_rank() != 0:
+            return
+        if not save_result_path:
+            return
+
+        output_path = Path(save_result_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        image_prefix = str(output_path.with_suffix(""))
+        image_suffix = output_path.suffix[1:] if output_path.suffix else "png"
+
+        if len(images) == 1:
+            images[0].save(str(output_path))
+            logger.info(f"Image saved: {output_path}")
+            return
+
+        for idx, image in enumerate(images):
+            image_path = f"{image_prefix}_{idx:05d}.{image_suffix}"
+            image.save(image_path)
+            logger.info(f"Image saved: {image_path}")
+
+    @torch.no_grad()
+    def run_pipeline(self, input_info):
+        self.input_info = input_info
+        self._ensure_pipe()
+
+        logger.info(f"input_info: {self.input_info}")
+        try:
+            if self.config.get("use_diffusers_pipeline_call", False):
+                images = self._run_diffusers_pipeline(input_info)
+            else:
+                images = self._run_decomposed_pipeline(input_info)
+
+            if getattr(input_info, "return_result_tensor", False):
+                return {"images": images}
+
+            self._save_images(images, getattr(input_info, "save_result_path", None))
+            return {"images": None}
+        finally:
+            if self.config.get("unload_modules", False):
+                self._unload_pipe()

--- a/lightx2v/models/runners/ernie_image/ernie_image_runner.py
+++ b/lightx2v/models/runners/ernie_image/ernie_image_runner.py
@@ -97,7 +97,8 @@ class ErnieImageRunner(BaseRunner):
         if not self.config.get("lazy_load", False) and not self.config.get("unload_modules", False):
             self.load_model()
         elif self.config.get("lazy_load", False):
-            assert self.config.get("cpu_offload", False), "ERNIE-Image lazy_load requires cpu_offload."
+            if not self.config.get("cpu_offload", False):
+                raise ValueError("ERNIE-Image lazy_load requires cpu_offload.")
 
         if hasattr(self.config, "lock"):
             self.config.lock()

--- a/lightx2v/models/schedulers/ernie_image/__init__.py
+++ b/lightx2v/models/schedulers/ernie_image/__init__.py
@@ -1,0 +1,3 @@
+from .scheduler import ErnieImageScheduler
+
+__all__ = ["ErnieImageScheduler"]

--- a/lightx2v/models/schedulers/ernie_image/scheduler.py
+++ b/lightx2v/models/schedulers/ernie_image/scheduler.py
@@ -1,0 +1,57 @@
+import torch
+
+
+class ErnieImageScheduler:
+    def __init__(self, config, scheduler):
+        self.config = config
+        self.scheduler = scheduler
+        self.generator = None
+        self.latents = None
+        self.noise_pred = None
+        self.step_index = None
+        self.timesteps = None
+        self.infer_steps = None
+
+    @staticmethod
+    def make_generator(seed):
+        if seed is None:
+            return None
+        return torch.Generator(device="cpu").manual_seed(int(seed))
+
+    def prepare_latents(self, latent_shape, device, dtype, seed=None, generator=None):
+        try:
+            from diffusers.utils.torch_utils import randn_tensor
+        except ImportError as exc:
+            raise ImportError("ERNIE-Image scheduler requires diffusers.utils.torch_utils.randn_tensor.") from exc
+
+        self.generator = generator if generator is not None else self.make_generator(seed)
+        self.latents = randn_tensor(
+            latent_shape,
+            generator=self.generator,
+            device=device,
+            dtype=dtype,
+        )
+        return self.latents
+
+    def prepare(self, num_inference_steps, device, latent_shape=None, dtype=None, seed=None, generator=None):
+        self.infer_steps = int(num_inference_steps)
+        sigmas = torch.linspace(1.0, 0.0, self.infer_steps + 1)
+        self.scheduler.set_timesteps(sigmas=sigmas[:-1], device=device)
+        self.timesteps = self.scheduler.timesteps
+        if latent_shape is not None:
+            if dtype is None:
+                raise ValueError("ERNIE-Image scheduler requires dtype when preparing latents.")
+            self.prepare_latents(latent_shape, device, dtype, seed=seed, generator=generator)
+        return self.timesteps
+
+    def step_pre(self, step_index):
+        self.step_index = int(step_index)
+
+    def step(self, pred, timestep, latents=None):
+        if latents is None:
+            if self.latents is None:
+                raise ValueError("ERNIE-Image scheduler latents are not prepared.")
+            latents = self.latents
+        self.noise_pred = pred
+        self.latents = self.scheduler.step(pred, timestep, latents).prev_sample
+        return self.latents

--- a/lightx2v/models/video_encoders/hf/ernie_image/__init__.py
+++ b/lightx2v/models/video_encoders/hf/ernie_image/__init__.py
@@ -1,0 +1,3 @@
+from .vae import AutoencoderKLErnieImageVAE
+
+__all__ = ["AutoencoderKLErnieImageVAE"]

--- a/lightx2v/models/video_encoders/hf/ernie_image/vae.py
+++ b/lightx2v/models/video_encoders/hf/ernie_image/vae.py
@@ -47,8 +47,8 @@ class AutoencoderKLErnieImageVAE:
                 self._move_model_to(latents.device)
 
             device = latents.device
-            bn_mean = self.model.bn.running_mean.view(1, -1, 1, 1).to(device)
-            bn_std = torch.sqrt(self.model.bn.running_var.view(1, -1, 1, 1).to(device) + 1e-5)
+            bn_mean = self.model.bn.running_mean.view(1, -1, 1, 1).to(device=device, dtype=latents.dtype)
+            bn_std = torch.sqrt(self.model.bn.running_var.view(1, -1, 1, 1).to(device=device, dtype=latents.dtype) + 1e-5)
             latents = latents * bn_std + bn_mean
             latents = self.unpatchify_latents(latents)
 

--- a/lightx2v/models/video_encoders/hf/ernie_image/vae.py
+++ b/lightx2v/models/video_encoders/hf/ernie_image/vae.py
@@ -1,0 +1,67 @@
+import gc
+
+import torch
+from PIL import Image
+
+
+def _truthy(value):
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+class AutoencoderKLErnieImageVAE:
+    def __init__(self, config, model, unpatchify_latents=None, diffusers_cpu_offload=False):
+        self.config = config
+        self.model = model
+        self.unpatchify_latents = unpatchify_latents or self._unpatchify_latents
+        self.cpu_offload = _truthy(config.get("vae_cpu_offload", config.get("cpu_offload", False)))
+        self.diffusers_cpu_offload = _truthy(diffusers_cpu_offload)
+        self.manage_cpu_offload = self.cpu_offload and not self.diffusers_cpu_offload
+        if self.manage_cpu_offload:
+            self._move_model_to(torch.device("cpu"))
+
+    def _move_model_to(self, device):
+        if hasattr(self.model, "to"):
+            self.model.to(device)
+
+    def _empty_cache(self):
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    @staticmethod
+    def _unpatchify_latents(latents):
+        batch_size, channels, height, width = latents.shape
+        latents = latents.reshape(batch_size, channels // 4, 2, 2, height, width)
+        latents = latents.permute(0, 1, 4, 2, 5, 3)
+        return latents.reshape(batch_size, channels // 4, height * 2,  width * 2)
+
+    @torch.no_grad()
+    def decode(self, latents, output_type="pil"):
+        if output_type == "latent":
+            return latents
+
+        try:
+            if self.manage_cpu_offload:
+                self._move_model_to(latents.device)
+
+            device = latents.device
+            bn_mean = self.model.bn.running_mean.view(1, -1, 1, 1).to(device)
+            bn_std = torch.sqrt(self.model.bn.running_var.view(1, -1, 1, 1).to(device) + 1e-5)
+            latents = latents * bn_std + bn_mean
+            latents = self.unpatchify_latents(latents)
+
+            images = self.model.decode(latents, return_dict=False)[0]
+            images = (images.clamp(-1, 1) + 1) / 2
+
+            if output_type == "pt":
+                return images
+            if output_type == "pil":
+                images = images.cpu().permute(0, 2, 3, 1).float().numpy()
+                return [Image.fromarray((image * 255).astype("uint8")) for image in images]
+            raise ValueError(f"Unsupported ERNIE-Image output_type '{output_type}'. Supported values: pil, pt, latent.")
+        finally:
+            if self.manage_cpu_offload:
+                self._move_model_to(torch.device("cpu"))
+                self._empty_cache()

--- a/lightx2v/pipeline.py
+++ b/lightx2v/pipeline.py
@@ -14,6 +14,7 @@ try:
     from lightx2v.models.runners.flux2.flux2_runner import Flux2DevRunner, Flux2KleinRunner  # noqa: F401
 except (ImportError, ModuleNotFoundError) as e:
     logger.warning(f"Flux2 runners not available: {e}")
+from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner  # noqa: F401
 from lightx2v.models.runners.hunyuan_video.hunyuan_video_15_runner import HunyuanVideo15Runner  # noqa: F401
 from lightx2v.models.runners.longcat_image.longcat_image_runner import LongCatImageRunner  # noqa: F401
 from lightx2v.models.runners.ltx2.ltx2_runner import LTX2Runner  # noqa: F401
@@ -135,6 +136,8 @@ class LightX2VPipeline:
                 self.prompt_template_encode_start_idx = 34
         elif self.model_cls in ["z_image"]:
             self.model_cls = "z_image"
+        elif model_cls in ["ernie_image", "ernie-image", "ernie-image-turbo", "ERNIE-Image"]:
+            self.model_cls = "ernie_image"
         elif self.model_cls in ["flux2_klein"]:
             self.model_cls = "flux2_klein"
         elif self.model_cls in ["flux2_dev"]:

--- a/lightx2v/pipeline.py
+++ b/lightx2v/pipeline.py
@@ -136,7 +136,7 @@ class LightX2VPipeline:
                 self.prompt_template_encode_start_idx = 34
         elif self.model_cls in ["z_image"]:
             self.model_cls = "z_image"
-        elif model_cls in ["ernie_image", "ernie-image", "ernie-image-turbo", "ERNIE-Image"]:
+        elif self.model_cls in ["ernie_image", "ernie-image", "ernie-image-turbo", "ERNIE-Image"]:
             self.model_cls = "ernie_image"
         elif self.model_cls in ["flux2_klein"]:
             self.model_cls = "flux2_klein"

--- a/lightx2v/utils/set_config.py
+++ b/lightx2v/utils/set_config.py
@@ -66,7 +66,11 @@ def auto_calc_config(config):
         if cli_num_iterations is not None:
             config["num_iterations"] = cli_num_iterations
 
-    assert os.path.exists(config["model_path"]), f"Model path not found: {config['model_path']}"
+    if not os.path.exists(config["model_path"]):
+        if config["model_cls"] == "ernie_image":
+            logger.info(f"Model path {config['model_path']} does not exist locally; Diffusers will resolve it as a Hugging Face repo ID or cached path.")
+        else:
+            raise AssertionError(f"Model path not found: {config['model_path']}")
 
     if config["model_cls"] in ["hunyuan_video_1.5", "hunyuan_video_1.5_distill"]:  # Special config for hunyuan video 1.5 model folder structure
         config["transformer_model_path"] = os.path.join(config["model_path"], "transformer", config["transformer_model_name"])  # transformer_model_name: [480p_t2v, 480p_i2v, 720p_t2v, 720p_i2v]

--- a/test_cases/test_ernie_image_runner.py
+++ b/test_cases/test_ernie_image_runner.py
@@ -196,6 +196,17 @@ class ErnieImageRunnerTest(unittest.TestCase):
         self.assertIs(latent_result, latents)
         self.assertEqual(len(fake_vae.decode_calls), 1)
 
+    def test_vae_wrapper_preserves_latent_dtype_after_bn_restore(self):
+        from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
+
+        fake_vae = FakeVAE()
+        wrapper = AutoencoderKLErnieImageVAE({}, fake_vae)
+        latents = torch.zeros(1, 128, 4, 4, dtype=torch.bfloat16)
+
+        wrapper.decode(latents, output_type="pt")
+
+        self.assertEqual(fake_vae.decode_calls[0][0].dtype, torch.bfloat16)
+
     def test_vae_wrapper_delegates_diffusers_cpu_offload_to_pipeline_hooks(self):
         from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
 
@@ -396,6 +407,14 @@ class ErnieImageRunnerTest(unittest.TestCase):
         self.assertFalse(runner.vae.manage_cpu_offload)
         self.assertIsInstance(runner.scheduler, ErnieImageScheduler)
         self.assertIs(runner.scheduler.scheduler, runner.components.scheduler)
+
+    def test_lazy_load_without_cpu_offload_raises_value_error(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        runner = ErnieImageRunner(make_config(lazy_load=True, cpu_offload=False))
+
+        with self.assertRaisesRegex(ValueError, "lazy_load requires cpu_offload"):
+            runner.init_modules()
 
     def test_builtin_16_by_9_shape_is_allowed(self):
         from lightx2v.models.runners.ernie_image.ernie_image_runner import resolve_ernie_image_shape

--- a/test_cases/test_ernie_image_runner.py
+++ b/test_cases/test_ernie_image_runner.py
@@ -1,0 +1,574 @@
+# ruff: noqa: E402
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+import torch
+from PIL import Image
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+loguru_stub = ModuleType("loguru")
+loguru_stub.logger = SimpleNamespace(
+    debug=lambda *args, **kwargs: None,
+    error=lambda *args, **kwargs: None,
+    info=lambda *args, **kwargs: None,
+    warning=lambda *args, **kwargs: None,
+)
+sys.modules.setdefault("loguru", loguru_stub)
+
+imageio_ffmpeg_stub = ModuleType("imageio_ffmpeg")
+imageio_ffmpeg_stub.get_ffmpeg_exe = lambda: "ffmpeg"
+sys.modules.setdefault("imageio_ffmpeg", imageio_ffmpeg_stub)
+
+lightx2v_pkg = ModuleType("lightx2v")
+lightx2v_pkg.__path__ = [os.path.join(REPO_ROOT, "lightx2v")]
+sys.modules.setdefault("lightx2v", lightx2v_pkg)
+
+import lightx2v_platform.base.global_var as global_var
+
+global_var.AI_DEVICE = "cpu"
+
+from lightx2v.utils.registry_factory import RUNNER_REGISTER
+
+
+class FakeImage:
+    def __init__(self):
+        self.saved_path = None
+
+    def save(self, path):
+        self.saved_path = str(path)
+        Path(path).write_text("fake image")
+
+
+class FakeTransformer:
+    def __init__(self):
+        self.dtype = torch.float32
+        self.config = SimpleNamespace(in_channels=128, text_in_dim=4)
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return (torch.zeros_like(kwargs["hidden_states"]),)
+
+
+class FakeScheduler:
+    def __init__(self):
+        self.timesteps = []
+        self.set_timesteps_calls = []
+        self.step_calls = []
+
+    def set_timesteps(self, sigmas, device):
+        self.set_timesteps_calls.append((sigmas, device))
+        self.timesteps = sigmas
+
+    def step(self, pred, timestep, latents):
+        self.step_calls.append((pred, timestep, latents))
+        return SimpleNamespace(prev_sample=latents)
+
+
+class FakeVAE:
+    def __init__(self):
+        self.bn = SimpleNamespace(
+            running_mean=torch.zeros(128),
+            running_var=torch.ones(128),
+        )
+        self.decode_calls = []
+        self.to_calls = []
+
+    def to(self, device):
+        self.to_calls.append(torch.device(device))
+        return self
+
+    def decode(self, latents, return_dict=False):
+        self.decode_calls.append((latents, return_dict))
+        batch_size = latents.shape[0]
+        return (torch.zeros(batch_size, 3, 16, 16),)
+
+
+class FakeErnieImagePipeline:
+    from_pretrained_calls = []
+
+    def __init__(self):
+        self.cpu_offload_enabled = False
+        self.device = None
+        self.calls = []
+        self.image = FakeImage()
+        self.transformer = FakeTransformer()
+        self.scheduler = FakeScheduler()
+        self.vae = FakeVAE()
+        self.vae_scale_factor = 16
+        self.pe = object()
+        self.pe_tokenizer = object()
+        self.encoded_prompts = []
+        self.enhanced_prompts = []
+        self.freed_hooks = False
+        self._execution_device = torch.device("cpu")
+
+    @classmethod
+    def from_pretrained(cls, model_path, **kwargs):
+        cls.from_pretrained_calls.append((model_path, kwargs))
+        return cls()
+
+    def enable_model_cpu_offload(self):
+        self.cpu_offload_enabled = True
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(images=[self.image])
+
+    def _enhance_prompt_with_pe(self, prompt, device, width=1024, height=1024):
+        self.enhanced_prompts.append((prompt, device, width, height))
+        return f"enhanced {prompt}"
+
+    def encode_prompt(self, prompt, device, num_images_per_prompt=1):
+        self.encoded_prompts.append((list(prompt), device, num_images_per_prompt))
+        hiddens = []
+        for _ in prompt:
+            for _ in range(num_images_per_prompt):
+                hiddens.append(torch.ones(2, self.transformer.config.text_in_dim, device=device))
+        return hiddens
+
+    @staticmethod
+    def _pad_text(text_hiddens, device, dtype, text_in_dim):
+        lens = torch.tensor([hidden.shape[0] for hidden in text_hiddens], device=device, dtype=torch.long)
+        text_bth = torch.zeros(len(text_hiddens), int(lens.max().item()), text_in_dim, device=device, dtype=dtype)
+        for index, hidden in enumerate(text_hiddens):
+            text_bth[index, : hidden.shape[0]] = hidden.to(device=device, dtype=dtype)
+        return text_bth, lens
+
+    @staticmethod
+    def _unpatchify_latents(latents):
+        batch_size, channels, height, width = latents.shape
+        latents = latents.reshape(batch_size, channels // 4, 2, 2, height, width)
+        latents = latents.permute(0, 1, 4, 2, 5, 3)
+        return latents.reshape(batch_size, channels // 4, height * 2, width * 2)
+
+    def maybe_free_model_hooks(self):
+        self.freed_hooks = True
+
+
+def make_config(**overrides):
+    config = {
+        "model_cls": "ernie_image",
+        "model_path": "baidu/ERNIE-Image",
+        "task": "t2i",
+        "cpu_offload": True,
+        "infer_steps": 8,
+        "sample_guide_scale": 1.0,
+        "target_height": 512,
+        "target_width": 768,
+        "use_pe": False,
+    }
+    config.update(overrides)
+    return config
+
+
+class ErnieImageRunnerTest(unittest.TestCase):
+    def setUp(self):
+        FakeErnieImagePipeline.from_pretrained_calls.clear()
+
+    def test_vae_wrapper_decodes_pil_and_preserves_latent_output(self):
+        from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
+
+        fake_vae = FakeVAE()
+        wrapper = AutoencoderKLErnieImageVAE({}, fake_vae)
+        latents = torch.zeros(1, 128, 4, 4)
+
+        images = wrapper.decode(latents, output_type="pil")
+
+        self.assertEqual(fake_vae.decode_calls[0][0].shape, torch.Size([1, 32, 8, 8]))
+        self.assertEqual(len(images), 1)
+        self.assertIsInstance(images[0], Image.Image)
+
+        latent_result = wrapper.decode(latents, output_type="latent")
+
+        self.assertIs(latent_result, latents)
+        self.assertEqual(len(fake_vae.decode_calls), 1)
+
+    def test_vae_wrapper_delegates_diffusers_cpu_offload_to_pipeline_hooks(self):
+        from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
+
+        fake_vae = FakeVAE()
+        wrapper = AutoencoderKLErnieImageVAE({"cpu_offload": True}, fake_vae, diffusers_cpu_offload=True)
+
+        wrapper.decode(torch.zeros(1, 128, 4, 4), output_type="pil")
+
+        self.assertTrue(wrapper.cpu_offload)
+        self.assertTrue(wrapper.diffusers_cpu_offload)
+        self.assertFalse(wrapper.manage_cpu_offload)
+        self.assertEqual(fake_vae.to_calls, [])
+
+    def test_vae_wrapper_can_manage_standalone_cpu_offload(self):
+        from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
+
+        fake_vae = FakeVAE()
+        latents = torch.zeros(1, 128, 4, 4)
+        wrapper = AutoencoderKLErnieImageVAE({"vae_cpu_offload": True, "cpu_offload": False}, fake_vae)
+
+        wrapper.decode(latents, output_type="pil")
+
+        self.assertTrue(wrapper.cpu_offload)
+        self.assertFalse(wrapper.diffusers_cpu_offload)
+        self.assertTrue(wrapper.manage_cpu_offload)
+        self.assertEqual(fake_vae.to_calls[0], torch.device("cpu"))
+        self.assertEqual(fake_vae.to_calls[-2:], [latents.device, torch.device("cpu")])
+
+    def test_scheduler_wrapper_prepares_sigmas_and_returns_prev_sample(self):
+        from lightx2v.models.schedulers.ernie_image.scheduler import ErnieImageScheduler
+
+        fake_scheduler = FakeScheduler()
+        wrapper = ErnieImageScheduler({}, fake_scheduler)
+        device = torch.device("cpu")
+        latent_shape = (1, 128, 4, 4)
+
+        timesteps = wrapper.prepare(4, device, latent_shape=latent_shape, dtype=torch.float32, seed=123)
+        pred = torch.zeros_like(wrapper.latents)
+        wrapper.step_pre(0)
+        next_latents = wrapper.step(pred, timesteps[0])
+
+        sigmas, call_device = fake_scheduler.set_timesteps_calls[0]
+        self.assertEqual(call_device, device)
+        self.assertTrue(torch.equal(sigmas, torch.tensor([1.0, 0.75, 0.5, 0.25])))
+        self.assertIs(wrapper.timesteps, fake_scheduler.timesteps)
+        self.assertEqual(wrapper.infer_steps, 4)
+        self.assertEqual(wrapper.latents.shape, torch.Size(latent_shape))
+        self.assertIsInstance(wrapper.generator, torch.Generator)
+        self.assertEqual(wrapper.step_index, 0)
+        self.assertIs(wrapper.noise_pred, pred)
+        self.assertIs(next_latents, wrapper.latents)
+
+    def test_text_encoder_wrapper_handles_pe_cfg_and_padding(self):
+        from lightx2v.models.input_encoders.hf.ernie_image.text_encoder import ErnieImageTextEncoder
+
+        pipe = FakeErnieImagePipeline()
+        wrapper = ErnieImageTextEncoder({}, pipe, diffusers_cpu_offload=True)
+        generation_kwargs = {
+            "prompt": "a glass pavilion",
+            "negative_prompt": "low quality",
+            "width": 768,
+            "height": 512,
+            "use_pe": True,
+            "num_images_per_prompt": 1,
+        }
+
+        batch_size, text_bth, text_lens = wrapper.encode(
+            generation_kwargs,
+            torch.device("cpu"),
+            torch.float32,
+            do_classifier_free_guidance=True,
+        )
+
+        self.assertEqual(batch_size, 1)
+        self.assertEqual(pipe.enhanced_prompts[0], ("a glass pavilion", torch.device("cpu"), 768, 512))
+        self.assertEqual(wrapper.revised_prompts, ["enhanced a glass pavilion"])
+        self.assertEqual(pipe.encoded_prompts[0][0], ["enhanced a glass pavilion"])
+        self.assertEqual(pipe.encoded_prompts[1][0], ["low quality"])
+        self.assertEqual(text_bth.shape, torch.Size([2, 2, 4]))
+        self.assertTrue(torch.equal(text_lens, torch.tensor([2, 2])))
+
+    def test_transformer_model_wrapper_handles_cfg_and_sets_scheduler_noise_pred(self):
+        from lightx2v.models.networks.ernie_image.model import ErnieImageTransformerModel
+
+        class CfgTransformer(FakeTransformer):
+            def __call__(self, **kwargs):
+                self.calls.append(kwargs)
+                batch_size = kwargs["hidden_states"].shape[0]
+                values = torch.arange(batch_size, dtype=kwargs["hidden_states"].dtype).view(batch_size, 1, 1, 1)
+                return (values.expand_as(kwargs["hidden_states"]),)
+
+        scheduler = SimpleNamespace(latents=torch.zeros(1, 128, 4, 4), noise_pred=None)
+        transformer = CfgTransformer()
+        wrapper = ErnieImageTransformerModel({}, transformer)
+        wrapper.set_scheduler(scheduler)
+        text_bth = torch.zeros(2, 2, 4)
+        text_lens = torch.tensor([2, 2])
+
+        pred = wrapper.infer(
+            {
+                "timestep": torch.tensor(0.5),
+                "text_bth": text_bth,
+                "text_lens": text_lens,
+                "device": torch.device("cpu"),
+                "dtype": torch.float32,
+                "total_batch_size": 1,
+                "guidance_scale": 4.0,
+                "do_classifier_free_guidance": True,
+            }
+        )
+
+        self.assertTrue(torch.equal(pred, torch.full_like(scheduler.latents, 4.0)))
+        self.assertIs(scheduler.noise_pred, pred)
+        self.assertEqual(transformer.calls[0]["hidden_states"].shape[0], 2)
+        self.assertEqual(transformer.calls[0]["timestep"].shape, torch.Size([2]))
+        self.assertIs(transformer.calls[0]["text_bth"], text_bth)
+        self.assertIs(transformer.calls[0]["text_lens"], text_lens)
+
+    def test_pipeline_components_expose_diffusers_modules_and_hooks(self):
+        from lightx2v.models.runners.ernie_image.components import ErnieImagePipelineComponents
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            components = ErnieImagePipelineComponents.from_pretrained(
+                "baidu/ERNIE-Image",
+                {"torch_dtype": torch.bfloat16},
+                target_device="cpu",
+                cpu_offload=True,
+            )
+
+        self.assertEqual(FakeErnieImagePipeline.from_pretrained_calls[0][0], "baidu/ERNIE-Image")
+        self.assertEqual(FakeErnieImagePipeline.from_pretrained_calls[0][1]["torch_dtype"], torch.bfloat16)
+        self.assertTrue(components.pipeline.cpu_offload_enabled)
+        self.assertIs(components.transformer, components.pipeline.transformer)
+        self.assertIs(components.scheduler, components.pipeline.scheduler)
+        self.assertIs(components.vae, components.pipeline.vae)
+        self.assertEqual(components.vae_scale_factor, 16)
+        self.assertEqual(components.execution_device, torch.device("cpu"))
+
+        revised_prompt = components.enhance_prompt_with_pe("a glass pavilion", torch.device("cpu"), width=768, height=512)
+        text_hiddens = components.encode_prompt([revised_prompt], torch.device("cpu"), 1)
+        text_bth, text_lens = components.pad_text(text_hiddens, torch.device("cpu"), torch.float32)
+
+        self.assertEqual(revised_prompt, "enhanced a glass pavilion")
+        self.assertEqual(text_bth.shape, torch.Size([1, 2, 4]))
+        self.assertTrue(torch.equal(text_lens, torch.tensor([2])))
+
+    def test_runner_is_registered(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        self.assertIs(RUNNER_REGISTER["ernie_image"], ErnieImageRunner)
+
+    def test_auto_calc_config_allows_huggingface_repo_id(self):
+        from lightx2v.utils.set_config import auto_calc_config, get_default_config
+
+        config = get_default_config()
+        config.update(
+            {
+                "config_json": None,
+                "model_cls": "ernie_image",
+                "model_path": "baidu/ERNIE-Image",
+                "task": "t2i",
+            }
+        )
+
+        result = auto_calc_config(config)
+
+        self.assertEqual(result["model_path"], "baidu/ERNIE-Image")
+
+    def test_load_model_uses_diffusers_pipeline_and_cpu_offload(self):
+        from lightx2v.models.input_encoders.hf.ernie_image.text_encoder import ErnieImageTextEncoder
+        from lightx2v.models.networks.ernie_image.model import ErnieImageTransformerModel
+        from lightx2v.models.runners.ernie_image.components import ErnieImagePipelineComponents
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+        from lightx2v.models.schedulers.ernie_image.scheduler import ErnieImageScheduler
+        from lightx2v.models.video_encoders.hf.ernie_image.vae import AutoencoderKLErnieImageVAE
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            runner = ErnieImageRunner(make_config())
+            runner.init_modules()
+
+        self.assertEqual(FakeErnieImagePipeline.from_pretrained_calls[0][0], "baidu/ERNIE-Image")
+        self.assertEqual(FakeErnieImagePipeline.from_pretrained_calls[0][1]["torch_dtype"], torch.bfloat16)
+        self.assertTrue(runner.pipe.cpu_offload_enabled)
+        self.assertIsNone(runner.pipe.device)
+        self.assertIsInstance(runner.components, ErnieImagePipelineComponents)
+        self.assertIs(runner.components.pipeline, runner.pipe)
+        self.assertIsInstance(runner.text_encoder, ErnieImageTextEncoder)
+        self.assertIs(runner.text_encoder.components, runner.components)
+        self.assertTrue(runner.text_encoder.diffusers_cpu_offload)
+        self.assertIsInstance(runner.model, ErnieImageTransformerModel)
+        self.assertIs(runner.model.transformer, runner.components.transformer)
+        self.assertIs(runner.model.scheduler, runner.scheduler)
+        self.assertTrue(runner.model.diffusers_cpu_offload)
+        self.assertIsInstance(runner.vae, AutoencoderKLErnieImageVAE)
+        self.assertIs(runner.vae.model, runner.components.vae)
+        self.assertTrue(runner.vae.cpu_offload)
+        self.assertTrue(runner.vae.diffusers_cpu_offload)
+        self.assertFalse(runner.vae.manage_cpu_offload)
+        self.assertIsInstance(runner.scheduler, ErnieImageScheduler)
+        self.assertIs(runner.scheduler.scheduler, runner.components.scheduler)
+
+    def test_builtin_16_by_9_shape_is_allowed(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import resolve_ernie_image_shape
+
+        input_info = SimpleNamespace(target_shape=[], aspect_ratio="16:9")
+        height, width = resolve_ernie_image_shape(input_info, make_config(target_height=None, target_width=None))
+
+        self.assertEqual((height, width), (720, 1280))
+
+    def test_progress_callback_runs_from_decomposed_step_loop(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        progress_calls = []
+        input_info = SimpleNamespace(
+            seed=123,
+            prompt="a glass pavilion",
+            save_result_path="/tmp/unused.png",
+            return_result_tensor=True,
+            target_shape=[640, 640],
+            aspect_ratio="16:9",
+        )
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            runner = ErnieImageRunner(make_config())
+            runner.set_progress_callback(lambda percent, total: progress_calls.append((percent, total)))
+            runner.init_modules()
+            runner.run_pipeline(input_info)
+
+        self.assertEqual(runner.pipe.calls, [])
+        self.assertEqual(len(progress_calls), 8)
+        self.assertEqual(progress_calls[0], (12.5, 100))
+        self.assertEqual(progress_calls[-1], (100.0, 100))
+
+    def test_run_pipeline_passes_generation_parameters_and_saves_image(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "ernie.png"
+            input_info = SimpleNamespace(
+                seed=123,
+                prompt="a compact observatory on a snowy ridge",
+                negative_prompt="low quality",
+                save_result_path=str(output_path),
+                return_result_tensor=False,
+                target_shape=[],
+                aspect_ratio="1:1",
+            )
+
+            with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+                runner = ErnieImageRunner(make_config())
+                runner.init_modules()
+                result = runner.run_pipeline(input_info)
+
+            self.assertEqual(runner.pipe.calls, [])
+            self.assertEqual(runner.pipe.encoded_prompts[0][0], [input_info.prompt])
+            self.assertEqual(len(runner.pipe.transformer.calls), 8)
+            self.assertEqual(len(runner.pipe.scheduler.step_calls), 8)
+            self.assertEqual(len(runner.pipe.vae.decode_calls), 1)
+            self.assertEqual(runner.scheduler.latents.shape, torch.Size([1, 128, 32, 48]))
+            self.assertIsInstance(runner.scheduler.generator, torch.Generator)
+            self.assertEqual(runner.scheduler.step_index, 7)
+            self.assertTrue(runner.pipe.freed_hooks)
+            with Image.open(output_path) as image:
+                self.assertIsInstance(image, Image.Image)
+            self.assertTrue(output_path.exists())
+            self.assertEqual(result, {"images": None})
+
+    def test_decomposed_runner_handles_cfg_and_progress_without_calling_pipeline(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        progress_calls = []
+        input_info = SimpleNamespace(
+            seed=123,
+            prompt="a glass pavilion",
+            negative_prompt="low quality",
+            save_result_path="/tmp/unused.png",
+            return_result_tensor=True,
+            target_shape=[64, 64],
+            aspect_ratio="1:1",
+        )
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            runner = ErnieImageRunner(make_config(target_height=None, target_width=None, sample_guide_scale=4.0, use_pe=True))
+            runner.set_progress_callback(lambda percent, total: progress_calls.append((percent, total)))
+            runner.init_modules()
+            result = runner.run_pipeline(input_info)
+
+        self.assertEqual(runner.pipe.calls, [])
+        self.assertEqual(runner.pipe.enhanced_prompts[0][0], input_info.prompt)
+        self.assertEqual(runner.pipe.encoded_prompts[0][0], [f"enhanced {input_info.prompt}"])
+        self.assertEqual(runner.pipe.encoded_prompts[1][0], [input_info.negative_prompt])
+        self.assertEqual(len(runner.pipe.transformer.calls), 8)
+        self.assertEqual(runner.pipe.transformer.calls[0]["hidden_states"].shape[0], 2)
+        self.assertEqual(progress_calls[-1], (100.0, 100))
+        self.assertEqual(len(progress_calls), 8)
+        self.assertEqual(len(result["images"]), 1)
+
+    def test_decomposed_runner_delegates_transformer_inference_to_model_boundary(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        input_info = SimpleNamespace(
+            seed=123,
+            prompt="a glass pavilion",
+            negative_prompt="low quality",
+            save_result_path="/tmp/unused.png",
+            return_result_tensor=True,
+            target_shape=[64, 64],
+            aspect_ratio="1:1",
+        )
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            runner = ErnieImageRunner(make_config(target_height=None, target_width=None, sample_guide_scale=4.0, use_pe=True))
+            runner.init_modules()
+
+            def infer_through_boundary(inputs):
+                del inputs
+                runner.scheduler.noise_pred = torch.zeros_like(runner.scheduler.latents)
+                return runner.scheduler.noise_pred
+
+            runner.model.infer = mock.Mock(side_effect=infer_through_boundary)
+            runner.run_pipeline(input_info)
+
+        self.assertEqual(runner.pipe.transformer.calls, [])
+        self.assertEqual(runner.model.infer.call_count, 8)
+
+    def test_return_tensor_skips_save(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        input_info = SimpleNamespace(
+            seed=123,
+            prompt="a glass pavilion",
+            save_result_path="/tmp/unused.png",
+            return_result_tensor=True,
+            target_shape=[640, 640],
+            aspect_ratio="16:9",
+        )
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            runner = ErnieImageRunner(make_config())
+            runner.init_modules()
+            result = runner.run_pipeline(input_info)
+
+        self.assertEqual(runner.pipe.calls, [])
+        self.assertEqual(len(result["images"]), 1)
+        self.assertIsInstance(result["images"][0], Image.Image)
+        self.assertIsNone(runner.pipe.image.saved_path)
+
+    def test_return_tensor_still_unloads_pipeline_when_configured(self):
+        from lightx2v.models.runners.ernie_image.ernie_image_runner import ErnieImageRunner
+
+        input_info = SimpleNamespace(
+            seed=123,
+            prompt="a glass pavilion",
+            save_result_path="/tmp/unused.png",
+            return_result_tensor=True,
+            target_shape=[640, 640],
+            aspect_ratio="16:9",
+        )
+
+        with mock.patch("diffusers.ErnieImagePipeline", FakeErnieImagePipeline, create=True):
+            runner = ErnieImageRunner(make_config(unload_modules=True))
+            runner.init_modules()
+            result = runner.run_pipeline(input_info)
+
+        self.assertEqual(len(result["images"]), 1)
+        self.assertIsInstance(result["images"][0], Image.Image)
+        self.assertIsNone(runner.pipe)
+        self.assertIsNone(runner.components)
+        self.assertIsNone(runner.model)
+        self.assertIsNone(runner.text_encoder)
+        self.assertIsNone(runner.vae)
+        self.assertIsNone(runner.scheduler)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds ERNIE-Image text-to-image support through a Diffusers-backed LightX2V runner.

This PR introduces:
- `ernie_image` configs and model pipeline registration
- `ErnieImageRunner` with a decomposed generation path instead of defaulting to `ErnieImagePipeline.__call__`
- LightX2V wrappers for component access, text/PE encoding, transformer inference, scheduler state, and VAE decode
- progress callback integration, image save/tensor return handling, CPU offload, and `unload_modules` cleanup
- focused unit tests for shape handling, PE/CFG, scheduler/VAE behavior, component loading, progress, save, tensor return, and unload cleanup

## Scope

This is still intentionally Diffusers-backed. It uses `diffusers.ErnieImagePipeline.from_pretrained` as the underlying loader and then routes runtime access through LightX2V wrapper boundaries. It does not yet implement native ERNIE weight mapping, native transformer infer classes, quantization, LoRA, or distributed execution.

## Validation

Local checks:
- `python -m unittest test_cases.test_ernie_image_runner` -> 17 tests OK
- `ruff check configs/ernie_image lightx2v/infer.py lightx2v/pipeline.py lightx2v/utils/set_config.py lightx2v/models/runners/ernie_image lightx2v/models/input_encoders/hf/ernie_image lightx2v/models/networks/ernie_image lightx2v/models/schedulers/ernie_image lightx2v/models/video_encoders/hf/ernie_image test_cases/test_ernie_image_runner.py` -> all checks passed
- `python -m py_compile ...` for the ERNIE runner/wrapper/test files -> passed

H100 smoke regression after the component-container migration:
- PE off, no offload: LightX2V runner vs direct Diffusers was pixel-identical, MSE `0.0`, max abs diff `0`
- PE off, CPU offload: LightX2V runner vs direct Diffusers was pixel-identical, MSE `0.0`, max abs diff `0`
- PE on, CPU offload + `unload_modules=true` + tensor return: generation completed, progress reached `(100.0, 100)`, and `pipe/components/model/text_encoder/scheduler/vae` were all unloaded
