### PR TITLE
fix: remove blocking asyncio gather after cancelling disconnect watch…

### DIFF
--- a/lightx2v/server/api/openai_images.py
+++ b/lightx2v/server/api/openai_images.py
@@ -121,25 +121,17 @@ async def _run_sync_image_task(request: Request, message: ImageTaskRequest) -> t
         disconnect_task = asyncio.create_task(_watch_client_disconnect(request, task_id))
 
         done, pending = await asyncio.wait({wait_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED)
+        for pending_task in pending:
+            pending_task.cancel()
 
-        if wait_task in done:
-            result_png, usage = wait_task.result()
-            for pending_task in pending:
-                pending_task.cancel()
-            if pending:
-                _, still_pending = await asyncio.wait(pending, timeout=0)
-                if still_pending:
-                    logger.debug(f"Task {task_id} disconnect watcher cancellation is still pending")
-            logger.info(f"Task {task_id} OpenAI image task result ready, building response")
-            return result_png, usage
-
-        if disconnect_task in done and disconnect_task.result():
+        if disconnect_task in done:
             if not wait_task.done():
                 wait_task.cancel()
-                await asyncio.wait({wait_task}, timeout=0)
             raise HTTPException(status_code=499, detail=f"Client disconnected, task {task_id} cancelled")
 
-        raise HTTPException(status_code=500, detail=f"Task {task_id} ended without image result")
+        result_png, usage = wait_task.result()
+        logger.info(f"Task {task_id} OpenAI image task result ready, building response")
+        return result_png, usage
     except RuntimeError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except HTTPException:

--- a/lightx2v/server/api/tasks/image.py
+++ b/lightx2v/server/api/tasks/image.py
@@ -154,12 +154,10 @@ async def create_image_task_sync(
         done, pending = await asyncio.wait({wait_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED)
         for pending_task in pending:
             pending_task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
 
-        if disconnect_task in done and disconnect_task.result():
+        if disconnect_task in done:
             if not wait_task.done():
                 wait_task.cancel()
-                await asyncio.gather(wait_task, return_exceptions=True)
             raise HTTPException(status_code=499, detail=f"Client disconnected, task {task_id} cancelled")
 
         result_png = wait_task.result()


### PR DESCRIPTION
…er in sync endpoints

   After wait_task completes, cancel() on disconnect_task followed by asyncio.gather
   blocks indefinitely because the disconnect watcher is stuck in request.is_disconnected()
   → receive() which never returns while the client is still connected. Fire-and-forget
   cancel is sufficient — the completed task already holds the result.

   Affected: POST /v1/tasks/image/sync and OpenAI /v1/images/* sync handlers.