### PR TITLE
perf: optimize Hunyuan DiT Ulysses and non-attention paths

### DIFF
--- a/lightx2v/common/ops/attn/ulysses_attn.py
+++ b/lightx2v/common/ops/attn/ulysses_attn.py
@@ -1,3 +1,6 @@
+import os
+from contextlib import nullcontext
+
 import torch
 import torch.distributed as dist
 from loguru import logger
@@ -7,6 +10,34 @@ from lightx2v.utils.registry_factory import ATTN_WEIGHT_REGISTER
 
 from .template import AttnWeightTemplate
 from .utils.all2all import all2all_head2seq
+
+
+def _env_flag(name, default="0"):
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+_PROFILE_RANGES_ENABLED = _env_flag("LIGHTX2V_ULYSSES_PROFILE_RANGES")
+_ASYNC_TEXT_GATHER_ENABLED = _env_flag("LIGHTX2V_ULYSSES_ASYNC_TEXT_GATHER")
+_REUSE_TEXT_GATHER_BUFFERS_ENABLED = _env_flag("LIGHTX2V_ULYSSES_REUSE_TEXT_GATHER_BUFFERS")
+
+
+def _profile_range(name):
+    return torch.profiler.record_function(f"ulysses::{name}") if _PROFILE_RANGES_ENABLED else nullcontext()
+
+
+def _is_split_qkv_input(tensor_or_pair):
+    return isinstance(tensor_or_pair, (tuple, list))
+
+
+def _to_3d_qkv(tensor):
+    if len(tensor.shape) == 4:
+        return tensor.reshape(-1, tensor.shape[-2], tensor.shape[-1])
+    return tensor
+
+
+def _contiguous_if_needed(tensor):
+    return tensor if tensor.is_contiguous() else tensor.contiguous()
+
 
 try:
     from sageattn3_sparse import dequant_fp4 as dequant_fp4_sage3
@@ -21,6 +52,18 @@ except ImportError:
 class UlyssesAttnWeight(AttnWeightTemplate):
     def __init__(self):
         self.config = {}
+        self._text_gather_buffers = {}
+
+    def _get_text_gather_buffers(self, tensor, world_size):
+        if not _REUSE_TEXT_GATHER_BUFFERS_ENABLED:
+            return [torch.empty_like(tensor) for _ in range(world_size)]
+
+        key = (world_size, tuple(tensor.shape), tensor.dtype, tensor.device)
+        buffers = self._text_gather_buffers.get(key)
+        if buffers is None:
+            buffers = [torch.empty_like(tensor) for _ in range(world_size)]
+            self._text_gather_buffers[key] = buffers
+        return buffers
 
     def apply(
         self,
@@ -37,6 +80,7 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         enable_head_parallel=False,
         img_first=True,
         q_only_img=False,
+        return_split_output=False,
         **kwargs,
     ):
         """
@@ -62,8 +106,16 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         assert not (use_fp8_comm and use_fp4_comm), "use_fp8_comm and use_fp4_comm can't be enabled at the same time."
 
         use_qkv_fusion = use_tensor_fusion
+        split_qkv_input = _is_split_qkv_input(q)
 
-        if len(q.shape) == 4:
+        if split_qkv_input:
+            if q_only_img:
+                raise NotImplementedError("split QKV input does not support q_only_img yet.")
+            assert _is_split_qkv_input(k) and _is_split_qkv_input(v), "q/k/v must all use split img/txt input."
+            img_q, txt_q = (_to_3d_qkv(tensor) for tensor in q)
+            img_k, txt_k = (_to_3d_qkv(tensor) for tensor in k)
+            img_v, txt_v = (_to_3d_qkv(tensor) for tensor in v)
+        elif len(q.shape) == 4:
             q = q.reshape(-1, q.shape[-2], q.shape[-1])
             k = k.reshape(-1, k.shape[-2], k.shape[-1])
             v = v.reshape(-1, v.shape[-2], v.shape[-1])
@@ -73,7 +125,11 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         cur_rank = dist.get_rank(seq_p_group)
 
         # 获取序列长度和文本相关的长度
-        if img_first:
+        if split_qkv_input:
+            img_qkv_len = img_q.shape[0]
+            txt_qkv_len = txt_q.shape[0]
+            txt_mask_len = None
+        elif img_first:
             img_qkv_len = slice_qkv_len
             if len(cu_seqlens_qkv) == 3:
                 txt_qkv_len = cu_seqlens_qkv[1] - slice_qkv_len  # 文本查询、键和值的长度
@@ -87,8 +143,12 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             txt_mask_len = None
 
         # 分别获取 q 和 kv 的头数，支持 GQA（k/v 头数可能少于 q）
-        _, q_heads, hidden_dims = q.shape
-        _, kv_heads, _ = k.shape
+        if split_qkv_input:
+            _, q_heads, hidden_dims = img_q.shape
+            _, kv_heads, _ = img_k.shape
+        else:
+            _, q_heads, hidden_dims = q.shape
+            _, kv_heads, _ = k.shape
         is_gqa = q_heads != kv_heads
         q_shard_heads = q_heads // world_size  # q 每个进程处理的头数
         kv_shard_heads = kv_heads // world_size  # k/v 每个进程处理的头数
@@ -118,7 +178,15 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             max_seqlen_q = max_seqlen_kv
 
         # 分割图像和文本的查询、键和值
-        if q_only_img:
+        if split_qkv_input:
+            with _profile_range("split_qkv_contiguous"):
+                img_q = _contiguous_if_needed(img_q)
+                img_k = _contiguous_if_needed(img_k)
+                img_v = _contiguous_if_needed(img_v)
+                txt_q = _contiguous_if_needed(txt_q)
+                txt_k = _contiguous_if_needed(txt_k)
+                txt_v = _contiguous_if_needed(txt_v)
+        elif q_only_img:
             # q 只含图像 token，无需分割；仅 k/v 需要拆出图像和文本部分
             img_q = q.contiguous()
             txt_q = None
@@ -148,16 +216,17 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                 img_k = k[txt_qkv_len:, :, :].contiguous()
                 img_v = v[txt_qkv_len:, :, :].contiguous()
 
-        if use_qkv_fusion:
-            # fusion 路径：q_shard_heads == kv_shard_heads（非 GQA、非 q_only_img 时才走此分支）
-            img_qkv = torch.stack([img_q, img_k, img_v], dim=0).reshape(3, img_qkv_len, world_size, shard_heads, hidden_dims)
-            original_dtype = img_qkv.dtype
-        else:
-            # 非 fusion：q 和 kv 分别 reshape，支持 GQA 下头数不同
-            img_q = img_q.reshape(img_qkv_len, world_size, q_shard_heads, hidden_dims)
-            img_k = img_k.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
-            img_v = img_v.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
-            original_dtype = img_q.dtype
+        with _profile_range("seq2head_initial_reshape"):
+            if use_qkv_fusion:
+                # fusion 路径：q_shard_heads == kv_shard_heads（非 GQA、非 q_only_img 时才走此分支）
+                img_qkv = torch.stack([img_q, img_k, img_v], dim=0).reshape(3, img_qkv_len, world_size, shard_heads, hidden_dims)
+                original_dtype = img_qkv.dtype
+            else:
+                # 非 fusion：q 和 kv 分别 reshape，支持 GQA 下头数不同
+                img_q = img_q.reshape(img_qkv_len, world_size, q_shard_heads, hidden_dims)
+                img_k = img_k.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
+                img_v = img_v.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
+                original_dtype = img_q.dtype
 
         if enable_head_parallel:
             assert not is_gqa, "GQA（q_heads != kv_heads）暂不支持 enable_head_parallel 模式"
@@ -333,12 +402,13 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             attn = torch.cat(head_attns, dim=1)
 
         else:
-            if use_qkv_fusion:
-                img_qkv = img_qkv.permute(2, 1, 0, 3, 4).contiguous()  # (world_size, img_qkv_len, 3, shard_heads, hidden_dims)
-            else:
-                img_q = img_q.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, q_shard_heads, hidden_dims)
-                img_k = img_k.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, kv_shard_heads, hidden_dims)
-                img_v = img_v.permute(1, 0, 2, 3).contiguous()
+            with _profile_range("pre_all_to_all_layout"):
+                if use_qkv_fusion:
+                    img_qkv = img_qkv.permute(2, 1, 0, 3, 4).contiguous()  # (world_size, img_qkv_len, 3, shard_heads, hidden_dims)
+                else:
+                    img_q = img_q.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, q_shard_heads, hidden_dims)
+                    img_k = img_k.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, kv_shard_heads, hidden_dims)
+                    img_v = img_v.permute(1, 0, 2, 3).contiguous()
 
             # 通信图像的查询、键和值
             if use_qkv_fusion:
@@ -411,12 +481,13 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                         output_k = dequant_fp4_sage3(output_k_quant.reshape(1, 1, -1, hidden_dims // 2), output_k_scale.reshape(1, 1, -1, hidden_dims // 16))
                         output_v = dequant_fp4_sage3(output_v_quant.reshape(1, 1, -1, hidden_dims // 2), output_v_scale.reshape(1, 1, -1, hidden_dims // 16))
                 else:
-                    output_q = torch.empty_like(img_q)
-                    output_k = torch.empty_like(img_k)
-                    output_v = torch.empty_like(img_v)
-                    dist.all_to_all_single(output_q, img_q, group=seq_p_group)
-                    dist.all_to_all_single(output_k, img_k, group=seq_p_group)
-                    dist.all_to_all_single(output_v, img_v, group=seq_p_group)
+                    with _profile_range("pre_attn_all_to_all_qkv"):
+                        output_q = torch.empty_like(img_q)
+                        output_k = torch.empty_like(img_k)
+                        output_v = torch.empty_like(img_v)
+                        dist.all_to_all_single(output_q, img_q, group=seq_p_group)
+                        dist.all_to_all_single(output_k, img_k, group=seq_p_group)
+                        dist.all_to_all_single(output_v, img_v, group=seq_p_group)
                 # q 与 kv 使用各自对应的 shard_heads 进行 reshape
                 shard_img_q = output_q.reshape(global_img_seqlen, q_shard_heads, hidden_dims)
                 shard_img_k = output_k.reshape(global_img_seqlen, kv_shard_heads, hidden_dims)
@@ -438,17 +509,19 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                 shard_txt_q = txt_q[:, cur_rank * q_shard_heads : (cur_rank + 1) * q_shard_heads, :]
                 shard_txt_k = txt_k[:, cur_rank * kv_shard_heads : (cur_rank + 1) * kv_shard_heads, :]
                 shard_txt_v = txt_v[:, cur_rank * kv_shard_heads : (cur_rank + 1) * kv_shard_heads, :]
-                if img_first:
-                    q = torch.cat((shard_img_q, shard_txt_q), dim=0)
-                    k = torch.cat((shard_img_k, shard_txt_k), dim=0)
-                    v = torch.cat((shard_img_v, shard_txt_v), dim=0)
-                else:
-                    q = torch.cat((shard_txt_q, shard_img_q), dim=0)
-                    k = torch.cat((shard_txt_k, shard_img_k), dim=0)
-                    v = torch.cat((shard_txt_v, shard_img_v), dim=0)
+                with _profile_range("attn_input_cat"):
+                    if img_first:
+                        q = torch.cat((shard_img_q, shard_txt_q), dim=0)
+                        k = torch.cat((shard_img_k, shard_txt_k), dim=0)
+                        v = torch.cat((shard_img_v, shard_txt_v), dim=0)
+                    else:
+                        q = torch.cat((shard_txt_q, shard_img_q), dim=0)
+                        k = torch.cat((shard_txt_k, shard_img_k), dim=0)
+                        v = torch.cat((shard_txt_v, shard_img_v), dim=0)
 
             # 调用注意力函数计算注意力结果
-            attn = attention_module.apply(q=q, k=k, v=v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv, **kwargs)
+            with _profile_range("attention_apply"):
+                attn = attention_module.apply(q=q, k=k, v=v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv, **kwargs)
 
         if q_only_img:
             # q 只含图像 token：attn 全部是图像侧结果，无 txt_attn，直接还原通信格式
@@ -462,18 +535,35 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             txt_attn, img_attn = attn[:txt_qkv_len, :], attn[txt_qkv_len:]
 
         # 通信所有进程的图像注意力结果
+        gathered_txt_attn = None
+        text_gather_work = None
+        if _ASYNC_TEXT_GATHER_ENABLED:
+            with _profile_range("text_all_gather_launch"):
+                gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size)
+                text_gather_work = dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group, async_op=True)
+
         img_attn = self._reshape_img_attn(img_attn, world_size, shard_seqlen, q_shard_heads, hidden_dims, seq_p_group, use_fp8_comm)
 
         # 收集所有进程的文本注意力结果
-        gathered_txt_attn = [torch.empty_like(txt_attn) for _ in range(world_size)]
-        dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group)
-        txt_attn = torch.cat(gathered_txt_attn, dim=1)  # 合并所有进程的文本注意力结果
+        if _ASYNC_TEXT_GATHER_ENABLED:
+            with _profile_range("text_all_gather_wait"):
+                text_gather_work.wait()
+        else:
+            with _profile_range("text_all_gather"):
+                gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size)
+                dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group)
+        with _profile_range("text_all_gather_cat"):
+            txt_attn = torch.cat(gathered_txt_attn, dim=1)  # 合并所有进程的文本注意力结果
+
+        if return_split_output:
+            return img_attn, txt_attn
 
         # 合并图像和文本的注意力结果
-        if img_first:
-            attn = torch.cat([img_attn, txt_attn], dim=0)
-        else:
-            attn = torch.cat([txt_attn, img_attn], dim=0)
+        with _profile_range("output_img_txt_cat"):
+            if img_first:
+                attn = torch.cat([img_attn, txt_attn], dim=0)
+            else:
+                attn = torch.cat([txt_attn, img_attn], dim=0)
 
         return attn  # 返回最终的注意力结果
 
@@ -485,11 +575,13 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             original_dtype = img_attn.dtype
             original_shape = img_attn.shape
             img_attn_quant, attn_scale = quant_fp8_vllm(img_attn.reshape(-1, original_shape[-1]))
-            img_attn_quant = all2all_head2seq(img_attn_quant.reshape(original_shape), group=seq_p_group)
-            attn_scale = all2all_head2seq(attn_scale.reshape(original_shape[0], original_shape[1], 1), group=seq_p_group)
+            with _profile_range("output_all2all_head2seq"):
+                img_attn_quant = all2all_head2seq(img_attn_quant.reshape(original_shape), group=seq_p_group)
+                attn_scale = all2all_head2seq(attn_scale.reshape(original_shape[0], original_shape[1], 1), group=seq_p_group)
             img_attn = dequant_fp8_vllm(img_attn_quant, attn_scale, original_dtype)
         else:
-            img_attn = all2all_head2seq(img_attn, group=seq_p_group)
+            with _profile_range("output_all2all_head2seq"):
+                img_attn = all2all_head2seq(img_attn, group=seq_p_group)
 
         img_attn = img_attn.reshape(shard_seqlen, -1)  # 重塑为 [shard_seqlen, -1] 形状
         return img_attn

--- a/lightx2v/common/ops/attn/ulysses_attn.py
+++ b/lightx2v/common/ops/attn/ulysses_attn.py
@@ -16,9 +16,17 @@ def _env_flag(name, default="0"):
     return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _env_int(name, default):
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 _PROFILE_RANGES_ENABLED = _env_flag("LIGHTX2V_ULYSSES_PROFILE_RANGES")
 _ASYNC_TEXT_GATHER_ENABLED = _env_flag("LIGHTX2V_ULYSSES_ASYNC_TEXT_GATHER")
 _REUSE_TEXT_GATHER_BUFFERS_ENABLED = _env_flag("LIGHTX2V_ULYSSES_REUSE_TEXT_GATHER_BUFFERS")
+_TEXT_GATHER_BUFFER_CACHE_MAX = max(1, _env_int("LIGHTX2V_ULYSSES_TEXT_GATHER_BUFFER_CACHE_MAX", 16))
 
 
 def _profile_range(name):
@@ -61,6 +69,8 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         key = (world_size, tuple(tensor.shape), tensor.dtype, tensor.device)
         buffers = self._text_gather_buffers.get(key)
         if buffers is None:
+            if len(self._text_gather_buffers) >= _TEXT_GATHER_BUFFER_CACHE_MAX:
+                self._text_gather_buffers.clear()
             buffers = [torch.empty_like(tensor) for _ in range(world_size)]
             self._text_gather_buffers[key] = buffers
         return buffers
@@ -128,7 +138,7 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         if split_qkv_input:
             img_qkv_len = img_q.shape[0]
             txt_qkv_len = txt_q.shape[0]
-            txt_mask_len = None
+            txt_mask_len = cu_seqlens_qkv[2] - img_qkv_len if img_first and len(cu_seqlens_qkv) == 3 else None
         elif img_first:
             img_qkv_len = slice_qkv_len
             if len(cu_seqlens_qkv) == 3:
@@ -542,13 +552,15 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                 gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size)
                 text_gather_work = dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group, async_op=True)
 
-        img_attn = self._reshape_img_attn(img_attn, world_size, shard_seqlen, q_shard_heads, hidden_dims, seq_p_group, use_fp8_comm)
-
-        # 收集所有进程的文本注意力结果
+        # Finish the async gather before launching any later collective on the same process group.
         if _ASYNC_TEXT_GATHER_ENABLED:
             with _profile_range("text_all_gather_wait"):
                 text_gather_work.wait()
-        else:
+
+        img_attn = self._reshape_img_attn(img_attn, world_size, shard_seqlen, q_shard_heads, hidden_dims, seq_p_group, use_fp8_comm)
+
+        # Gather text attention synchronously when async launch is disabled.
+        if not _ASYNC_TEXT_GATHER_ENABLED:
             with _profile_range("text_all_gather"):
                 gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size)
                 dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group)

--- a/lightx2v/common/ops/attn/ulysses_attn.py
+++ b/lightx2v/common/ops/attn/ulysses_attn.py
@@ -1,6 +1,3 @@
-import os
-from contextlib import nullcontext
-
 import torch
 import torch.distributed as dist
 from loguru import logger
@@ -10,27 +7,6 @@ from lightx2v.utils.registry_factory import ATTN_WEIGHT_REGISTER
 
 from .template import AttnWeightTemplate
 from .utils.all2all import all2all_head2seq
-
-
-def _env_flag(name, default="0"):
-    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _env_int(name, default):
-    try:
-        return int(os.getenv(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-
-
-_PROFILE_RANGES_ENABLED = _env_flag("LIGHTX2V_ULYSSES_PROFILE_RANGES")
-_ASYNC_TEXT_GATHER_ENABLED = _env_flag("LIGHTX2V_ULYSSES_ASYNC_TEXT_GATHER")
-_REUSE_TEXT_GATHER_BUFFERS_ENABLED = _env_flag("LIGHTX2V_ULYSSES_REUSE_TEXT_GATHER_BUFFERS")
-_TEXT_GATHER_BUFFER_CACHE_MAX = max(1, _env_int("LIGHTX2V_ULYSSES_TEXT_GATHER_BUFFER_CACHE_MAX", 16))
-
-
-def _profile_range(name):
-    return torch.profiler.record_function(f"ulysses::{name}") if _PROFILE_RANGES_ENABLED else nullcontext()
 
 
 def _is_split_qkv_input(tensor_or_pair):
@@ -62,14 +38,14 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         self.config = {}
         self._text_gather_buffers = {}
 
-    def _get_text_gather_buffers(self, tensor, world_size):
-        if not _REUSE_TEXT_GATHER_BUFFERS_ENABLED:
+    def _get_text_gather_buffers(self, tensor, world_size, reuse_buffers=False, cache_max=16):
+        if not reuse_buffers:
             return [torch.empty_like(tensor) for _ in range(world_size)]
 
         key = (world_size, tuple(tensor.shape), tensor.dtype, tensor.device)
         buffers = self._text_gather_buffers.get(key)
         if buffers is None:
-            if len(self._text_gather_buffers) >= _TEXT_GATHER_BUFFER_CACHE_MAX:
+            if len(self._text_gather_buffers) >= max(1, cache_max):
                 self._text_gather_buffers.clear()
             buffers = [torch.empty_like(tensor) for _ in range(world_size)]
             self._text_gather_buffers[key] = buffers
@@ -91,6 +67,9 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         img_first=True,
         q_only_img=False,
         return_split_output=False,
+        async_text_gather=False,
+        reuse_text_gather_buffers=False,
+        text_gather_buffer_cache_max=16,
         **kwargs,
     ):
         """
