### PR TITLE
Quality: Typo in parameter name: `adapter_block_inde`

### DIFF
--- a/lightx2v/common/ops/attn/template.py
+++ b/lightx2v/common/ops/attn/template.py
@@ -28,8 +28,8 @@ class AttnWeightTemplate(metaclass=ABCMeta):
             destination = {}
         return destination
 
-    def load_state_dict(self, destination, block_index, adapter_block_inde=None):
+    def load_state_dict(self, destination, block_index, adapter_block_index=None):
         return {}
 
-    def load_state_dict_from_disk(self, block_index, adapter_block_inde=None):
+    def load_state_dict_from_disk(self, block_index, adapter_block_index=None):
         pass


### PR DESCRIPTION
## Summary

Quality: Typo in parameter name: `adapter_block_inde`

## Problem

**Severity**: `Medium` | **File**: `lightx2v/common/ops/attn/template.py:L44`

The parameter `adapter_block_inde` is defined in `load_state_dict` and `load_state_dict_from_disk` in the `AttnWeightTemplate` base class. It appears to be a typo for `adapter_block_index`. This inconsistency can cause confusion and bugs if subclasses or callers attempt to use keyword arguments based on the correct spelling.

## Solution

Rename `adapter_block_inde` to `adapter_block_index` across the base class and all implementations to ensure consistency.

## Changes

- `lightx2v/common/ops/attn/template.py` (modified)