### PR TITLE
fix(mlu):fix LTX-2.3 single- and multi-card inference

### DIFF
--- a/configs/platforms/mlu/ltx2_3.json
+++ b/configs/platforms/mlu/ltx2_3.json
@@ -1,0 +1,47 @@
+{
+    "infer_steps": 30,
+    "target_video_length": 121,
+    "target_height": 512,
+    "target_width": 768,
+    "noise_generator_device": "cpu",
+    "attn_type": "torch_sdpa",
+    "gemma_attn_implementation": "eager",
+    "rope_type": "torch_real_rope",
+    "layer_norm_type": "torch",
+    "rms_norm_type": "torch",
+    "norm_modulate_backend": "torch",
+    "modulate_with_rmsnorm": "torch",
+    "sample_guide_scale": 3.0,
+    "sample_shift": [2.05, 0.95],
+    "enable_cfg": true,
+    "cpu_offload": false,
+    "num_channels_latents": 128,
+    "fps": 24,
+    "audio_fps": 24000,
+    "audio_mel_bins": 16,
+    "double_precision_rope": true,
+    "use_tiling_vae": false,
+    "dit_original_ckpt": "/data/models/LTX-2.3/ltx-2.3-22b-dev.safetensors",
+    "caption_proj_before_connector": true,
+    "cross_attention_adaln": true,
+    "apply_gated_attention": true,
+    "mm_guider": {
+        "enabled": true,
+        "video": {
+            "cfg_scale": 3.0,
+            "stg_scale": 1.0,
+            "stg_blocks": [28],
+            "modality_scale": 3.0,
+            "rescale_scale": 0.7,
+            "skip_step": 0
+        },
+        "audio": {
+            "cfg_scale": 7.0,
+            "stg_scale": 1.0,
+            "stg_blocks": [28],
+            "modality_scale": 3.0,
+            "rescale_scale": 0.7,
+            "skip_step": 0
+        }
+    }
+}

--- a/configs/platforms/mlu/ltx2_3_dist.json
+++ b/configs/platforms/mlu/ltx2_3_dist.json
@@ -1,0 +1,50 @@
+{
+    "infer_steps": 30,
+    "target_video_length": 121,
+    "target_height": 512,
+    "target_width": 768,
+    "attn_type": "torch_sdpa",
+    "rope_type": "torch_real_rope",
+    "layer_norm_type": "torch",
+    "rms_norm_type": "torch",
+    "norm_modulate_backend": "torch",
+    "modulate_with_rmsnorm": "torch",
+    "gemma_attn_implementation": "eager",
+    "sample_guide_scale": 3.0,
+    "sample_shift": [2.05, 0.95],
+    "enable_cfg": true,
+    "cpu_offload": false,
+    "num_channels_latents": 128,
+    "fps": 24,
+    "audio_fps": 24000,
+    "audio_mel_bins": 16,
+    "double_precision_rope": true,
+    "use_tiling_vae": false,
+    "dit_original_ckpt": "/data/models/LTX-2.3/ltx-2.3-22b-dev.safetensors",
+    "caption_proj_before_connector": true,
+    "cross_attention_adaln": true,
+    "apply_gated_attention": true,
+    "mm_guider": {
+        "enabled": true,
+        "video": {
+            "cfg_scale": 3.0,
+            "stg_scale": 1.0,
+            "stg_blocks": [28],
+            "modality_scale": 3.0,
+            "rescale_scale": 0.7,
+            "skip_step": 0
+        },
+        "audio": {
+            "cfg_scale": 7.0,
+            "stg_scale": 1.0,
+            "stg_blocks": [28],
+            "modality_scale": 3.0,
+            "rescale_scale": 0.7,
+            "skip_step": 0
+        }
+    },
+    "parallel": {
+        "seq_p_size": 8,
+        "seq_p_attn_type": "ulysses"
+    }
+}