@@ -189,13 +168,12 @@ class UlyssesAttnWeight(AttnWeightTemplate):
 
         # 分割图像和文本的查询、键和值
         if split_qkv_input:
-            with _profile_range("split_qkv_contiguous"):
-                img_q = _contiguous_if_needed(img_q)
-                img_k = _contiguous_if_needed(img_k)
-                img_v = _contiguous_if_needed(img_v)
-                txt_q = _contiguous_if_needed(txt_q)
-                txt_k = _contiguous_if_needed(txt_k)
-                txt_v = _contiguous_if_needed(txt_v)
+            img_q = _contiguous_if_needed(img_q)
+            img_k = _contiguous_if_needed(img_k)
+            img_v = _contiguous_if_needed(img_v)
+            txt_q = _contiguous_if_needed(txt_q)
+            txt_k = _contiguous_if_needed(txt_k)
+            txt_v = _contiguous_if_needed(txt_v)
         elif q_only_img:
             # q 只含图像 token，无需分割；仅 k/v 需要拆出图像和文本部分
             img_q = q.contiguous()
@@ -226,17 +204,16 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                 img_k = k[txt_qkv_len:, :, :].contiguous()
                 img_v = v[txt_qkv_len:, :, :].contiguous()
 
-        with _profile_range("seq2head_initial_reshape"):
-            if use_qkv_fusion:
-                # fusion 路径：q_shard_heads == kv_shard_heads（非 GQA、非 q_only_img 时才走此分支）
-                img_qkv = torch.stack([img_q, img_k, img_v], dim=0).reshape(3, img_qkv_len, world_size, shard_heads, hidden_dims)
-                original_dtype = img_qkv.dtype
-            else:
-                # 非 fusion：q 和 kv 分别 reshape，支持 GQA 下头数不同
-                img_q = img_q.reshape(img_qkv_len, world_size, q_shard_heads, hidden_dims)
-                img_k = img_k.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
-                img_v = img_v.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
-                original_dtype = img_q.dtype
+        if use_qkv_fusion:
+            # fusion 路径：q_shard_heads == kv_shard_heads（非 GQA、非 q_only_img 时才走此分支）
+            img_qkv = torch.stack([img_q, img_k, img_v], dim=0).reshape(3, img_qkv_len, world_size, shard_heads, hidden_dims)
+            original_dtype = img_qkv.dtype
+        else:
+            # 非 fusion：q 和 kv 分别 reshape，支持 GQA 下头数不同
+            img_q = img_q.reshape(img_qkv_len, world_size, q_shard_heads, hidden_dims)
+            img_k = img_k.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
+            img_v = img_v.reshape(img_qkv_len, world_size, kv_shard_heads, hidden_dims)
+            original_dtype = img_q.dtype
 
         if enable_head_parallel:
             assert not is_gqa, "GQA（q_heads != kv_heads）暂不支持 enable_head_parallel 模式"
