### PR TITLE
fix(s2v): preserve original audio quality by using -c:a copy instead …

### DIFF
--- a/lightx2v/models/runners/wan/wan_s2v_runner.py
+++ b/lightx2v/models/runners/wan/wan_s2v_runner.py
@@ -41,7 +41,7 @@ def merge_video_audio(video_path: str, audio_path: str):
         "-c:v",
         "copy",
         "-c:a",
-        "aac",
+        "copy",
         "-shortest",
         tmp_path,
     ]


### PR DESCRIPTION
…of aac re-encoding

When merging video and audio in merge_video_audio(), using '-c:a aac' caused the original MP3 audio (generated by TTS) to be re-encoded, resulting in audible quality degradation (less clarity, duller timbre).

Changing to '-c:a copy' preserves the original audio stream without re-encoding.