--- a/lightx2v/models/input_encoders/hf/ltx2/gemma/feature_extractor.py
+++ b/lightx2v/models/input_encoders/hf/ltx2/gemma/feature_extractor.py
@@ -75,7 +75,7 @@ def norm_and_concat_per_token_rms(
     normed = encoded_text * torch.rsqrt(variance + 1e-6)
     normed = normed.reshape(B, T, D * L)
     mask_3d = attention_mask.bool().unsqueeze(-1)  # [B, T, 1]
-    return torch.where(mask_3d, normed, torch.zeros_like(normed))
+    return normed.masked_fill_(~mask_3d, 0.0)
 
 
 def _rescale_norm(x: torch.Tensor, target_dim: int, source_dim: int) -> torch.Tensor:

--- a/lightx2v/models/input_encoders/hf/ltx2/model.py
+++ b/lightx2v/models/input_encoders/hf/ltx2/model.py
@@ -71,6 +71,7 @@ class LTX2TextEncoder:
         device: torch.device,
         dtype: torch.dtype = torch.bfloat16,
         cpu_offload: bool = False,
+        gemma_attn_implementation: str | None = None,
     ):
         """
         Initialize the simplified text encoder loader.
@@ -80,19 +81,28 @@ class LTX2TextEncoder:
             gemma_root: Root directory containing Gemma model, tokenizer, and processor
             device: Target device for the model
             dtype: Data type for model parameters
+            gemma_attn_implementation: Optional Transformers attention
+                implementation override (for example, ``"eager"``).
         """
         self.checkpoint_path = checkpoint_path
         self.gemma_root = gemma_root
         self.device = device
         self.dtype = dtype
         self.cpu_offload = cpu_offload
+        self.gemma_attn_implementation = gemma_attn_implementation
         self.loader = SafetensorsModelStateDictLoader()
         self.text_encoder = self.load()
 
     def _load_gemma_model(self) -> Gemma3ForConditionalGeneration:
         """Load Gemma model from gemma_root."""
         gemma_path = _find_matching_dir(self.gemma_root, "model*.safetensors")
-        return Gemma3ForConditionalGeneration.from_pretrained(gemma_path, local_files_only=True, torch_dtype=torch.bfloat16)
+        kwargs = {
+            "local_files_only": True,
+            "torch_dtype": torch.bfloat16,
+        }
+        if self.gemma_attn_implementation is not None:
+            kwargs["attn_implementation"] = self.gemma_attn_implementation
+        return Gemma3ForConditionalGeneration.from_pretrained(gemma_path, **kwargs)
 
     def _load_tokenizer(self) -> LTXVGemmaTokenizer:
         """Load tokenizer from gemma_root."""

--- a/lightx2v/models/runners/ltx2/ltx2_runner.py
+++ b/lightx2v/models/runners/ltx2/ltx2_runner.py
@@ -165,6 +165,7 @@ class LTX2Runner(DefaultRunner):
             device=text_encoder_device,
             dtype=GET_DTYPE(),
             cpu_offload=text_encoder_offload,
+            gemma_attn_implementation=self.config.get("gemma_attn_implementation"),
         )
 
         # Apply LoRA to text encoder if configured

--- a/lightx2v/models/schedulers/ltx2/scheduler.py
+++ b/lightx2v/models/schedulers/ltx2/scheduler.py
@@ -369,6 +369,19 @@ class LTX2Scheduler(BaseScheduler):
         self.v_noise_pred = None
         self.a_noise_pred = None
         self.keep_latents_dtype_in_scheduler = config.get("keep_latents_dtype_in_scheduler", False)
+        # Device-local RNG algorithms differ across CUDA and MLU. Allow callers
+        # to generate noise on CPU, where the same seed produces identical
+        # latent noise on both platforms, and then copy it to the target device.
+        self.noise_generator_device = config.get("noise_generator_device", AI_DEVICE)
+
+    def _randn(self, shape, dtype, target_device):
+        noise = torch.randn(
+            shape,
+            dtype=dtype,
+            device=self.noise_generator_device,
+            generator=self.generator,
+        )
+        return noise.to(device=target_device)
 
     def step_pre(self, step_index):
         self.step_index = step_index
@@ -420,7 +433,8 @@ class LTX2Scheduler(BaseScheduler):
 
         # Initialize generator
         if self.generator is None:
