### PR TITLE
Fix FA4 sparse attention API usage

### DIFF
--- a/lightx2v/common/ops/attn/dynamic_sparse_attn.py
+++ b/lightx2v/common/ops/attn/dynamic_sparse_attn.py
@@ -12,9 +12,11 @@ from .utils.sparge_util import block_map_incremental_lut_triton, block_map_ordin
 
 try:
     from flash_attn.cute import flash_attn_func as flash_attn_func_v4
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
 except ImportError:
     logger.info("flash_attn.cute not found, please install flashattention4 first")
     flash_attn_func_v4 = None
+    BlockSparseTensorsTorch = None
 
 try:
     from sageattn3_sparse import sage3_block_sparse_attn
@@ -198,16 +200,19 @@ class DynamicSparseAttnWeight(AttnWeightTemplate):
         full_block_idx, full_block_cnt = block_map_ordinal_lut_triton(sparse_map)
         mask_block_cnt = torch.zeros_like(full_block_cnt)
         mask_block_idx = torch.zeros_like(full_block_idx)
-
-        out, _ = flash_attn_func_v4(
-            q=q,
-            k=k,
-            v=v,
+        block_sparse_tensors = BlockSparseTensorsTorch(
             mask_block_cnt=mask_block_cnt,
             mask_block_idx=mask_block_idx,
             full_block_cnt=full_block_cnt,
             full_block_idx=full_block_idx,
             block_size=(self.BLKQ, self.BLKK),
+        )
+
+        out, _ = flash_attn_func_v4(
+            q=q,
+            k=k,
+            v=v,
+            block_sparse_tensors=block_sparse_tensors,
         )
         out = out.reshape(max_seqlen_q, -1)
         return out

--- a/lightx2v/common/ops/attn/flash_attn.py
+++ b/lightx2v/common/ops/attn/flash_attn.py
@@ -22,9 +22,11 @@ except ImportError:
 
 try:
     from flash_attn.cute import flash_attn_func as flash_attn_func_v4
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
 except ImportError:
     logger.info("flash_attn.cute not found, please install flashattention4 first")
     flash_attn_func_v4 = None
+    BlockSparseTensorsTorch = None
 
 
 from lightx2v.utils.registry_factory import ATTN_WEIGHT_REGISTER
@@ -256,16 +258,19 @@ class SparseFlashAttn4Weight(AttnWeightTemplate):
         full_block_idx, full_block_cnt = block_map_ordinal_lut_triton(sparse_map)
         mask_block_cnt = torch.zeros_like(full_block_cnt)
         mask_block_idx = torch.zeros_like(full_block_idx)
-
-        x, _ = flash_attn_func_v4(
-            q=q,
-            k=k,
-            v=v,
+        block_sparse_tensors = BlockSparseTensorsTorch(
             mask_block_cnt=mask_block_cnt,
             mask_block_idx=mask_block_idx,
             full_block_cnt=full_block_cnt,
             full_block_idx=full_block_idx,
             block_size=(self.BLKQ, self.BLKK),
+        )
+
+        x, _ = flash_attn_func_v4(
+            q=q,
+            k=k,
+            v=v,
+            block_sparse_tensors=block_sparse_tensors,
         )
 
         x = x.reshape(bs * max_seqlen_q, -1)

--- a/lightx2v/common/ops/attn/sparse_operator.py
+++ b/lightx2v/common/ops/attn/sparse_operator.py
@@ -10,9 +10,11 @@ from .utils.sparge_util import block_map_incremental_lut_triton, block_map_ordin
 
 try:
     from flash_attn.cute import flash_attn_func as flash_attn_func_v4
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
 except ImportError:
     logger.info("flash_attn.cute not found, please install flashattention4 first")
     flash_attn_func_v4 = None
+    BlockSparseTensorsTorch = None
 
 try:
     from sageattn3_sparse import sage3_block_sparse_attn
@@ -165,16 +167,19 @@ class SparseFlashAttentionV4Operator:
         full_block_idx, full_block_cnt = block_map_ordinal_lut_triton(mask)
         mask_block_cnt = torch.zeros_like(full_block_cnt)
         mask_block_idx = torch.zeros_like(full_block_idx)
-
-        out, _ = flash_attn_func_v4(
-            q=q,
-            k=k,
-            v=v,
+        block_sparse_tensors = BlockSparseTensorsTorch(
             mask_block_cnt=mask_block_cnt,
             mask_block_idx=mask_block_idx,
             full_block_cnt=full_block_cnt,
             full_block_idx=full_block_idx,
             block_size=(self.q_block_size, self.k_block_size),
+        )
+
+        out, _ = flash_attn_func_v4(
+            q=q,
+            k=k,
+            v=v,
+            block_sparse_tensors=block_sparse_tensors,
         )
 
         out = out.reshape(max_seqlen_q, -1)


### PR DESCRIPTION
Update FA4 sparse attention calls to match the latest FlashAttention 4 API.
The old direct sparse kwargs are replaced with BlockSparseTensorsTorch and passed through block_sparse_tensors across dynamic sparse attention, sparse FA4 attention weight, and sparse operator paths.