@@ -412,13 +389,12 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             attn = torch.cat(head_attns, dim=1)
 
         else:
-            with _profile_range("pre_all_to_all_layout"):
-                if use_qkv_fusion:
-                    img_qkv = img_qkv.permute(2, 1, 0, 3, 4).contiguous()  # (world_size, img_qkv_len, 3, shard_heads, hidden_dims)
-                else:
-                    img_q = img_q.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, q_shard_heads, hidden_dims)
-                    img_k = img_k.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, kv_shard_heads, hidden_dims)
-                    img_v = img_v.permute(1, 0, 2, 3).contiguous()
+            if use_qkv_fusion:
+                img_qkv = img_qkv.permute(2, 1, 0, 3, 4).contiguous()  # (world_size, img_qkv_len, 3, shard_heads, hidden_dims)
+            else:
+                img_q = img_q.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, q_shard_heads, hidden_dims)
+                img_k = img_k.permute(1, 0, 2, 3).contiguous()  # (world_size, img_qkv_len, kv_shard_heads, hidden_dims)
+                img_v = img_v.permute(1, 0, 2, 3).contiguous()
 
             # 通信图像的查询、键和值
             if use_qkv_fusion:
@@ -491,13 +467,12 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                         output_k = dequant_fp4_sage3(output_k_quant.reshape(1, 1, -1, hidden_dims // 2), output_k_scale.reshape(1, 1, -1, hidden_dims // 16))
                         output_v = dequant_fp4_sage3(output_v_quant.reshape(1, 1, -1, hidden_dims // 2), output_v_scale.reshape(1, 1, -1, hidden_dims // 16))
                 else:
-                    with _profile_range("pre_attn_all_to_all_qkv"):
-                        output_q = torch.empty_like(img_q)
-                        output_k = torch.empty_like(img_k)
-                        output_v = torch.empty_like(img_v)
-                        dist.all_to_all_single(output_q, img_q, group=seq_p_group)
-                        dist.all_to_all_single(output_k, img_k, group=seq_p_group)
-                        dist.all_to_all_single(output_v, img_v, group=seq_p_group)
+                    output_q = torch.empty_like(img_q)
+                    output_k = torch.empty_like(img_k)
+                    output_v = torch.empty_like(img_v)
+                    dist.all_to_all_single(output_q, img_q, group=seq_p_group)
+                    dist.all_to_all_single(output_k, img_k, group=seq_p_group)
+                    dist.all_to_all_single(output_v, img_v, group=seq_p_group)
                 # q 与 kv 使用各自对应的 shard_heads 进行 reshape
                 shard_img_q = output_q.reshape(global_img_seqlen, q_shard_heads, hidden_dims)
                 shard_img_k = output_k.reshape(global_img_seqlen, kv_shard_heads, hidden_dims)
@@ -519,19 +494,17 @@ class UlyssesAttnWeight(AttnWeightTemplate):
                 shard_txt_q = txt_q[:, cur_rank * q_shard_heads : (cur_rank + 1) * q_shard_heads, :]
                 shard_txt_k = txt_k[:, cur_rank * kv_shard_heads : (cur_rank + 1) * kv_shard_heads, :]
                 shard_txt_v = txt_v[:, cur_rank * kv_shard_heads : (cur_rank + 1) * kv_shard_heads, :]
-                with _profile_range("attn_input_cat"):
-                    if img_first:
-                        q = torch.cat((shard_img_q, shard_txt_q), dim=0)
-                        k = torch.cat((shard_img_k, shard_txt_k), dim=0)
-                        v = torch.cat((shard_img_v, shard_txt_v), dim=0)
-                    else:
-                        q = torch.cat((shard_txt_q, shard_img_q), dim=0)
-                        k = torch.cat((shard_txt_k, shard_img_k), dim=0)
-                        v = torch.cat((shard_txt_v, shard_img_v), dim=0)
+                if img_first:
+                    q = torch.cat((shard_img_q, shard_txt_q), dim=0)
+                    k = torch.cat((shard_img_k, shard_txt_k), dim=0)
+                    v = torch.cat((shard_img_v, shard_txt_v), dim=0)
+                else:
+                    q = torch.cat((shard_txt_q, shard_img_q), dim=0)
+                    k = torch.cat((shard_txt_k, shard_img_k), dim=0)
+                    v = torch.cat((shard_txt_v, shard_img_v), dim=0)
 
             # 调用注意力函数计算注意力结果
-            with _profile_range("attention_apply"):
-                attn = attention_module.apply(q=q, k=k, v=v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv, **kwargs)
+            attn = attention_module.apply(q=q, k=k, v=v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_kv=cu_seqlens_kv, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv, **kwargs)
 
         if q_only_img:
             # q 只含图像 token：attn 全部是图像侧结果，无 txt_attn，直接还原通信格式
@@ -547,35 +520,30 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         # 通信所有进程的图像注意力结果
         gathered_txt_attn = None
         text_gather_work = None
-        if _ASYNC_TEXT_GATHER_ENABLED:
-            with _profile_range("text_all_gather_launch"):
-                gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size)
-                text_gather_work = dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group, async_op=True)
+        if async_text_gather:
+            gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size, reuse_text_gather_buffers, text_gather_buffer_cache_max)
+            text_gather_work = dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group, async_op=True)
 
         # Finish the async gather before launching any later collective on the same process group.
-        if _ASYNC_TEXT_GATHER_ENABLED:
-            with _profile_range("text_all_gather_wait"):
-                text_gather_work.wait()
+        if async_text_gather:
+            text_gather_work.wait()
 
         img_attn = self._reshape_img_attn(img_attn, world_size, shard_seqlen, q_shard_heads, hidden_dims, seq_p_group, use_fp8_comm)
 
         # Gather text attention synchronously when async launch is disabled.
-        if not _ASYNC_TEXT_GATHER_ENABLED:
-            with _profile_range("text_all_gather"):
-                gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size)
-                dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group)
-        with _profile_range("text_all_gather_cat"):
-            txt_attn = torch.cat(gathered_txt_attn, dim=1)  # 合并所有进程的文本注意力结果
+        if not async_text_gather:
+            gathered_txt_attn = self._get_text_gather_buffers(txt_attn, world_size, reuse_text_gather_buffers, text_gather_buffer_cache_max)
+            dist.all_gather(gathered_txt_attn, txt_attn, group=seq_p_group)
+        txt_attn = torch.cat(gathered_txt_attn, dim=1)  # 合并所有进程的文本注意力结果
 
         if return_split_output:
             return img_attn, txt_attn
 
         # 合并图像和文本的注意力结果
-        with _profile_range("output_img_txt_cat"):
-            if img_first:
-                attn = torch.cat([img_attn, txt_attn], dim=0)
-            else:
-                attn = torch.cat([txt_attn, img_attn], dim=0)
+        if img_first:
+            attn = torch.cat([img_attn, txt_attn], dim=0)
+        else:
+            attn = torch.cat([txt_attn, img_attn], dim=0)
 
         return attn  # 返回最终的注意力结果
 
@@ -587,13 +555,11 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             original_dtype = img_attn.dtype
             original_shape = img_attn.shape
             img_attn_quant, attn_scale = quant_fp8_vllm(img_attn.reshape(-1, original_shape[-1]))
-            with _profile_range("output_all2all_head2seq"):
-                img_attn_quant = all2all_head2seq(img_attn_quant.reshape(original_shape), group=seq_p_group)
-                attn_scale = all2all_head2seq(attn_scale.reshape(original_shape[0], original_shape[1], 1), group=seq_p_group)
+            img_attn_quant = all2all_head2seq(img_attn_quant.reshape(original_shape), group=seq_p_group)
+            attn_scale = all2all_head2seq(attn_scale.reshape(original_shape[0], original_shape[1], 1), group=seq_p_group)
             img_attn = dequant_fp8_vllm(img_attn_quant, attn_scale, original_dtype)
         else:
-            with _profile_range("output_all2all_head2seq"):
-                img_attn = all2all_head2seq(img_attn, group=seq_p_group)
+            img_attn = all2all_head2seq(img_attn, group=seq_p_group)
 
         img_attn = img_attn.reshape(shard_seqlen, -1)  # 重塑为 [shard_seqlen, -1] 形状
         return img_attn

--- a/lightx2v/common/ops/attn/ulysses_attn.py
+++ b/lightx2v/common/ops/attn/ulysses_attn.py
@@ -18,6 +18,7 @@ class UlyssesAttnWeight(AttnWeightTemplate):
     def __init__(self, a2a_backend="torch"):
         self.config = {}
         self.default_a2a_backend = a2a_backend
