### PR TITLE
feat(nvfp4): add Wan FFN split-N workaround

### DIFF
--- a/lightx2v/common/ops/mm/mm_weight.py
+++ b/lightx2v/common/ops/mm/mm_weight.py
@@ -1334,6 +1334,53 @@ class MMWeightWnvfp4Anvfp4dynamic(MMWeightQuantTemplate):
             del weight_scale_tensor
 
 
+@MM_WEIGHT_REGISTER("nvfp4-split-n-workaround")
+class MMWeightWnvfp4Anvfp4dynamicSplitNWorkaround(MMWeightWnvfp4Anvfp4dynamic):
+    """Temporary application-level two-way split-N workaround.
+
+    This path is intentionally separate from the normal ``nvfp4`` weight type.
+    It works around a throughput cliff observed for large Wan FFN GEMMs on
+    NVIDIA Jetson AGX Thor by quantizing the activation once, launching two
+    serial N/2 GEMMs, and concatenating their outputs.
+
+    This is not the desired long-term backend design: it adds another kernel
+    launch, temporary output tensors, and a concatenation. Remove this class,
+    its registry entry, and ``nvfp4_ffn_split_n_workaround`` once
+    ``cutlass_scaled_nvfp4_mm`` can select an architecture/shape-aware tactic
+    (or an internal split-N implementation that writes directly to the final
+    output).
+    """
+
+    split_n_parts = 2
+    split_n_alignment = 128
+
+    def apply(self, input_tensor):
+        input_tensor_quant, input_tensor_scale = self.act_quant_func(input_tensor)
+
+        n = self.weight.shape[0]
+        required_alignment = self.split_n_parts * self.split_n_alignment
+        if n % required_alignment != 0:
+            raise ValueError(f"NVFP4 split-N requires each N shard to be aligned to {self.split_n_alignment} rows, but {self.weight_name} has N={n}")
+        if self.weight_scale.shape[0] != n:
+            raise ValueError(f"NVFP4 split-N expects weight and weight_scale to share the output-channel dimension, got {n} and {self.weight_scale.shape[0]} for {self.weight_name}")
+
+        shard_n = n // self.split_n_parts
+        outputs = []
+        for start in range(0, n, shard_n):
+            bias = None if self.bias is None else self.bias.narrow(0, start, shard_n)
+            outputs.append(
+                cutlass_scaled_nvfp4_mm(
+                    input_tensor_quant,
+                    self.weight.narrow(0, start, shard_n),
+                    input_tensor_scale,
+                    self.weight_scale.narrow(0, start, shard_n),
+                    alpha=self.alpha,
+                    bias=bias,
+                )
+            )
+        return torch.cat(outputs, dim=-1)
+
+
 @MM_WEIGHT_REGISTER("CalibMax")
 class MMCalibMax(MMWeight):
     """Max-absmax calibration: record max(|input|) across every forward.

--- a/lightx2v/models/networks/wan/weights/transformer_weights.py
+++ b/lightx2v/models/networks/wan/weights/transformer_weights.py
@@ -41,10 +41,24 @@ def _build_causal_rope(config):
     )
 
 
-def _mm_weight(config, weight_name, bias_name, split_dim=None, create_cuda_buffer=False, create_cpu_buffer=False, lazy_load=False, lazy_load_file=None, lora_prefix="", lora_path=""):
-    mm_type = config.get("dit_quant_scheme", "Default")
-    if config.get("do_mm_calib", False):
-        mm_type = "Calib"
+def _mm_weight(
+    config,
+    weight_name,
+    bias_name,
+    split_dim=None,
+    create_cuda_buffer=False,
+    create_cpu_buffer=False,
+    lazy_load=False,
+    lazy_load_file=None,
+    lora_prefix="",
+    lora_path="",
+    mm_type_override=None,
+):
+    mm_type = mm_type_override
+    if mm_type is None:
+        mm_type = config.get("dit_quant_scheme", "Default")
+        if config.get("do_mm_calib", False):
+            mm_type = "Calib"
     if config.get("tensor_parallel", False) and split_dim is not None:
         tp_group = config["device_mesh"].get_group(mesh_dim="tensor_p")
         return MM_WEIGHT_REGISTER["TensorParallel"](
@@ -794,6 +808,13 @@ class WanFFN(WeightModule):
             LN_WEIGHT_REGISTER[config.get("layer_norm_type", "torch")](),
         )
 
+        split_n = config.get("nvfp4_ffn_split_n_workaround", False)
+        if not isinstance(split_n, bool):
+            raise TypeError("nvfp4_ffn_split_n_workaround must be a boolean")
+        # Temporary and intentionally scoped to Wan FFN. The checkpoint format
+        # remains ``nvfp4``; only the execution implementation changes.
+        ffn_mm_type = "nvfp4-split-n-workaround" if self.mm_type == "nvfp4" and split_n else self.mm_type
+
         fp = f"{block_prefix}.{self.block_index}"
         self.add_module(
             "ffn_0",
@@ -808,6 +829,7 @@ class WanFFN(WeightModule):
                 lazy_load_file=self.lazy_load_file,
                 lora_prefix=block_prefix,
                 lora_path=lora_path,
+                mm_type_override=ffn_mm_type,
             ),
         )
         self.add_module(
@@ -823,6 +845,7 @@ class WanFFN(WeightModule):
                 lazy_load_file=self.lazy_load_file,
                 lora_prefix=block_prefix,
                 lora_path=lora_path,
+                mm_type_override=ffn_mm_type,
             ),
         )
 


### PR DESCRIPTION
This MR adds an opt-in split-N workaround for Wan FFN NVFP4 GEMMs on NVIDIA Jetson AGX Thor. A dedicated weight implementation quantizes activations once, splits the output dimension into two aligned N/2 shards, runs two serial `cutlass_scaled_nvfp4_mm `calls, and concatenates the outputs. The existing NVFP4 implementation remains unchanged. The workaround is selected only for Wan `ffn_0 `and `ffn_2 `through the `nvfp4_ffn_split_n_workaround `boolean option, so other linear layers and models keep their current behavior. This path is temporary and can be removed once the backend supports architecture- and shape-aware dispatch or internal split-N.