### PR TITLE
Add token usage computation to OpenAI image API response

### DIFF
--- a/lightx2v/models/runners/bagel/bagel_runner.py
+++ b/lightx2v/models/runners/bagel/bagel_runner.py
@@ -29,6 +29,15 @@ class BagelRunner(DefaultRunner):
     def __init__(self, config):
         super().__init__(config)
 
+    def _get_spatial_stride(self):
+        vae_config = self.config.get("vae_config", {})
+        ds = vae_config.get("downsample", 8)
+        return ds, ds
+
+    def _get_spatial_patch(self):
+        ps = self.config.get("latent_patch_size", 2)
+        return ps, ps
+
     def init_scheduler(self):
         self.scheduler = BagelScheduler(self.config)
 

--- a/lightx2v/models/runners/base_runner.py
+++ b/lightx2v/models/runners/base_runner.py
@@ -181,6 +181,86 @@ class BaseRunner(ABC):
     def end_run(self):
         pass
 
+    def compute_usage(self, prompt: str, target_shape: list[int], has_input_image: bool = False) -> dict | None:
+        """Compute token usage for the current generation.
+
+        Returns a dict with fields matching the OpenAI Usage schema, or None if
+        the runner cannot compute usage.
+        """
+        try:
+            stride_h, stride_w = self._get_spatial_stride()
+            patch_h, patch_w = self._get_spatial_patch()
+
+            text_tokens = self._get_text_token_count(prompt)
+
+            output_image_tokens = 0
+            if target_shape and len(target_shape) >= 2:
+                h, w = target_shape[0], target_shape[1]
+                patched_h = max(1, h // stride_h // patch_h)
+                patched_w = max(1, w // stride_w // patch_w)
+                output_image_tokens = patched_h * patched_w
+
+            input_image_tokens = output_image_tokens if has_input_image else 0
+            output_tokens = output_image_tokens
+
+            return {
+                "input_tokens": text_tokens + input_image_tokens,
+                "input_tokens_details": {"image_tokens": input_image_tokens, "text_tokens": text_tokens},
+                "output_tokens": output_tokens,
+                "total_tokens": text_tokens + input_image_tokens + output_tokens,
+                "output_tokens_details": {"image_tokens": output_image_tokens, "text_tokens": 0},
+            }
+        except Exception:
+            return None
+
+    def _get_spatial_stride(self) -> tuple[int, int]:
+        vae_stride = self.config.get("vae_stride")
+        if vae_stride and len(vae_stride) >= 3:
+            return vae_stride[1], vae_stride[2]
+        vae_scale_factor = self.config.get("vae_scale_factor")
+        if vae_scale_factor:
+            sf = int(vae_scale_factor)
+            return sf, sf
+        return 8, 8
+
+    def _get_spatial_patch(self) -> tuple[int, int]:
+        patch_size = self.config.get("patch_size")
+        if patch_size:
+            if isinstance(patch_size, (list, tuple)):
+                if len(patch_size) >= 3:
+                    return patch_size[1], patch_size[2]
+                return int(patch_size[0]), int(patch_size[0])
+            return int(patch_size), int(patch_size)
+        return 2, 2
+
+    def _get_text_token_count(self, prompt: str) -> int:
+        try:
+            text_encoders = getattr(self, "text_encoders", None)
+            if text_encoders and len(text_encoders) > 0:
+                tokenizer = getattr(text_encoders[0], "tokenizer", None)
+                if tokenizer:
+                    return len(tokenizer.encode(prompt))
+        except Exception:
+            pass
+
+        try:
+            tokenizer = getattr(self, "tokenizer", None)
+            if tokenizer:
+                return len(tokenizer.encode(prompt))
+        except Exception:
+            pass
+
+        try:
+            model = getattr(self, "model", None)
+            if model:
+                tokenizer = getattr(model, "tokenizer", None)
+                if tokenizer:
+                    return len(tokenizer.encode(prompt))
+        except Exception:
+            pass
+
+        return 0
+
     def check_stop(self):
         """Check if the stop signal is received"""
 

--- a/lightx2v/models/runners/hidream_o1_image/hidream_o1_image_runner.py
+++ b/lightx2v/models/runners/hidream_o1_image/hidream_o1_image_runner.py
@@ -43,6 +43,12 @@ class HidreamO1ImageRunner(DefaultRunner):
         self.default_timesteps = None
         self.dtype = torch.bfloat16
 
+    def _get_spatial_stride(self):
+        return 32, 32
+
+    def _get_spatial_patch(self):
+        return 1, 1
+
     def init_scheduler(self):
         self.scheduler = HidreamO1ImageScheduler(self.config, torch.bfloat16)
 

--- a/lightx2v/server/api/openai_images.py
+++ b/lightx2v/server/api/openai_images.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 
-from ..schema import ImageTaskRequest
+from ..schema import ImageTaskRequest, Usage
 from ..task_manager import TaskStatus, task_manager
 from .deps import get_services
 
@@ -34,6 +34,7 @@ class OpenAIImageGenerationRequest(BaseModel):
 class OpenAIImageResponse(BaseModel):
     created: int
     data: list[dict[str, str]]
+    usage: Optional[Usage] = None
 
 
 def _write_file_sync(file_path: Path, content: bytes) -> None:
@@ -52,7 +53,7 @@ def _shape_from_size(size: str) -> tuple[int, int]:
     return width, height
 
 
-async def _wait_task_result_png(task_id: str, timeout_seconds: int, poll_interval_seconds: float) -> bytes:
+async def _wait_task_result_png(task_id: str, timeout_seconds: int, poll_interval_seconds: float) -> tuple[bytes, Optional[dict]]:
     start_time = time.monotonic()
     status_checks = 0
     while True:
@@ -64,6 +65,7 @@ async def _wait_task_result_png(task_id: str, timeout_seconds: int, poll_interva
         status = task_status.get("status")
         if status == TaskStatus.COMPLETED.value:
             result_png = task_manager.get_task_result_png(task_id)
+            usage = task_manager.get_task_result_usage(task_id)
             if result_png:
                 wait_elapsed_ms = (time.monotonic() - start_time) * 1000
                 completion_observe_lag_ms = 0.0
@@ -75,7 +77,7 @@ async def _wait_task_result_png(task_id: str, timeout_seconds: int, poll_interva
                     f"completion_observe_lag={completion_observe_lag_ms:.2f} ms "
                     f"poll_interval={poll_interval_seconds:.2f} s status_checks={status_checks}"
                 )
-                return result_png
+                return result_png, usage
             raise HTTPException(status_code=500, detail=f"Task completed but no in-memory image found: {task_id}")
 
         if status == TaskStatus.FAILED.value:
@@ -100,7 +102,7 @@ async def _watch_client_disconnect(request: Request, task_id: str, poll_interval
         await asyncio.sleep(poll_interval_seconds)
 
 
-async def _run_sync_image_task(request: Request, message: ImageTaskRequest) -> bytes:
+async def _run_sync_image_task(request: Request, message: ImageTaskRequest) -> tuple[bytes, Optional[dict]]:
     task_id = None
     timeout_seconds = 600
     poll_interval_seconds = OPENAI_IMAGE_RESULT_POLL_INTERVAL_SECONDS
@@ -119,7 +121,7 @@ async def _run_sync_image_task(request: Request, message: ImageTaskRequest) -> b
         done, pending = await asyncio.wait({wait_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED)
 
         if wait_task in done:
-            result_png = wait_task.result()
+            result_png, usage = wait_task.result()
             for pending_task in pending:
                 pending_task.cancel()
             if pending:
@@ -127,7 +129,7 @@ async def _run_sync_image_task(request: Request, message: ImageTaskRequest) -> b
                 if still_pending:
                     logger.debug(f"Task {task_id} disconnect watcher cancellation is still pending")
             logger.info(f"Task {task_id} OpenAI image task result ready, building response")
-            return result_png
+            return result_png, usage
 
         if disconnect_task in done and disconnect_task.result():
             if not wait_task.done():
@@ -162,13 +164,14 @@ def _build_url_response(request: Request, task_id: str, image_bytes: bytes) -> s
     return f"{base}/v1/files/download/{file_name}"
 
 
-def _build_openai_response(request: Request, task_id: str, image_bytes: bytes, response_format: Literal["url", "b64_json"]):
+def _build_openai_response(request: Request, task_id: str, image_bytes: bytes, response_format: Literal["url", "b64_json"], usage: Optional[dict] = None):
     total_start = time.perf_counter()
+    usage_obj = Usage(**usage) if isinstance(usage, dict) else usage
     if response_format == "b64_json":
         base64_start = time.perf_counter()
         b64_json = base64.b64encode(image_bytes).decode("utf-8")
         base64_elapsed_ms = (time.perf_counter() - base64_start) * 1000
-        response = OpenAIImageResponse(created=int(time.time()), data=[{"b64_json": b64_json}])
+        response = OpenAIImageResponse(created=int(time.time()), data=[{"b64_json": b64_json}], usage=usage_obj)
         total_elapsed_ms = (time.perf_counter() - total_start) * 1000
         logger.info(
             f"Task {task_id} OpenAI image response build cost total={total_elapsed_ms:.2f} ms base64={base64_elapsed_ms:.2f} ms format=b64_json png_bytes={len(image_bytes)} b64_chars={len(b64_json)}"
@@ -178,7 +181,7 @@ def _build_openai_response(request: Request, task_id: str, image_bytes: bytes, r
     url_start = time.perf_counter()
     url = _build_url_response(request, task_id, image_bytes)
     url_elapsed_ms = (time.perf_counter() - url_start) * 1000
-    response = OpenAIImageResponse(created=int(time.time()), data=[{"url": url}])
+    response = OpenAIImageResponse(created=int(time.time()), data=[{"url": url}], usage=usage_obj)
     total_elapsed_ms = (time.perf_counter() - total_start) * 1000
     logger.info(f"Task {task_id} OpenAI image response build cost total={total_elapsed_ms:.2f} ms url_write={url_elapsed_ms:.2f} ms format=url png_bytes={len(image_bytes)}")
     return response
@@ -230,8 +233,8 @@ async def create_openai_image_generation(request: Request, body: OpenAIImageGene
         target_shape=target_shape,
     )
 
-    result_png = await _run_sync_image_task(request, message)
-    return _build_openai_response(request, message.task_id, result_png, body.response_format)
+    result_png, usage = await _run_sync_image_task(request, message)
+    return _build_openai_response(request, message.task_id, result_png, body.response_format, usage)
 
 
 async def _save_upload_file(file: UploadFile, target_dir: Path) -> str:
@@ -310,5 +313,5 @@ async def create_openai_image_edit(
         i2i_denoise_strength=i2i_denoise_strength,
     )
 
-    result_png = await _run_sync_image_task(request, message)
-    return _build_openai_response(request, message.task_id, result_png, response_format)
+    result_png, usage = await _run_sync_image_task(request, message)
+    return _build_openai_response(request, message.task_id, result_png, response_format, usage)

--- a/lightx2v/server/api/openai_images.py
+++ b/lightx2v/server/api/openai_images.py
@@ -33,7 +33,9 @@ class OpenAIImageGenerationRequest(BaseModel):
 
 class OpenAIImageResponse(BaseModel):
     created: int
-    data: list[dict[str, str]]
+    data: Optional[list[dict[str, str]]] = None
+    output_format: Optional[Literal["png", "webp", "jpeg"]] = None
+    size: Optional[str] = None
     usage: Optional[Usage] = None
 
 
@@ -164,14 +166,14 @@ def _build_url_response(request: Request, task_id: str, image_bytes: bytes) -> s
     return f"{base}/v1/files/download/{file_name}"
 
 
-def _build_openai_response(request: Request, task_id: str, image_bytes: bytes, response_format: Literal["url", "b64_json"], usage: Optional[dict] = None):
+def _build_openai_response(request: Request, task_id: str, image_bytes: bytes, response_format: Literal["url", "b64_json"], usage: Optional[dict] = None, size: Optional[str] = None):
     total_start = time.perf_counter()
     usage_obj = Usage(**usage) if isinstance(usage, dict) else usage
     if response_format == "b64_json":
         base64_start = time.perf_counter()
         b64_json = base64.b64encode(image_bytes).decode("utf-8")
         base64_elapsed_ms = (time.perf_counter() - base64_start) * 1000
-        response = OpenAIImageResponse(created=int(time.time()), data=[{"b64_json": b64_json}], usage=usage_obj)
+        response = OpenAIImageResponse(created=int(time.time()), data=[{"b64_json": b64_json}], output_format="png", usage=usage_obj, size=size)
         total_elapsed_ms = (time.perf_counter() - total_start) * 1000
         logger.info(
             f"Task {task_id} OpenAI image response build cost total={total_elapsed_ms:.2f} ms base64={base64_elapsed_ms:.2f} ms format=b64_json png_bytes={len(image_bytes)} b64_chars={len(b64_json)}"
@@ -181,7 +183,7 @@ def _build_openai_response(request: Request, task_id: str, image_bytes: bytes, r
     url_start = time.perf_counter()
     url = _build_url_response(request, task_id, image_bytes)
     url_elapsed_ms = (time.perf_counter() - url_start) * 1000
-    response = OpenAIImageResponse(created=int(time.time()), data=[{"url": url}], usage=usage_obj)
+    response = OpenAIImageResponse(created=int(time.time()), data=[{"url": url}], output_format="png", usage=usage_obj, size=size)
     total_elapsed_ms = (time.perf_counter() - total_start) * 1000
     logger.info(f"Task {task_id} OpenAI image response build cost total={total_elapsed_ms:.2f} ms url_write={url_elapsed_ms:.2f} ms format=url png_bytes={len(image_bytes)}")
     return response
@@ -234,7 +236,7 @@ async def create_openai_image_generation(request: Request, body: OpenAIImageGene
     )
 
     result_png, usage = await _run_sync_image_task(request, message)
-    return _build_openai_response(request, message.task_id, result_png, body.response_format, usage)
+    return _build_openai_response(request, message.task_id, result_png, body.response_format, usage, size=body.size)
 
 
 async def _save_upload_file(file: UploadFile, target_dir: Path) -> str:
@@ -314,4 +316,4 @@ async def create_openai_image_edit(
     )
 
     result_png, usage = await _run_sync_image_task(request, message)
-    return _build_openai_response(request, message.task_id, result_png, response_format, usage)
+    return _build_openai_response(request, message.task_id, result_png, response_format, usage, size=size)

--- a/lightx2v/server/api/server.py
+++ b/lightx2v/server/api/server.py
@@ -137,6 +137,7 @@ class ApiServer:
                     task_id,
                     save_result_path=result.save_result_path or None,
                     result_png=getattr(result, "result_png", None),
+                    usage=getattr(result, "usage", None),
                 )
                 logger.info(f"Task {task_id} completed successfully")
             else:

--- a/lightx2v/server/schema.py
+++ b/lightx2v/server/schema.py
@@ -6,6 +6,24 @@ from pydantic import BaseModel, Field
 from ..utils.generate_task_id import generate_task_id
 
 
+class UsageInputTokensDetails(BaseModel):
+    image_tokens: int = 0
+    text_tokens: int = 0
+
+
+class UsageOutputTokensDetails(BaseModel):
+    image_tokens: int = 0
+    text_tokens: int = 0
+
+
+class Usage(BaseModel):
+    input_tokens: int
+    input_tokens_details: UsageInputTokensDetails
+    output_tokens: int
+    total_tokens: int
+    output_tokens_details: UsageOutputTokensDetails
+
+
 def generate_random_seed() -> int:
     return random.randint(0, 2**32 - 1)
 
@@ -90,6 +108,7 @@ class TaskResponse(BaseModel):
     save_result_path: str
     # Filled after image generation in-process; never serialized in JSON responses.
     result_png: Optional[bytes] = Field(default=None, exclude=True)
+    usage: Optional[Usage] = Field(default=None, exclude=True)
 
 
 class StopTaskResponse(BaseModel):

--- a/lightx2v/server/services/generation/image.py
+++ b/lightx2v/server/services/generation/image.py
@@ -66,11 +66,13 @@ class ImageGenerationService(BaseGenerationService):
                     result_png = result.get("result_png")
                     if not result_png:
                         raise RuntimeError("Image inference did not return in-memory PNG bytes (result_png)")
+                    usage = result.get("usage")
                     return TaskResponse(
                         task_id=message.task_id,
                         task_status="completed",
                         save_result_path="",
                         result_png=result_png,
+                        usage=usage,
                     )
 
                 return TaskResponse(

--- a/lightx2v/server/services/inference/worker.py
+++ b/lightx2v/server/services/inference/worker.py
@@ -133,6 +133,13 @@ class TorchrunInferenceWorker:
                     logger.info(f"Task {task_data.get('task_id')} encode result_png cost {encode_elapsed_ms:.2f} ms")
                     if png:
                         out["result_png"] = png
+                    usage = self.runner.compute_usage(
+                        prompt=task_data.get("prompt", ""),
+                        target_shape=task_data.get("target_shape", []),
+                        has_input_image=bool(task_data.get("image_path")),
+                    )
+                    if usage:
+                        out["usage"] = usage
                 return out
         else:
             return None

--- a/lightx2v/server/task_manager.py
+++ b/lightx2v/server/task_manager.py
@@ -30,6 +30,7 @@ class TaskInfo:
     error_type: Optional[str] = None
     save_result_path: Optional[str] = None
     result_png: Optional[bytes] = None
+    usage: Optional[dict] = None
     stop_event: threading.Event = field(default_factory=threading.Event)
     thread: Optional[threading.Thread] = None
 
@@ -85,7 +86,7 @@ class TaskManager:
 
             return task
 
-    def complete_task(self, task_id: str, save_result_path: Optional[str] = None, result_png: Optional[bytes] = None):
+    def complete_task(self, task_id: str, save_result_path: Optional[str] = None, result_png: Optional[bytes] = None, usage: Optional[dict] = None):
         with self._lock:
             if task_id not in self._tasks:
                 logger.warning(f"Task {task_id} not found for completion")
@@ -96,6 +97,7 @@ class TaskManager:
             task.end_time = datetime.now()
             task.save_result_path = save_result_path
             task.result_png = result_png
+            task.usage = usage
 
             self.completed_tasks += 1
             self._emit_queue_metrics_unlocked()
@@ -152,6 +154,13 @@ class TaskManager:
             if not task:
                 return None
             return task.result_png
+
+    def get_task_result_usage(self, task_id: str) -> Optional[dict]:
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return None
+            return task.usage
 
     def get_task_status(self, task_id: str) -> Optional[Dict[str, Any]]:
         task = self.get_task(task_id)


### PR DESCRIPTION
Compute input/output token counts via runner and return usage metadata in /v1/images/generations and /v1/images/edits responses.