### PR TITLE
chore: update PyTorch version constraints to torch<=2.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ classifiers = [
 dependencies = [
     "numpy",
     "scipy",
-    "torch<=2.8.0",
-    "torchvision<=0.23.0",
-    "torchaudio<=2.8.0",
+    "torch<=2.11.0",
+    "torchvision<=0.26.0",
+    "torchaudio<=2.11.0",
     "diffusers",
     "transformers",
     "tokenizers",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ packaging
 ninja
 numpy
 scipy
-torch<=2.8.0
-torchvision<=0.23.0
-torchaudio<=2.8.0
+torch<=2.11.0
+torchvision<=0.26.0
+torchaudio<=2.11.0
 torchao
 diffusers
 transformers


### PR DESCRIPTION
Description:

  ## Changes

  Updated the maximum supported versions for PyTorch-related dependencies:

  - torch: `<=2.11.0`
  - torchvision: `<=0.26.0`
  - torchaudio: `<=2.11.0`

  ## Files Changed

  - `pyproject.toml`
  - `requirements.txt`