+        self._aux_gather_buffers = {}
 
     def apply(
         self,
@@ -101,6 +102,9 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         head_parallel=False,
         aux_first=False,
         attention_kwargs=None,
+        async_aux_gather=False,
+        reuse_aux_gather_buffers=False,
+        aux_gather_buffer_cache_max=16,
     ):
         """Run Ulysses attention over QKV and optional auxiliary token regions.
 
@@ -161,13 +165,16 @@ class UlyssesAttnWeight(AttnWeightTemplate):
             world_size=world_size,
             rank=rank,
             attention_kwargs=attention_kwargs,
+            async_aux_gather=async_aux_gather,
+            reuse_aux_gather_buffers=reuse_aux_gather_buffers,
+            aux_gather_buffer_cache_max=aux_gather_buffer_cache_max,
         )
         if head_parallel:
             return self._apply_head_pipeline(**common_args)
         return self._apply_bulk(**common_args)
 
-    @staticmethod
     def _apply_bulk(
+        self,
         prepost,
         a2a,
         q,
@@ -184,6 +191,9 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         world_size,
         rank,
         attention_kwargs,
+        async_aux_gather,
+        reuse_aux_gather_buffers,
+        aux_gather_buffer_cache_max,
     ):
         local_len, q_heads, hidden_dims = q.shape
         shard_heads = q_heads // world_size
@@ -214,15 +224,40 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         ).reshape(attn_q.shape[0], -1)
         output, local_aux_attn = split_main_aux_output(attn, global_len, aux_len, aux_first)
 
+        aux_output = None
+        aux_gather_work = None
+        if async_aux_gather and local_aux_attn is not None:
+            aux_output, aux_gather_work = self._gather_aux(
+                local_aux_attn,
+                world_size,
+                seq_p_group,
+                reuse_buffers=reuse_aux_gather_buffers,
+                cache_max=aux_gather_buffer_cache_max,
+                async_op=True,
+            )
+
         packed_attn = prepost.pack_attn(output, local_len, world_size, shard_heads, hidden_dims, quant_scheme)
+        # Collectives on the same process group must remain ordered. The async
+        # auxiliary gather may overlap with the local packing above, but must
+        # finish before the output all-to-all starts.
+        if aux_gather_work is not None:
+            aux_gather_work.wait()
+            aux_output = torch.cat(aux_output, dim=1)
         exchanged_attn = UlyssesAttnWeight._exchange_packed(packed_attn, a2a, seq_p_group)
         output = prepost.unpack_attn(exchanged_attn, attn.dtype, hidden_dims)
 
-        aux_output = UlyssesAttnWeight._gather_aux(local_aux_attn, world_size, seq_p_group)
+        if not async_aux_gather:
+            aux_output, _ = self._gather_aux(
+                local_aux_attn,
+                world_size,
+                seq_p_group,
+                reuse_buffers=reuse_aux_gather_buffers,
+                cache_max=aux_gather_buffer_cache_max,
+            )
         return output, aux_output
 
-    @staticmethod
     def _apply_head_pipeline(
+        self,
         prepost,
         a2a,
         q,
@@ -239,6 +274,9 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         world_size,
         rank,
         attention_kwargs,
+        async_aux_gather,
+        reuse_aux_gather_buffers,
+        aux_gather_buffer_cache_max,
     ):
         local_len, q_heads, hidden_dims = q.shape
         shard_heads = q_heads // world_size
@@ -303,7 +341,14 @@ class UlyssesAttnWeight(AttnWeightTemplate):
 
         if local_aux_heads:
             local_aux = torch.cat(local_aux_heads, dim=1)
-            aux_output = UlyssesAttnWeight._gather_aux(local_aux, world_size, seq_p_group).reshape(local_aux.shape[0], -1)
+            aux_output, _ = self._gather_aux(
+                local_aux,
+                world_size,
+                seq_p_group,
+                reuse_buffers=reuse_aux_gather_buffers,
+                cache_max=aux_gather_buffer_cache_max,
+            )
+            aux_output = aux_output.reshape(local_aux.shape[0], -1)
         else:
             aux_output = None
         return output, aux_output
@@ -347,13 +392,31 @@ class UlyssesAttnWeight(AttnWeightTemplate):
         dense_kwargs.setdefault("max_seqlen_kv", k.shape[0])
         return dense_kwargs
 
-    @staticmethod
-    def _gather_aux(local_aux, world_size, group):
+    def _gather_aux(self, local_aux, world_size, group, reuse_buffers=False, cache_max=16, async_op=False):
         if local_aux is None:
-            return None
-        gathered = [torch.empty_like(local_aux) for _ in range(world_size)]
-        dist.all_gather(gathered, local_aux, group=group)
-        return torch.cat(gathered, dim=1)
+            return None, None
+        gathered = self._get_aux_gather_buffers(local_aux, world_size, reuse_buffers, cache_max)
+        work = dist.all_gather(gathered, local_aux, group=group, async_op=async_op)
+        if async_op:
+            return gathered, work
+        return torch.cat(gathered, dim=1), work
+
+    def _get_aux_gather_buffers(self, tensor, world_size, reuse_buffers, cache_max):
+        if not reuse_buffers:
+            return [torch.empty_like(tensor) for _ in range(world_size)]
+
+        try:
+            cache_max = max(1, int(cache_max))
+        except (TypeError, ValueError):
+            cache_max = 16
+        key = (world_size, tuple(tensor.shape), tensor.dtype, tensor.device)
+        buffers = self._aux_gather_buffers.get(key)
+        if buffers is None:
+            if len(self._aux_gather_buffers) >= cache_max:
+                self._aux_gather_buffers.clear()
+            buffers = [torch.empty_like(tensor) for _ in range(world_size)]
+            self._aux_gather_buffers[key] = buffers
+        return buffers
 
     def _resolve_options(self, prepost_backend, a2a_backend, q, k, quant_scheme, qkv_fusion, head_parallel):
         prepost_name = "torch" if prepost_backend is None else prepost_backend

--- a/lightx2v/common/ops/attn/utils/all2all.py
+++ b/lightx2v/common/ops/attn/utils/all2all.py
@@ -1,6 +1,3 @@
-import os
-from contextlib import nullcontext
-
 import torch
 import torch.distributed as dist
 
@@ -10,17 +7,6 @@ try:
 except ImportError:
     quant_fp4_sage3 = None
     dequant_fp4_sage3 = None
-
-
-def _env_flag(name, default="0"):
-    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
-
-
-_PROFILE_RANGES_ENABLED = _env_flag("LIGHTX2V_ULYSSES_PROFILE_RANGES")
-
-
-def _profile_range(name):
-    return torch.profiler.record_function(f"ulysses::{name}") if _PROFILE_RANGES_ENABLED else nullcontext()
 
 
 def _fp8_all_to_all(input_t, group=None):
@@ -132,26 +118,23 @@ def all2all_head2seq(input, group=None):
     shard_seq_len = seq_len // world_size  # 计算每个进程处理的序列长度
 
     # 重塑输入张量以便进行 all-to-all 操作
-    with _profile_range("head2seq_pre_layout"):
-        input_t = (
-            input.reshape(world_size, shard_seq_len, shard_heads, hidden_dims)  # 重塑为 [world_size, shard_seq_len, shard_heads, hidden_dims]
-            .transpose(1, 2)  # 转置以便进行 all-to-all 操作
-            .contiguous()  # 确保内存连续
-            .reshape(world_size, shard_heads, shard_seq_len, hidden_dims)  # 再次重塑为 [world_size, shard_heads, shard_seq_len, hidden_dims]
-        )
+    input_t = (
+        input.reshape(world_size, shard_seq_len, shard_heads, hidden_dims)  # 重塑为 [world_size, shard_seq_len, shard_heads, hidden_dims]
+        .transpose(1, 2)  # 转置以便进行 all-to-all 操作
+        .contiguous()  # 确保内存连续
+        .reshape(world_size, shard_heads, shard_seq_len, hidden_dims)  # 再次重塑为 [world_size, shard_heads, shard_seq_len, hidden_dims]
+    )
 
     # 创建一个与输入张量相同形状的输出张量
     output = torch.empty_like(input_t)
 
     # 执行 all-to-all 操作，将输入张量的内容分发到所有进程
-    with _profile_range("head2seq_all_to_all"):
-        dist.all_to_all_single(output, input_t, group=group)
+    dist.all_to_all_single(output, input_t, group=group)
 
-    with _profile_range("head2seq_post_layout"):
-        # 重塑输出张量为 [heads, shard_seq_len, hidden_dims] 形状
-        output = output.reshape(heads, shard_seq_len, hidden_dims)
+    # 重塑输出张量为 [heads, shard_seq_len, hidden_dims] 形状
+    output = output.reshape(heads, shard_seq_len, hidden_dims)
 
-        # 转置输出张量并重塑为 [shard_seq_len, heads, hidden_dims] 形状
-        output = output.transpose(0, 1).contiguous().reshape(shard_seq_len, heads, hidden_dims)
+    # 转置输出张量并重塑为 [shard_seq_len, heads, hidden_dims] 形状
+    output = output.transpose(0, 1).contiguous().reshape(shard_seq_len, heads, hidden_dims)
 
     return output  # 返回转换后的输出张量

--- a/lightx2v/common/ops/attn/utils/all2all.py
+++ b/lightx2v/common/ops/attn/utils/all2all.py
@@ -1,3 +1,6 @@
+import os
+from contextlib import nullcontext
+
 import torch
 import torch.distributed as dist
 
@@ -7,6 +10,17 @@ try:
 except ImportError:
     quant_fp4_sage3 = None
     dequant_fp4_sage3 = None
+
+
+def _env_flag(name, default="0"):
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+_PROFILE_RANGES_ENABLED = _env_flag("LIGHTX2V_ULYSSES_PROFILE_RANGES")
+
+
+def _profile_range(name):
+    return torch.profiler.record_function(f"ulysses::{name}") if _PROFILE_RANGES_ENABLED else nullcontext()
 
 
 def _fp8_all_to_all(input_t, group=None):
@@ -118,23 +132,26 @@ def all2all_head2seq(input, group=None):
     shard_seq_len = seq_len // world_size  # 计算每个进程处理的序列长度
 
     # 重塑输入张量以便进行 all-to-all 操作
-    input_t = (
-        input.reshape(world_size, shard_seq_len, shard_heads, hidden_dims)  # 重塑为 [world_size, shard_seq_len, shard_heads, hidden_dims]
-        .transpose(1, 2)  # 转置以便进行 all-to-all 操作
-        .contiguous()  # 确保内存连续
-        .reshape(world_size, shard_heads, shard_seq_len, hidden_dims)  # 再次重塑为 [world_size, shard_heads, shard_seq_len, hidden_dims]
-    )
+    with _profile_range("head2seq_pre_layout"):
+        input_t = (
+            input.reshape(world_size, shard_seq_len, shard_heads, hidden_dims)  # 重塑为 [world_size, shard_seq_len, shard_heads, hidden_dims]
+            .transpose(1, 2)  # 转置以便进行 all-to-all 操作
+            .contiguous()  # 确保内存连续
+            .reshape(world_size, shard_heads, shard_seq_len, hidden_dims)  # 再次重塑为 [world_size, shard_heads, shard_seq_len, hidden_dims]
+        )
 
     # 创建一个与输入张量相同形状的输出张量
     output = torch.empty_like(input_t)
 
     # 执行 all-to-all 操作，将输入张量的内容分发到所有进程
-    dist.all_to_all_single(output, input_t, group=group)
+    with _profile_range("head2seq_all_to_all"):
+        dist.all_to_all_single(output, input_t, group=group)
 
-    # 重塑输出张量为 [heads, shard_seq_len, hidden_dims] 形状
-    output = output.reshape(heads, shard_seq_len, hidden_dims)
+    with _profile_range("head2seq_post_layout"):
+        # 重塑输出张量为 [heads, shard_seq_len, hidden_dims] 形状
+        output = output.reshape(heads, shard_seq_len, hidden_dims)
 
-    # 转置输出张量并重塑为 [shard_seq_len, heads, hidden_dims] 形状
-    output = output.transpose(0, 1).contiguous().reshape(shard_seq_len, heads, hidden_dims)
+        # 转置输出张量并重塑为 [shard_seq_len, heads, hidden_dims] 形状
+        output = output.transpose(0, 1).contiguous().reshape(shard_seq_len, heads, hidden_dims)
 
     return output  # 返回转换后的输出张量

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -111,11 +111,17 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.seq_p_fp8_comm = self.config["parallel"].get("seq_p_fp8_comm", False)
             self.seq_p_fp4_comm = self.config["parallel"].get("seq_p_fp4_comm", False)
             self.enable_head_parallel = self.config["parallel"].get("seq_p_head_parallel", False)
+            self.seq_p_tensor_fusion = self.config["parallel"].get("seq_p_tensor_fusion", False)
+            self.seq_p_split_qkv_input = _env_flag("LIGHTX2V_SEQ_P_SPLIT_QKV_INPUT")
+            self.seq_p_split_attn_output = _env_flag("LIGHTX2V_SEQ_P_SPLIT_ATTN_OUTPUT")
         else:
             self.seq_p_group = None
             self.seq_p_fp8_comm = False
             self.seq_p_fp4_comm = False
             self.enable_head_parallel = False
+            self.seq_p_tensor_fusion = False
+            self.seq_p_split_qkv_input = False
+            self.seq_p_split_attn_output = False
         self.infer_func = self.infer_without_offload
         if self.config.get("modulate_type", "triton") == "triton":
             self.modulate_func = fuse_scale_shift_kernel
@@ -128,8 +134,15 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
         self.compile_before_attn = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
         self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
+        self.share_qkv_act_quant = _env_flag("LIGHTX2V_INT8_SHARE_QKV_ACT_QUANT")
         self._compiled_non_attn = {}
         self._compile_non_attn_failed = set()
+        if self.share_qkv_act_quant:
+            logger.info("[Quant] Reusing dynamic activation quantization for consecutive Q/K/V projections")
+        if self.seq_p_split_qkv_input:
+            logger.info("[Ulysses] Passing split img/txt QKV tensors to avoid pre-attention concat/slice copies")
+        if self.seq_p_split_attn_output:
+            logger.info("[Ulysses] Returning split img/txt attention outputs to avoid post-attention concat/slice copies")
         if self.compile_non_attn or self.compile_before_attn:
             try:
                 torch._dynamo.config.suppress_errors = True
@@ -174,6 +187,22 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         txt = self._infer_txt_branch_after_attn(weights, txt_attn, infer_module_out.txt, txt_branch_out)
         return img, txt
 
+    def _apply_qkv(self, q_weight, k_weight, v_weight, hidden_states):
+        use_shared_quant = (
+            self.share_qkv_act_quant
+            and hasattr(q_weight, "prepare_quantized_input")
+            and hasattr(q_weight, "apply_quantized_input")
+            and not any(getattr(weight, "use_bf16_fallback", False) for weight in (q_weight, k_weight, v_weight))
+        )
+        if use_shared_quant:
+            quantized_input = q_weight.prepare_quantized_input(hidden_states)
+            return (
+                q_weight.apply_quantized_input(hidden_states, quantized_input),
+                k_weight.apply_quantized_input(hidden_states, quantized_input),
+                v_weight.apply_quantized_input(hidden_states, quantized_input),
+            )
+        return q_weight.apply(hidden_states), k_weight.apply(hidden_states), v_weight.apply(hidden_states)
+
     @torch.no_grad()
     def _infer_img_branch_before_attn(self, weights, infer_module_out):
         return self._run_non_attn_branch(
@@ -195,9 +224,12 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         ) = weights.img_branch.img_mod.apply(infer_module_out.vec).chunk(6, dim=-1)
         img_modulated = weights.img_branch.img_norm1.apply(infer_module_out.img.squeeze(0))
         img_modulated = self.modulate_func(img_modulated, scale=img_mod1_scale, shift=img_mod1_shift).squeeze(0)
-        img_q = weights.img_branch.img_attn_q.apply(img_modulated)
-        img_k = weights.img_branch.img_attn_k.apply(img_modulated)
-        img_v = weights.img_branch.img_attn_v.apply(img_modulated)
+        img_q, img_k, img_v = self._apply_qkv(
+            weights.img_branch.img_attn_q,
+            weights.img_branch.img_attn_k,
+            weights.img_branch.img_attn_v,
+            img_modulated,
+        )
         img_q = rearrange(img_q, "L (H D) -> L H D", H=self.heads_num)
         img_k = rearrange(img_k, "L (H D) -> L H D", H=self.heads_num)
         img_v = rearrange(img_v, "L (H D) -> L H D", H=self.heads_num)
@@ -237,9 +269,12 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         ) = weights.txt_branch.txt_mod.apply(infer_module_out.vec).chunk(6, dim=-1)
         txt_modulated = weights.txt_branch.txt_norm1.apply(infer_module_out.txt.squeeze(0))
         txt_modulated = self.modulate_func(txt_modulated, scale=txt_mod1_scale, shift=txt_mod1_shift).squeeze(0)
-        txt_q = weights.txt_branch.txt_attn_q.apply(txt_modulated)
-        txt_k = weights.txt_branch.txt_attn_k.apply(txt_modulated)
-        txt_v = weights.txt_branch.txt_attn_v.apply(txt_modulated)
+        txt_q, txt_k, txt_v = self._apply_qkv(
+            weights.txt_branch.txt_attn_q,
+            weights.txt_branch.txt_attn_k,
+            weights.txt_branch.txt_attn_v,
+            txt_modulated,
+        )
         txt_q = rearrange(txt_q, "L (H D) -> L H D", H=self.heads_num)
         txt_k = rearrange(txt_k, "L (H D) -> L H D", H=self.heads_num)
         txt_v = rearrange(txt_v, "L (H D) -> L H D", H=self.heads_num)
@@ -260,29 +295,51 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
     @torch.no_grad()
     def _infer_attn(self, weights, img_q, img_k, img_v, txt_q, txt_k, txt_v):
         img_seqlen = img_q.shape[1]
-        query = torch.cat([img_q, txt_q], dim=1)
-        key = torch.cat([img_k, txt_k], dim=1)
-        value = torch.cat([img_v, txt_v], dim=1)
-        seqlen = query.shape[1]
+        txt_seqlen = txt_q.shape[1]
+        seqlen = img_seqlen + txt_seqlen
         cu_seqlens_qkv = torch.tensor([0, seqlen], dtype=torch.int32, device="cpu")
 
-        if self.config["seq_parallel"]:
+        if self.config["seq_parallel"] and self.seq_p_split_qkv_input:
             attn_out = weights.self_attention_parallel.apply(
-                q=query,
-                k=key,
-                v=value,
+                q=(img_q, txt_q),
+                k=(img_k, txt_k),
+                v=(img_v, txt_v),
                 slice_qkv_len=img_seqlen,
                 cu_seqlens_qkv=cu_seqlens_qkv,
                 attention_module=weights.self_attention,
                 seq_p_group=self.seq_p_group,
                 use_fp8_comm=self.seq_p_fp8_comm,
                 use_fp4_comm=self.seq_p_fp4_comm,
+                use_tensor_fusion=self.seq_p_tensor_fusion,
                 enable_head_parallel=self.enable_head_parallel,
+                return_split_output=self.seq_p_split_attn_output,
             )
         else:
-            attn_out = weights.self_attention.apply(q=query, k=key, v=value, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=seqlen, max_seqlen_kv=seqlen)
+            query = torch.cat([img_q, txt_q], dim=1)
+            key = torch.cat([img_k, txt_k], dim=1)
+            value = torch.cat([img_v, txt_v], dim=1)
+            if self.config["seq_parallel"]:
+                attn_out = weights.self_attention_parallel.apply(
+                    q=query,
+                    k=key,
+                    v=value,
+                    slice_qkv_len=img_seqlen,
+                    cu_seqlens_qkv=cu_seqlens_qkv,
+                    attention_module=weights.self_attention,
+                    seq_p_group=self.seq_p_group,
+                    use_fp8_comm=self.seq_p_fp8_comm,
+                    use_fp4_comm=self.seq_p_fp4_comm,
+                    use_tensor_fusion=self.seq_p_tensor_fusion,
+                    enable_head_parallel=self.enable_head_parallel,
+                    return_split_output=self.seq_p_split_attn_output,
+                )
+            else:
+                attn_out = weights.self_attention.apply(q=query, k=key, v=value, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=seqlen, max_seqlen_kv=seqlen)
 
-        img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
+        if isinstance(attn_out, (tuple, list)):
+            img_attn, txt_attn = attn_out
+        else:
+            img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
         return img_attn, txt_attn
 
     def _run_non_attn_branch(self, graph_name, eager_fn, *args, compile_enabled=None):

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -155,11 +155,7 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
                 torch._dynamo.config.suppress_errors = True
             except Exception as exc:
                 logger.warning(f"[Compile] Unable to enable Dynamo suppress_errors: {exc}")
-            logger.info(
-                "[Compile] Hunyuan DiT branch compile: "
-                f"after_attn={self.compile_non_attn}, before_attn={self.compile_before_attn}, "
-                f"mode={self.compile_non_attn_mode}"
-            )
+            logger.info(f"[Compile] Hunyuan DiT branch compile: after_attn={self.compile_non_attn}, before_attn={self.compile_before_attn}, mode={self.compile_non_attn_mode}")
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -132,7 +132,8 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         else:
             self.apply_rope_func = apply_hunyuan_rope_with_torch
         self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
-        self.compile_before_attn = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
+        self.compile_before_attn_requested = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
+        self.compile_before_attn = self.compile_before_attn_requested and _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE")
         self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
         self.share_qkv_act_quant = _env_flag("LIGHTX2V_INT8_SHARE_QKV_ACT_QUANT")
         self._compiled_non_attn = {}
@@ -143,6 +144,12 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             logger.info("[Ulysses] Passing split img/txt QKV tensors to avoid pre-attention concat/slice copies")
         if self.seq_p_split_attn_output:
             logger.info("[Ulysses] Returning split img/txt attention outputs to avoid post-attention concat/slice copies")
+        if self.compile_before_attn_requested and not self.compile_before_attn:
+            logger.warning(
+                "[Compile] LIGHTX2V_COMPILE_DIT_BEFORE_ATTN is ignored unless "
+                "LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE=1 is also set; before-attn graphs carry "
+                "block-specific weight objects and can grow Dynamo caches quickly."
+            )
         if self.compile_non_attn or self.compile_before_attn:
             try:
                 torch._dynamo.config.suppress_errors = True
@@ -191,7 +198,7 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         use_shared_quant = (
             self.share_qkv_act_quant
             and hasattr(q_weight, "prepare_quantized_input")
-            and hasattr(q_weight, "apply_quantized_input")
+            and all(hasattr(weight, "apply_quantized_input") for weight in (q_weight, k_weight, v_weight))
             and not any(getattr(weight, "use_bf16_fallback", False) for weight in (q_weight, k_weight, v_weight))
         )
         if use_shared_quant:

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -1,4 +1,3 @@
-import os
 from typing import Tuple
 
 import torch
@@ -38,10 +37,6 @@ def apply_gate(x, gate=None, tanh=False):
         return x * gate.unsqueeze(1).tanh()
     else:
         return x * gate.unsqueeze(1)
-
-
-def _env_flag(name, default="0"):
-    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def apply_hunyuan_rope_with_flashinfer(
@@ -106,14 +101,18 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         self.config = config
         self.double_blocks_num = config["mm_double_blocks_depth"]
         self.heads_num = config["heads_num"]
+        parallel_config = self.config.get("parallel", {})
         if self.config["seq_parallel"]:
             self.seq_p_group = self.config.get("device_mesh").get_group(mesh_dim="seq_p")
-            self.seq_p_fp8_comm = self.config["parallel"].get("seq_p_fp8_comm", False)
-            self.seq_p_fp4_comm = self.config["parallel"].get("seq_p_fp4_comm", False)
-            self.enable_head_parallel = self.config["parallel"].get("seq_p_head_parallel", False)
-            self.seq_p_tensor_fusion = self.config["parallel"].get("seq_p_tensor_fusion", False)
-            self.seq_p_split_qkv_input = _env_flag("LIGHTX2V_SEQ_P_SPLIT_QKV_INPUT")
-            self.seq_p_split_attn_output = _env_flag("LIGHTX2V_SEQ_P_SPLIT_ATTN_OUTPUT")
+            self.seq_p_fp8_comm = parallel_config.get("seq_p_fp8_comm", False)
+            self.seq_p_fp4_comm = parallel_config.get("seq_p_fp4_comm", False)
+            self.enable_head_parallel = parallel_config.get("seq_p_head_parallel", False)
+            self.seq_p_tensor_fusion = parallel_config.get("seq_p_tensor_fusion", False)
+            self.seq_p_split_qkv_input = parallel_config.get("seq_p_split_qkv_input", False)
+            self.seq_p_split_attn_output = parallel_config.get("seq_p_split_attn_output", False)
+            self.seq_p_async_text_gather = parallel_config.get("seq_p_async_text_gather", False)
+            self.seq_p_reuse_text_gather_buffers = parallel_config.get("seq_p_reuse_text_gather_buffers", False)
+            self.seq_p_text_gather_buffer_cache_max = parallel_config.get("seq_p_text_gather_buffer_cache_max", 16)
         else:
             self.seq_p_group = None
             self.seq_p_fp8_comm = False
@@ -122,6 +121,9 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.seq_p_tensor_fusion = False
             self.seq_p_split_qkv_input = False
             self.seq_p_split_attn_output = False
+            self.seq_p_async_text_gather = False
+            self.seq_p_reuse_text_gather_buffers = False
+            self.seq_p_text_gather_buffer_cache_max = 16
         self.infer_func = self.infer_without_offload
         if self.config.get("modulate_type", "triton") == "triton":
             self.modulate_func = fuse_scale_shift_kernel
@@ -131,11 +133,11 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.apply_rope_func = apply_hunyuan_rope_with_flashinfer
         else:
             self.apply_rope_func = apply_hunyuan_rope_with_torch
-        self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
-        self.compile_before_attn_requested = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
-        self.compile_before_attn = self.compile_before_attn_requested and _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE")
-        self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
-        self.share_qkv_act_quant = _env_flag("LIGHTX2V_INT8_SHARE_QKV_ACT_QUANT")
+        self.compile_non_attn = self.config.get("compile_dit_non_attn", False)
+        self.compile_before_attn_requested = self.config.get("compile_dit_before_attn", False)
+        self.compile_before_attn = self.compile_before_attn_requested and self.config.get("compile_dit_before_attn_unsafe", False)
+        self.compile_non_attn_mode = self.config.get("compile_dit_mode", "reduce-overhead")
+        self.share_qkv_act_quant = self.config.get("share_qkv_act_quant", False)
         self._compiled_non_attn = {}
         self._compile_non_attn_failed = set()
         if self.share_qkv_act_quant:
@@ -146,8 +148,8 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             logger.info("[Ulysses] Returning split img/txt attention outputs to avoid post-attention concat/slice copies")
         if self.compile_before_attn_requested and not self.compile_before_attn:
             logger.warning(
-                "[Compile] LIGHTX2V_COMPILE_DIT_BEFORE_ATTN is ignored unless "
-                "LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE=1 is also set; before-attn graphs carry "
+                "[Compile] compile_dit_before_attn is ignored unless "
+                "compile_dit_before_attn_unsafe is also set; before-attn graphs carry "
                 "block-specific weight objects and can grow Dynamo caches quickly."
             )
         if self.compile_non_attn or self.compile_before_attn:
@@ -316,6 +318,9 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
                 use_tensor_fusion=self.seq_p_tensor_fusion,
                 enable_head_parallel=self.enable_head_parallel,
                 return_split_output=self.seq_p_split_attn_output,
+                async_text_gather=self.seq_p_async_text_gather,
+                reuse_text_gather_buffers=self.seq_p_reuse_text_gather_buffers,
+                text_gather_buffer_cache_max=self.seq_p_text_gather_buffer_cache_max,
             )
         else:
             query = torch.cat([img_q, txt_q], dim=1)
@@ -335,6 +340,9 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
                     use_tensor_fusion=self.seq_p_tensor_fusion,
                     enable_head_parallel=self.enable_head_parallel,
                     return_split_output=self.seq_p_split_attn_output,
+                    async_text_gather=self.seq_p_async_text_gather,
+                    reuse_text_gather_buffers=self.seq_p_reuse_text_gather_buffers,
+                    text_gather_buffer_cache_max=self.seq_p_text_gather_buffer_cache_max,
                 )
             else:
                 attn_out = weights.self_attention.apply(q=query, k=key, v=value, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=seqlen, max_seqlen_kv=seqlen)

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -1,8 +1,10 @@
+import os
 from typing import Tuple
 
 import torch
 import torch.nn.functional as F
 from einops import rearrange
+from loguru import logger
 
 try:
     from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
@@ -36,6 +38,10 @@ def apply_gate(x, gate=None, tanh=False):
         return x * gate.unsqueeze(1).tanh()
     else:
         return x * gate.unsqueeze(1)
+
+
+def _env_flag(name, default="0"):
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def apply_hunyuan_rope_with_flashinfer(
@@ -119,6 +125,21 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.apply_rope_func = apply_hunyuan_rope_with_flashinfer
         else:
             self.apply_rope_func = apply_hunyuan_rope_with_torch
+        self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
+        self.compile_before_attn = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
+        self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
+        self._compiled_non_attn = {}
+        self._compile_non_attn_failed = set()
+        if self.compile_non_attn or self.compile_before_attn:
+            try:
+                torch._dynamo.config.suppress_errors = True
+            except Exception as exc:
+                logger.warning(f"[Compile] Unable to enable Dynamo suppress_errors: {exc}")
+            logger.info(
+                "[Compile] Hunyuan DiT branch compile: "
+                f"after_attn={self.compile_non_attn}, before_attn={self.compile_before_attn}, "
+                f"mode={self.compile_non_attn_mode}"
+            )
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler
@@ -155,6 +176,15 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
 
     @torch.no_grad()
     def _infer_img_branch_before_attn(self, weights, infer_module_out):
+        return self._run_non_attn_branch(
+            "img_before_attn",
+            self._infer_img_branch_before_attn_eager,
+            weights,
+            infer_module_out,
+            compile_enabled=self.compile_before_attn,
+        )
+
+    def _infer_img_branch_before_attn_eager(self, weights, infer_module_out):
         (
             img_mod1_shift,
             img_mod1_scale,
@@ -188,6 +218,15 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
 
     @torch.no_grad()
     def _infer_txt_branch_before_attn(self, weights, infer_module_out):
+        return self._run_non_attn_branch(
+            "txt_before_attn",
+            self._infer_txt_branch_before_attn_eager,
+            weights,
+            infer_module_out,
+            compile_enabled=self.compile_before_attn,
+        )
+
+    def _infer_txt_branch_before_attn_eager(self, weights, infer_module_out):
         (
             txt_mod1_shift,
             txt_mod1_scale,
@@ -246,8 +285,36 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
         return img_attn, txt_attn
 
+    def _run_non_attn_branch(self, graph_name, eager_fn, *args, compile_enabled=None):
+        if compile_enabled is None:
+            compile_enabled = self.compile_non_attn
+        if not compile_enabled or graph_name in self._compile_non_attn_failed:
+            return eager_fn(*args)
+
+        compiled_fn = self._compiled_non_attn.get(graph_name)
+        if compiled_fn is None:
+            try:
+                compiled_fn = torch.compile(eager_fn, fullgraph=False, dynamic=False, mode=self.compile_non_attn_mode)
+                self._compiled_non_attn[graph_name] = compiled_fn
+                logger.info(f"[Compile] Created compiled wrapper for {graph_name}")
+            except Exception as exc:
+                self._compile_non_attn_failed.add(graph_name)
+                logger.warning(f"[Compile] Failed to create compiled wrapper for {graph_name}, fallback to eager: {exc}")
+                return eager_fn(*args)
+
+        try:
+            return compiled_fn(*args)
+        except Exception as exc:
+            self._compile_non_attn_failed.add(graph_name)
+            self._compiled_non_attn.pop(graph_name, None)
+            logger.warning(f"[Compile] Runtime failure in {graph_name}, disabling this graph and falling back to eager: {exc}")
+            return eager_fn(*args)
+
     @torch.no_grad()
     def _infer_img_branch_after_attn(self, weights, img_attn, img, img_branch_out):
+        return self._run_non_attn_branch("img_after_attn", self._infer_img_branch_after_attn_eager, weights, img_attn, img, img_branch_out)
+
+    def _infer_img_branch_after_attn_eager(self, weights, img_attn, img, img_branch_out):
         img = img + apply_gate(weights.img_branch.img_attn_proj.apply(img_attn).unsqueeze(0), gate=img_branch_out.img_mod1_gate)
         out = weights.img_branch.img_mlp_fc1.apply(
             self.modulate_func(weights.img_branch.img_norm2.apply(img.squeeze(0)), scale=img_branch_out.img_mod2_scale, shift=img_branch_out.img_mod2_shift).squeeze(0)
@@ -258,6 +325,9 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
 
     @torch.no_grad()
     def _infer_txt_branch_after_attn(self, weights, txt_attn, txt, txt_branch_out):
+        return self._run_non_attn_branch("txt_after_attn", self._infer_txt_branch_after_attn_eager, weights, txt_attn, txt, txt_branch_out)
+
+    def _infer_txt_branch_after_attn_eager(self, weights, txt_attn, txt, txt_branch_out):
         txt = txt + apply_gate(weights.txt_branch.txt_attn_proj.apply(txt_attn).unsqueeze(0), gate=txt_branch_out.txt_mod1_gate)
         out = weights.txt_branch.txt_mlp_fc1.apply(
             self.modulate_func(weights.txt_branch.txt_norm2.apply(txt.squeeze(0)), scale=txt_branch_out.txt_mod2_scale, shift=txt_branch_out.txt_mod2_shift).squeeze(0)

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -73,7 +73,8 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         else:
             self.modulate_func = modulate
         self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
-        self.compile_before_attn = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
+        self.compile_before_attn_requested = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
+        self.compile_before_attn = self.compile_before_attn_requested and _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE")
         self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
         self.share_qkv_act_quant = _env_flag("LIGHTX2V_INT8_SHARE_QKV_ACT_QUANT")
         self._compiled_non_attn = {}
@@ -84,6 +85,12 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             logger.info("[Ulysses] Passing split img/txt QKV tensors to avoid pre-attention concat/slice copies")
         if self.seq_p_split_attn_output:
             logger.info("[Ulysses] Returning split img/txt attention outputs to avoid post-attention concat/slice copies")
+        if self.compile_before_attn_requested and not self.compile_before_attn:
+            logger.warning(
+                "[Compile] LIGHTX2V_COMPILE_DIT_BEFORE_ATTN is ignored unless "
+                "LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE=1 is also set; before-attn graphs carry "
+                "block-specific weight objects and can grow Dynamo caches quickly."
+            )
         if self.compile_non_attn or self.compile_before_attn:
             try:
                 torch._dynamo.config.suppress_errors = True
@@ -132,7 +139,7 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         use_shared_quant = (
             self.share_qkv_act_quant
             and hasattr(q_weight, "prepare_quantized_input")
-            and hasattr(q_weight, "apply_quantized_input")
+            and all(hasattr(weight, "apply_quantized_input") for weight in (q_weight, k_weight, v_weight))
             and not any(getattr(weight, "use_bf16_fallback", False) for weight in (q_weight, k_weight, v_weight))
         )
         if use_shared_quant:

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -1,6 +1,9 @@
+import os
+
 import torch
 import torch.nn.functional as F
 from einops import rearrange
+from loguru import logger
 
 from lightx2v.common.transformer_infer.transformer_infer import BaseTransformerInfer
 
@@ -39,6 +42,10 @@ def _apply_hunyuan_rope(module, xq, xk, cos_sin_cache):
     return q.view(q_shape), k.view(k_shape)
 
 
+def _env_flag(name, default="0"):
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
 class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
     def __init__(self, config):
         self.config = config
@@ -59,6 +66,21 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.modulate_func = fuse_scale_shift_kernel
         else:
             self.modulate_func = modulate
+        self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
+        self.compile_before_attn = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
+        self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
+        self._compiled_non_attn = {}
+        self._compile_non_attn_failed = set()
+        if self.compile_non_attn or self.compile_before_attn:
+            try:
+                torch._dynamo.config.suppress_errors = True
+            except Exception as exc:
+                logger.warning(f"[Compile] Unable to enable Dynamo suppress_errors: {exc}")
+            logger.info(
+                "[Compile] Hunyuan DiT branch compile: "
+                f"after_attn={self.compile_non_attn}, before_attn={self.compile_before_attn}, "
+                f"mode={self.compile_non_attn_mode}"
+            )
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler
@@ -95,6 +117,15 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
 
     @torch.no_grad()
     def _infer_img_branch_before_attn(self, weights, infer_module_out):
+        return self._run_non_attn_branch(
+            "img_before_attn",
+            self._infer_img_branch_before_attn_eager,
+            weights,
+            infer_module_out,
+            compile_enabled=self.compile_before_attn,
+        )
+
+    def _infer_img_branch_before_attn_eager(self, weights, infer_module_out):
         (
             img_mod1_shift,
             img_mod1_scale,
@@ -128,6 +159,15 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
 
     @torch.no_grad()
     def _infer_txt_branch_before_attn(self, weights, infer_module_out):
+        return self._run_non_attn_branch(
+            "txt_before_attn",
+            self._infer_txt_branch_before_attn_eager,
+            weights,
+            infer_module_out,
+            compile_enabled=self.compile_before_attn,
+        )
+
+    def _infer_txt_branch_before_attn_eager(self, weights, infer_module_out):
         (
             txt_mod1_shift,
             txt_mod1_scale,
@@ -186,8 +226,36 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
         return img_attn, txt_attn
 
+    def _run_non_attn_branch(self, graph_name, eager_fn, *args, compile_enabled=None):
+        if compile_enabled is None:
+            compile_enabled = self.compile_non_attn
+        if not compile_enabled or graph_name in self._compile_non_attn_failed:
+            return eager_fn(*args)
+
+        compiled_fn = self._compiled_non_attn.get(graph_name)
+        if compiled_fn is None:
+            try:
+                compiled_fn = torch.compile(eager_fn, fullgraph=False, dynamic=False, mode=self.compile_non_attn_mode)
+                self._compiled_non_attn[graph_name] = compiled_fn
+                logger.info(f"[Compile] Created compiled wrapper for {graph_name}")
+            except Exception as exc:
+                self._compile_non_attn_failed.add(graph_name)
+                logger.warning(f"[Compile] Failed to create compiled wrapper for {graph_name}, fallback to eager: {exc}")
+                return eager_fn(*args)
+
+        try:
+            return compiled_fn(*args)
+        except Exception as exc:
+            self._compile_non_attn_failed.add(graph_name)
+            self._compiled_non_attn.pop(graph_name, None)
+            logger.warning(f"[Compile] Runtime failure in {graph_name}, disabling this graph and falling back to eager: {exc}")
+            return eager_fn(*args)
+
     @torch.no_grad()
     def _infer_img_branch_after_attn(self, weights, img_attn, img, img_branch_out):
+        return self._run_non_attn_branch("img_after_attn", self._infer_img_branch_after_attn_eager, weights, img_attn, img, img_branch_out)
+
+    def _infer_img_branch_after_attn_eager(self, weights, img_attn, img, img_branch_out):
         img = img + apply_gate(weights.img_branch.img_attn_proj.apply(img_attn).unsqueeze(0), gate=img_branch_out.img_mod1_gate)
         out = weights.img_branch.img_mlp_fc1.apply(
             self.modulate_func(weights.img_branch.img_norm2.apply(img.squeeze(0)), scale=img_branch_out.img_mod2_scale, shift=img_branch_out.img_mod2_shift).squeeze(0)
@@ -198,6 +266,9 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
 
     @torch.no_grad()
     def _infer_txt_branch_after_attn(self, weights, txt_attn, txt, txt_branch_out):
+        return self._run_non_attn_branch("txt_after_attn", self._infer_txt_branch_after_attn_eager, weights, txt_attn, txt, txt_branch_out)
+
+    def _infer_txt_branch_after_attn_eager(self, weights, txt_attn, txt, txt_branch_out):
         txt = txt + apply_gate(weights.txt_branch.txt_attn_proj.apply(txt_attn).unsqueeze(0), gate=txt_branch_out.txt_mod1_gate)
         out = weights.txt_branch.txt_mlp_fc1.apply(
             self.modulate_func(weights.txt_branch.txt_norm2.apply(txt.squeeze(0)), scale=txt_branch_out.txt_mod2_scale, shift=txt_branch_out.txt_mod2_shift).squeeze(0)

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -56,11 +56,17 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.seq_p_fp8_comm = self.config["parallel"].get("seq_p_fp8_comm", False)
             self.seq_p_fp4_comm = self.config["parallel"].get("seq_p_fp4_comm", False)
             self.enable_head_parallel = self.config["parallel"].get("seq_p_head_parallel", False)
+            self.seq_p_tensor_fusion = self.config["parallel"].get("seq_p_tensor_fusion", False)
+            self.seq_p_split_qkv_input = _env_flag("LIGHTX2V_SEQ_P_SPLIT_QKV_INPUT")
+            self.seq_p_split_attn_output = _env_flag("LIGHTX2V_SEQ_P_SPLIT_ATTN_OUTPUT")
         else:
             self.seq_p_group = None
             self.seq_p_fp8_comm = False
             self.seq_p_fp4_comm = False
             self.enable_head_parallel = False
+            self.seq_p_tensor_fusion = False
+            self.seq_p_split_qkv_input = False
+            self.seq_p_split_attn_output = False
         self.infer_func = self.infer_without_offload
         if self.config.get("modulate_type", "triton") == "triton":
             self.modulate_func = fuse_scale_shift_kernel
@@ -69,8 +75,15 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
         self.compile_before_attn = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
         self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
+        self.share_qkv_act_quant = _env_flag("LIGHTX2V_INT8_SHARE_QKV_ACT_QUANT")
         self._compiled_non_attn = {}
         self._compile_non_attn_failed = set()
+        if self.share_qkv_act_quant:
+            logger.info("[Quant] Reusing dynamic activation quantization for consecutive Q/K/V projections")
+        if self.seq_p_split_qkv_input:
+            logger.info("[Ulysses] Passing split img/txt QKV tensors to avoid pre-attention concat/slice copies")
+        if self.seq_p_split_attn_output:
+            logger.info("[Ulysses] Returning split img/txt attention outputs to avoid post-attention concat/slice copies")
         if self.compile_non_attn or self.compile_before_attn:
             try:
                 torch._dynamo.config.suppress_errors = True
@@ -115,6 +128,22 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         txt = self._infer_txt_branch_after_attn(weights, txt_attn, infer_module_out.txt, txt_branch_out)
         return img, txt
 
+    def _apply_qkv(self, q_weight, k_weight, v_weight, hidden_states):
+        use_shared_quant = (
+            self.share_qkv_act_quant
+            and hasattr(q_weight, "prepare_quantized_input")
+            and hasattr(q_weight, "apply_quantized_input")
+            and not any(getattr(weight, "use_bf16_fallback", False) for weight in (q_weight, k_weight, v_weight))
+        )
+        if use_shared_quant:
+            quantized_input = q_weight.prepare_quantized_input(hidden_states)
+            return (
+                q_weight.apply_quantized_input(hidden_states, quantized_input),
+                k_weight.apply_quantized_input(hidden_states, quantized_input),
+                v_weight.apply_quantized_input(hidden_states, quantized_input),
+            )
+        return q_weight.apply(hidden_states), k_weight.apply(hidden_states), v_weight.apply(hidden_states)
+
     @torch.no_grad()
     def _infer_img_branch_before_attn(self, weights, infer_module_out):
         return self._run_non_attn_branch(
@@ -136,9 +165,12 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         ) = weights.img_branch.img_mod.apply(infer_module_out.vec).chunk(6, dim=-1)
         img_modulated = weights.img_branch.img_norm1.apply(infer_module_out.img.squeeze(0))
         img_modulated = self.modulate_func(img_modulated, scale=img_mod1_scale, shift=img_mod1_shift).squeeze(0)
-        img_q = weights.img_branch.img_attn_q.apply(img_modulated)
-        img_k = weights.img_branch.img_attn_k.apply(img_modulated)
-        img_v = weights.img_branch.img_attn_v.apply(img_modulated)
+        img_q, img_k, img_v = self._apply_qkv(
+            weights.img_branch.img_attn_q,
+            weights.img_branch.img_attn_k,
+            weights.img_branch.img_attn_v,
+            img_modulated,
+        )
         img_q = rearrange(img_q, "L (H D) -> L H D", H=self.heads_num)
         img_k = rearrange(img_k, "L (H D) -> L H D", H=self.heads_num)
         img_v = rearrange(img_v, "L (H D) -> L H D", H=self.heads_num)
@@ -178,9 +210,12 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         ) = weights.txt_branch.txt_mod.apply(infer_module_out.vec).chunk(6, dim=-1)
         txt_modulated = weights.txt_branch.txt_norm1.apply(infer_module_out.txt.squeeze(0))
         txt_modulated = self.modulate_func(txt_modulated, scale=txt_mod1_scale, shift=txt_mod1_shift).squeeze(0)
-        txt_q = weights.txt_branch.txt_attn_q.apply(txt_modulated)
-        txt_k = weights.txt_branch.txt_attn_k.apply(txt_modulated)
-        txt_v = weights.txt_branch.txt_attn_v.apply(txt_modulated)
+        txt_q, txt_k, txt_v = self._apply_qkv(
+            weights.txt_branch.txt_attn_q,
+            weights.txt_branch.txt_attn_k,
+            weights.txt_branch.txt_attn_v,
+            txt_modulated,
+        )
         txt_q = rearrange(txt_q, "L (H D) -> L H D", H=self.heads_num)
         txt_k = rearrange(txt_k, "L (H D) -> L H D", H=self.heads_num)
         txt_v = rearrange(txt_v, "L (H D) -> L H D", H=self.heads_num)
@@ -201,29 +236,51 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
     @torch.no_grad()
     def _infer_attn(self, weights, img_q, img_k, img_v, txt_q, txt_k, txt_v):
         img_seqlen = img_q.shape[1]
-        query = torch.cat([img_q, txt_q], dim=1)
-        key = torch.cat([img_k, txt_k], dim=1)
-        value = torch.cat([img_v, txt_v], dim=1)
-        seqlen = query.shape[1]
+        txt_seqlen = txt_q.shape[1]
+        seqlen = img_seqlen + txt_seqlen
         cu_seqlens_qkv = torch.tensor([0, seqlen], dtype=torch.int32, device="cpu")
 
-        if self.config["seq_parallel"]:
+        if self.config["seq_parallel"] and self.seq_p_split_qkv_input:
             attn_out = weights.self_attention_parallel.apply(
-                q=query,
-                k=key,
-                v=value,
+                q=(img_q, txt_q),
+                k=(img_k, txt_k),
+                v=(img_v, txt_v),
                 slice_qkv_len=img_seqlen,
                 cu_seqlens_qkv=cu_seqlens_qkv,
                 attention_module=weights.self_attention,
                 seq_p_group=self.seq_p_group,
                 use_fp8_comm=self.seq_p_fp8_comm,
                 use_fp4_comm=self.seq_p_fp4_comm,
+                use_tensor_fusion=self.seq_p_tensor_fusion,
                 enable_head_parallel=self.enable_head_parallel,
+                return_split_output=self.seq_p_split_attn_output,
             )
         else:
-            attn_out = weights.self_attention.apply(q=query, k=key, v=value, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=seqlen, max_seqlen_kv=seqlen)
+            query = torch.cat([img_q, txt_q], dim=1)
+            key = torch.cat([img_k, txt_k], dim=1)
+            value = torch.cat([img_v, txt_v], dim=1)
+            if self.config["seq_parallel"]:
+                attn_out = weights.self_attention_parallel.apply(
+                    q=query,
+                    k=key,
+                    v=value,
+                    slice_qkv_len=img_seqlen,
+                    cu_seqlens_qkv=cu_seqlens_qkv,
+                    attention_module=weights.self_attention,
+                    seq_p_group=self.seq_p_group,
+                    use_fp8_comm=self.seq_p_fp8_comm,
+                    use_fp4_comm=self.seq_p_fp4_comm,
+                    use_tensor_fusion=self.seq_p_tensor_fusion,
+                    enable_head_parallel=self.enable_head_parallel,
+                    return_split_output=self.seq_p_split_attn_output,
+                )
+            else:
+                attn_out = weights.self_attention.apply(q=query, k=key, v=value, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=seqlen, max_seqlen_kv=seqlen)
 
-        img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
+        if isinstance(attn_out, (tuple, list)):
+            img_attn, txt_attn = attn_out
+        else:
+            img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
         return img_attn, txt_attn
 
     def _run_non_attn_branch(self, graph_name, eager_fn, *args, compile_enabled=None):

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -1,5 +1,3 @@
-import os
-
 import torch
 import torch.nn.functional as F
 from einops import rearrange
@@ -42,23 +40,23 @@ def _apply_hunyuan_rope(module, xq, xk, cos_sin_cache):
     return q.view(q_shape), k.view(k_shape)
 
 
-def _env_flag(name, default="0"):
-    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
-
-
 class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
     def __init__(self, config):
         self.config = config
         self.double_blocks_num = config["mm_double_blocks_depth"]
         self.heads_num = config["heads_num"]
+        parallel_config = self.config.get("parallel", {})
         if self.config["seq_parallel"]:
             self.seq_p_group = self.config.get("device_mesh").get_group(mesh_dim="seq_p")
-            self.seq_p_fp8_comm = self.config["parallel"].get("seq_p_fp8_comm", False)
-            self.seq_p_fp4_comm = self.config["parallel"].get("seq_p_fp4_comm", False)
-            self.enable_head_parallel = self.config["parallel"].get("seq_p_head_parallel", False)
-            self.seq_p_tensor_fusion = self.config["parallel"].get("seq_p_tensor_fusion", False)
-            self.seq_p_split_qkv_input = _env_flag("LIGHTX2V_SEQ_P_SPLIT_QKV_INPUT")
-            self.seq_p_split_attn_output = _env_flag("LIGHTX2V_SEQ_P_SPLIT_ATTN_OUTPUT")
+            self.seq_p_fp8_comm = parallel_config.get("seq_p_fp8_comm", False)
+            self.seq_p_fp4_comm = parallel_config.get("seq_p_fp4_comm", False)
+            self.enable_head_parallel = parallel_config.get("seq_p_head_parallel", False)
+            self.seq_p_tensor_fusion = parallel_config.get("seq_p_tensor_fusion", False)
+            self.seq_p_split_qkv_input = parallel_config.get("seq_p_split_qkv_input", False)
+            self.seq_p_split_attn_output = parallel_config.get("seq_p_split_attn_output", False)
+            self.seq_p_async_text_gather = parallel_config.get("seq_p_async_text_gather", False)
+            self.seq_p_reuse_text_gather_buffers = parallel_config.get("seq_p_reuse_text_gather_buffers", False)
+            self.seq_p_text_gather_buffer_cache_max = parallel_config.get("seq_p_text_gather_buffer_cache_max", 16)
         else:
             self.seq_p_group = None
             self.seq_p_fp8_comm = False
@@ -67,16 +65,19 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             self.seq_p_tensor_fusion = False
             self.seq_p_split_qkv_input = False
             self.seq_p_split_attn_output = False
+            self.seq_p_async_text_gather = False
+            self.seq_p_reuse_text_gather_buffers = False
+            self.seq_p_text_gather_buffer_cache_max = 16
         self.infer_func = self.infer_without_offload
         if self.config.get("modulate_type", "triton") == "triton":
             self.modulate_func = fuse_scale_shift_kernel
         else:
             self.modulate_func = modulate
-        self.compile_non_attn = _env_flag("LIGHTX2V_COMPILE_DIT_NON_ATTN")
-        self.compile_before_attn_requested = _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN")
-        self.compile_before_attn = self.compile_before_attn_requested and _env_flag("LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE")
-        self.compile_non_attn_mode = os.getenv("LIGHTX2V_COMPILE_DIT_MODE", "reduce-overhead")
-        self.share_qkv_act_quant = _env_flag("LIGHTX2V_INT8_SHARE_QKV_ACT_QUANT")
+        self.compile_non_attn = self.config.get("compile_dit_non_attn", False)
+        self.compile_before_attn_requested = self.config.get("compile_dit_before_attn", False)
+        self.compile_before_attn = self.compile_before_attn_requested and self.config.get("compile_dit_before_attn_unsafe", False)
+        self.compile_non_attn_mode = self.config.get("compile_dit_mode", "reduce-overhead")
+        self.share_qkv_act_quant = self.config.get("share_qkv_act_quant", False)
         self._compiled_non_attn = {}
         self._compile_non_attn_failed = set()
         if self.share_qkv_act_quant:
@@ -87,8 +88,8 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
             logger.info("[Ulysses] Returning split img/txt attention outputs to avoid post-attention concat/slice copies")
         if self.compile_before_attn_requested and not self.compile_before_attn:
             logger.warning(
-                "[Compile] LIGHTX2V_COMPILE_DIT_BEFORE_ATTN is ignored unless "
-                "LIGHTX2V_COMPILE_DIT_BEFORE_ATTN_UNSAFE=1 is also set; before-attn graphs carry "
+                "[Compile] compile_dit_before_attn is ignored unless "
+                "compile_dit_before_attn_unsafe is also set; before-attn graphs carry "
                 "block-specific weight objects and can grow Dynamo caches quickly."
             )
         if self.compile_non_attn or self.compile_before_attn:
@@ -243,21 +244,25 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
         seqlen = img_seqlen + txt_seqlen
         cu_seqlens_qkv = torch.tensor([0, seqlen], dtype=torch.int32, device="cpu")
 
-        if self.config["seq_parallel"] and self.seq_p_split_qkv_input:
-            attn_out = weights.self_attention_parallel.apply(
-                q=(img_q, txt_q),
-                k=(img_k, txt_k),
-                v=(img_v, txt_v),
-                slice_qkv_len=img_seqlen,
-                cu_seqlens_qkv=cu_seqlens_qkv,
+        if self.config["seq_parallel"] and (self.seq_p_split_qkv_input or self.seq_p_split_attn_output):
+            quant_scheme = "fp8" if self.seq_p_fp8_comm else "fp4" if self.seq_p_fp4_comm else None
+            img_attn, txt_attn = weights.self_attention_parallel.apply_new(
+                q=img_q,
+                k=img_k,
+                v=img_v,
+                aux_q=txt_q,
+                aux_k=txt_k,
+                aux_v=txt_v,
                 attention_module=weights.self_attention,
                 seq_p_group=self.seq_p_group,
-                use_fp8_comm=self.seq_p_fp8_comm,
-                use_fp4_comm=self.seq_p_fp4_comm,
-                use_tensor_fusion=self.seq_p_tensor_fusion,
-                enable_head_parallel=self.enable_head_parallel,
-                return_split_output=self.seq_p_split_attn_output,
+                quant_scheme=quant_scheme,
+                tensor_fusion=self.seq_p_tensor_fusion,
+                head_parallel=self.enable_head_parallel,
+                async_aux_gather=self.seq_p_async_text_gather,
+                reuse_aux_gather_buffers=self.seq_p_reuse_text_gather_buffers,
+                aux_gather_buffer_cache_max=self.seq_p_text_gather_buffer_cache_max,
             )
+            return img_attn, txt_attn
         else:
             query = torch.cat([img_q, txt_q], dim=1)
             key = torch.cat([img_k, txt_k], dim=1)
@@ -275,15 +280,11 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
                     use_fp4_comm=self.seq_p_fp4_comm,
                     use_tensor_fusion=self.seq_p_tensor_fusion,
                     enable_head_parallel=self.enable_head_parallel,
-                    return_split_output=self.seq_p_split_attn_output,
                 )
             else:
                 attn_out = weights.self_attention.apply(q=query, k=key, v=value, cu_seqlens_q=cu_seqlens_qkv, cu_seqlens_kv=cu_seqlens_qkv, max_seqlen_q=seqlen, max_seqlen_kv=seqlen)
 
-        if isinstance(attn_out, (tuple, list)):
-            img_attn, txt_attn = attn_out
-        else:
-            img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
+        img_attn, txt_attn = attn_out[:img_seqlen], attn_out[img_seqlen:]
         return img_attn, txt_attn
 
     def _run_non_attn_branch(self, graph_name, eager_fn, *args, compile_enabled=None):

--- a/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_video/infer/transformer_infer.py
@@ -96,11 +96,7 @@ class HunyuanVideo15TransformerInfer(BaseTransformerInfer):
                 torch._dynamo.config.suppress_errors = True
             except Exception as exc:
                 logger.warning(f"[Compile] Unable to enable Dynamo suppress_errors: {exc}")
-            logger.info(
-                "[Compile] Hunyuan DiT branch compile: "
-                f"after_attn={self.compile_non_attn}, before_attn={self.compile_before_attn}, "
-                f"mode={self.compile_non_attn_mode}"
-            )
+            logger.info(f"[Compile] Hunyuan DiT branch compile: after_attn={self.compile_non_attn}, before_attn={self.compile_before_attn}, mode={self.compile_non_attn_mode}")
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler


### PR DESCRIPTION
## Summary
- add optional Hunyuan DiT non-attention `torch.compile` wrappers controlled by model config
- add split QKV input/output support for Ulysses attention through explicit config/API parameters
- add optional async text gather and bounded text gather buffer reuse without inference-operator profiling hooks
- wire shared QKV activation quantization into the Hunyuan transformer path through model config

## Why
These changes reduce Python/tensor layout overhead around HunyuanVideo DiT inference and let Hygon DCU deployments reuse activation quantization for consecutive Q/K/V projections. Runtime choices are now passed through config/API parameters instead of environment-variable switches.

## Validation
- branch rebuilt on latest `ModelTC/LightX2V:main` (`89dfa833`)
- `ruff check --config=pyproject.toml` passed for the touched files
- `ruff format --check --config=pyproject.toml` passed for the touched files
- `python -m py_compile` passed for the touched files
- source check confirmed no `LIGHTX2V_*` env switches or profiler ranges remain in the touched operator files
- validated as part of the HunyuanVideo1.5 I2V 8-card benchmark path on Hygon DCU