-            self.generator = torch.Generator(device=AI_DEVICE).manual_seed(seed)
+            self.generator = torch.Generator(device=self.noise_generator_device).manual_seed(seed)
+            logger.info(f"Noise generator device: {self.noise_generator_device}")
         else:
             logger.info(f"Generator is not None, using existing generator for latents")
 
@@ -566,11 +580,10 @@ class LTX2Scheduler(BaseScheduler):
             patchified_video_mask = patchified_video_mask.unsqueeze(-1)
 
         # Add noise after patchify (aligned with source code: GaussianNoiser operates on patchified latent)
-        noise_video = torch.randn(
-            *patchified_video_latent.shape,
+        noise_video = self._randn(
+            patchified_video_latent.shape,
             dtype=patchified_video_latent.dtype,
-            device=AI_DEVICE,
-            generator=self.generator,
+            target_device=AI_DEVICE,
         )
 
         scaled_mask_video = patchified_video_mask * noise_scale
@@ -653,11 +666,10 @@ class LTX2Scheduler(BaseScheduler):
             mask_k = torch.full((tk, 1), 1.0 - float(strength), device=AI_DEVICE, dtype=torch.float32)
             clean_k = patch_tokens.clone()
 
-            noise_k = torch.randn(
-                *patch_tokens.shape,
+            noise_k = self._randn(
+                patch_tokens.shape,
                 dtype=patch_tokens.dtype,
-                device=AI_DEVICE,
-                generator=self.generator,
+                target_device=AI_DEVICE,
             )
             scaled_m = mask_k * noise_scale
             noised_k = (noise_k * scaled_m + clean_k * (1 - scaled_m)).to(patch_tokens.dtype)
@@ -702,11 +714,10 @@ class LTX2Scheduler(BaseScheduler):
         mask = torch.full((tk, 1), 1.0 - strength, device=AI_DEVICE, dtype=torch.float32)
         clean = patch_tokens.clone()
 
-        noise = torch.randn(
-            *patch_tokens.shape,
+        noise = self._randn(
+            patch_tokens.shape,
             dtype=patch_tokens.dtype,
-            device=AI_DEVICE,
-            generator=self.generator,
+            target_device=AI_DEVICE,
         )
         scaled_m = mask * noise_scale
         noised = (noise * scaled_m + clean * (1 - scaled_m)).to(patch_tokens.dtype)
@@ -782,11 +793,10 @@ class LTX2Scheduler(BaseScheduler):
             patchified_audio_mask = patchified_audio_mask.unsqueeze(-1)
 
         # Add noise after patchify (aligned with source code: GaussianNoiser operates on patchified latent)
-        noise_audio = torch.randn(
-            *patchified_audio_latent.shape,
+        noise_audio = self._randn(
+            patchified_audio_latent.shape,
             dtype=patchified_audio_latent.dtype,
-            device=AI_DEVICE,
-            generator=self.generator,
+            target_device=AI_DEVICE,
         )
         scaled_mask_audio = patchified_audio_mask * noise_scale
         patchified_audio_latent = (noise_audio * scaled_mask_audio + patchified_audio_latent * (1 - scaled_mask_audio)).to(patchified_audio_latent.dtype)
@@ -965,11 +975,10 @@ class LTX2ARScheduler(LTX2Scheduler):
         return ((1.0 - sigma) * denoised.float() + sigma * noise.float()).to(denoised.dtype)
 
     def _next_self_forcing_latent(self, denoised, denoise_mask, clean, sigma_next):
-        noise = torch.randn(
+        noise = self._randn(
             denoised.shape,
             dtype=denoised.dtype,
-            device=denoised.device,
-            generator=self.generator,
+            target_device=denoised.device,
         )
         latent = self.self_forcing_renoise(denoised, noise, sigma_next)
         return self.post_process_latent(latent, denoise_mask, clean)

--- a/lightx2v_platform/base/cambricon_mlu.py
+++ b/lightx2v_platform/base/cambricon_mlu.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.distributed as dist
 
@@ -10,7 +12,9 @@ class MluDevice:
 
     @staticmethod
     def init_device_env():
-        pass
+        local_rank = os.environ.get("LOCAL_RANK")
+        if local_rank is not None:
+            torch.mlu.set_device(int(local_rank))
 
     @staticmethod
     def is_available() -> bool:
@@ -27,5 +31,5 @@ class MluDevice:
 
     @staticmethod
     def init_parallel_env():
+        MluDevice.init_device_env()
         dist.init_process_group(backend="cncl")
-        torch.mlu.set_device(dist.get_rank())

--- a/scripts/platforms/mlu/run_ltx2_3_s2v.sh
+++ b/scripts/platforms/mlu/run_ltx2_3_s2v.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+lightx2v_path=/data/LightX2V
+model_path=/data/models/LTX-2
+audio_path="${lightx2v_path}/assets/inputs/audio/seko_input.mp3"
+
+export PLATFORM=cambricon_mlu
+export MLU_VISIBLE_DEVICES="${MLU_VISIBLE_DEVICES:-0}"
+export PYTORCH_MLU_ALLOC_CONF="${PYTORCH_MLU_ALLOC_CONF:-expandable_segments:True}"
+export LD_LIBRARY_PATH="/usr/local/neuware/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+source "${lightx2v_path}/scripts/base/base.sh"
+
+python -m lightx2v.infer \
+  --model_cls ltx2 \
+  --task ltx2_s2v \
+  --model_path "${model_path}" \
+  --config_json "${lightx2v_path}/configs/platforms/mlu/ltx2_3.json" \
+  --audio_path "${audio_path}" \
+  --prompt "A person speaks clearly in a quiet room, natural lighting, cinematic medium shot." \
+  --negative_prompt "blurry, out of focus, overexposed, underexposed, low contrast, excessive noise, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, disfigured hands, artifacts, inconsistent perspective, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, off-sync audio, AI artifacts." \
+  --save_result_path "${lightx2v_path}/save_results/output_lightx2v_ltx2_3_s2v_mlu.mp4" \
+  --seed 42

--- a/scripts/platforms/mlu/run_ltx2_3_s2v_8card.sh
+++ b/scripts/platforms/mlu/run_ltx2_3_s2v_8card.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eo pipefail
+
+lightx2v_path=/data/LightX2V
+model_path=/data/models/LTX-2
+audio_path="${lightx2v_path}/assets/inputs/audio/seko_input.mp3"
+
+export PLATFORM=cambricon_mlu
+export MLU_VISIBLE_DEVICES="${MLU_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+export PYTORCH_MLU_ALLOC_CONF="${PYTORCH_MLU_ALLOC_CONF:-expandable_segments:True}"
+export LD_LIBRARY_PATH="/usr/local/neuware/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export PYTHONFAULTHANDLER=1
+
+source "${lightx2v_path}/scripts/base/base.sh"
+
+log_dir="${lightx2v_path}/save_results/logs/ltx2_3_s2v_mlu_8card"
+mkdir -p "${log_dir}"
+
+torchrun \
+  --standalone \
+  --nnodes=1 \
+  --nproc_per_node=8 \
+  --log-dir="${log_dir}" \
+  --redirects=3 \
+  --tee=3 \
+  -m lightx2v.infer \
+  --model_cls ltx2 \
+  --task ltx2_s2v \
+  --model_path "${model_path}" \
+  --config_json "${lightx2v_path}/configs/platforms/mlu/ltx2_3_dist.json" \
+  --audio_path "${audio_path}" \
+  --target_video_length 121 \
+  --prompt "A person speaks clearly in a quiet room, natural lighting, cinematic medium shot." \
+  --negative_prompt "blurry, out of focus, overexposed, underexposed, low contrast, excessive noise, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, disfigured hands, artifacts, inconsistent perspective, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, off-sync audio, AI artifacts." \
+  --save_result_path "${lightx2v_path}/save_results/output_lightx2v_ltx2_3_s2v_mlu_8card.mp4" \
+  --seed 42


### PR DESCRIPTION
Add MLU configs and launch scripts for single-card and 8-card S2V inference. Bind each distributed worker before CNCL initialization, make Gemma attention and scheduler RNG device configurable, and reduce the text feature masking memory peak.