### PR TITLE
feat(hunyuan-image3): add TI2I and T2I hybrid parallel entry

### DIFF
--- a/configs/hunyuan_image3/hunyuan_image3_t2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.json
+++ b/configs/hunyuan_image3/hunyuan_image3_t2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.json
@@ -1,0 +1,64 @@
+{
+    "infer_steps": 50,
+    "sample_guide_scale": 5.0,
+    "flow_shift": 1.0,
+    "target_height": 1024,
+    "target_width": 1024,
+    "feature_caching": "NoCaching",
+    "moe_impl": "flashinfer",
+    "flashinfer_multi_micro": true,
+    "flashinfer_multi_micro_backend": "grouped_mm",
+    "attn_impl": "torch_sdpa",
+    "flashinfer_autotune_mode": "auto",
+    "flashinfer_autotune_cache_by_phase": {
+        "ar": "save_results/hunyuan_image3_flashinfer_autotune_t2i_ar_tp4.json"
+    },
+    "flashinfer_tune_max_num_tokens": 16384,
+    "flashinfer_tuning_buckets": [
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        4096,
+        8192,
+        12288,
+        16384
+    ],
+    "flashinfer_autotune_round_up": true,
+    "enable_kv_cache": true,
+    "enable_text_kv_cache": true,
+    "use_taylor_cache": false,
+    "taylor_cache_interval": 5,
+    "taylor_cache_order": 2,
+    "taylor_cache_enable_first_enhance": false,
+    "taylor_cache_first_enhance_steps": 3,
+    "taylor_cache_enable_tailing_enhance": false,
+    "taylor_cache_tailing_enhance_steps": 1,
+    "taylor_cache_low_freqs_order": 2,
+    "taylor_cache_high_freqs_order": 2,
+    "parallel": {
+        "pipeline_parallel": false,
+        "phase_aware": true,
+        "storage_tensor_p_size": 2,
+        "ar": {
+            "tensor_p_size": 4,
+            "seq_p_size": 1
+        },
+        "denoise": {
+            "tensor_p_size": 2,
+            "seq_p_size": 2
+        },
+        "cfg_p_size": 1,
+        "seq_p_attn_type": "ulysses",
+        "cfg_mode": "serial"
+    },
+    "enable_cfg": true,
+    "bot_task": "think_recaption",
+    "use_system_prompt": "en_unified",
+    "max_new_tokens": 2048,
+    "text_do_sample": true,
+    "text_top_k": 1024,
+    "text_top_p": 0.95,
+    "text_temperature": 0.6
+}

--- a/configs/hunyuan_image3/hunyuan_image3_ti2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.json
+++ b/configs/hunyuan_image3/hunyuan_image3_ti2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.json
@@ -1,0 +1,64 @@
+{
+    "infer_steps": 50,
+    "sample_guide_scale": 5.0,
+    "flow_shift": 1.0,
+    "image_size": "auto",
+    "feature_caching": "NoCaching",
+    "moe_impl": "flashinfer",
+    "flashinfer_multi_micro": true,
+    "flashinfer_multi_micro_backend": "grouped_mm",
+    "attn_impl": "torch_sdpa",
+    "flashinfer_autotune_mode": "auto",
+    "flashinfer_autotune_cache_by_phase": {
+        "ar": "save_results/hunyuan_image3_flashinfer_autotune_ti2i_ar_tp4.json"
+    },
+    "flashinfer_tune_max_num_tokens": 16384,
+    "flashinfer_tuning_buckets": [
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        4096,
+        8192,
+        12288,
+        16384
+    ],
+    "flashinfer_autotune_round_up": true,
+    "enable_kv_cache": true,
+    "enable_text_kv_cache": true,
+    "use_taylor_cache": false,
+    "taylor_cache_interval": 5,
+    "taylor_cache_order": 2,
+    "taylor_cache_enable_first_enhance": false,
+    "taylor_cache_first_enhance_steps": 3,
+    "taylor_cache_enable_tailing_enhance": false,
+    "taylor_cache_tailing_enhance_steps": 1,
+    "taylor_cache_low_freqs_order": 2,
+    "taylor_cache_high_freqs_order": 2,
+    "parallel": {
+        "pipeline_parallel": false,
+        "phase_aware": true,
+        "storage_tensor_p_size": 2,
+        "ar": {
+            "tensor_p_size": 4,
+            "seq_p_size": 1
+        },
+        "denoise": {
+            "tensor_p_size": 2,
+            "seq_p_size": 2
+        },
+        "cfg_p_size": 1,
+        "seq_p_attn_type": "ulysses",
+        "cfg_mode": "serial"
+    },
+    "enable_cfg": true,
+    "infer_align_image_size": true,
+    "bot_task": "think_recaption",
+    "use_system_prompt": "en_unified",
+    "max_new_tokens": 2048,
+    "text_do_sample": true,
+    "text_top_k": 1024,
+    "text_top_p": 0.95,
+    "text_temperature": 0.6
+}

--- a/lightx2v/common/ops/moe/__init__.py
+++ b/lightx2v/common/ops/moe/__init__.py
@@ -1,0 +1,5 @@
+"""Mixture-of-experts operators used by LightX2V."""
+
+from .multi_micro_fused_moe import lightx2v_multi_micro_fused_moe
+
+__all__ = ["lightx2v_multi_micro_fused_moe"]

--- a/lightx2v/common/ops/moe/multi_micro_fused_moe.py
+++ b/lightx2v/common/ops/moe/multi_micro_fused_moe.py
@@ -1,0 +1,336 @@
+"""Hopper BF16 multi-micro-shard MoE inference operator.
+
+This module implements a targeted H200 backend for HunyuanImage-3's
+phase-dependent TP layout.  During denoising a logical TP2 expert weight is
+stored as two TP4 micro shards::
+
+    fc1: [micro=2, expert=64, 2 * intermediate=1536, hidden=4096]
+    fc2: [micro=2, expert=64, hidden=4096, intermediate=768]
+
+The public function deliberately consumes those tensors without stacking,
+transposing into a new allocation, or otherwise reorganising their storage.
+It creates one expert permutation and one set of expert offsets, reuses them
+for both micro shards, sums the two partial GEMM2 results, and applies routing
+scores exactly once in the final reduction.
+
+FlashInfer's CUTLASS fused-MoE runner cannot directly express this layout: one
+runner invocation creates one GEMM problem per expert and owns its routing and
+finalize workspaces.  Calling it once per micro shard repeats both operations.
+This implementation instead reuses one routing permutation across four Hopper
+grouped GEMMs, then performs one Triton FP32 micro-sum/top-k finalize.  It is
+one logical LightX2V operator call, not one CUDA kernel launch.
+
+The implementation is intentionally narrow and fails fast outside its target:
+CUDA SM90, BF16, two micro shards, 64 experts, top-k 8, SwiGLU, no bias,
+quantization, LoRA, or expert parallelism.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Final
+
+import torch
+import torch.nn.functional as F
+
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only in minimal installs.
+    triton = None
+    tl = None
+    _TRITON_AVAILABLE = False
+
+
+_MICRO_SHARDS: Final = 2
+_NUM_EXPERTS: Final = 64
+_TOP_K: Final = 8
+_HIDDEN_SIZE: Final = 4096
+_INTERMEDIATE_SIZE: Final = 768
+_FC1_SIZE: Final = 2 * _INTERMEDIATE_SIZE
+
+
+if _TRITON_AVAILABLE:
+
+    @triton.jit
+    def _invert_permutation_kernel(
+        permuted_to_expanded,
+        expanded_to_permuted,
+        num_routes,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        permuted_idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        active = permuted_idx < num_routes
+        expanded_idx = tl.load(permuted_to_expanded + permuted_idx, mask=active)
+        tl.store(expanded_to_permuted + expanded_idx, permuted_idx, mask=active)
+
+    @triton.jit
+    def _multi_micro_finalize_kernel(
+        permuted_expert_output_0,
+        permuted_expert_output_1,
+        expanded_to_permuted,
+        routing_scales,
+        output,
+        hidden_size: tl.constexpr,
+        TOP_K: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        token_idx = tl.program_id(0)
+        hidden_idx = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        hidden_mask = hidden_idx < hidden_size
+        accumulator = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+        # Sum the two BF16 GEMM2 partials in FP32 immediately before applying
+        # the router scale.  The score is therefore multiplied once,
+        # independently of the number of micro shards.
+        for route_idx in tl.static_range(0, TOP_K):
+            expanded_idx = token_idx * TOP_K + route_idx
+            permuted_idx = tl.load(expanded_to_permuted + expanded_idx)
+            value_0 = tl.load(
+                permuted_expert_output_0 + permuted_idx * hidden_size + hidden_idx,
+                mask=hidden_mask,
+                other=0.0,
+            ).to(tl.float32)
+            value_1 = tl.load(
+                permuted_expert_output_1 + permuted_idx * hidden_size + hidden_idx,
+                mask=hidden_mask,
+                other=0.0,
+            ).to(tl.float32)
+            scale = tl.load(routing_scales + expanded_idx).to(tl.float32)
+            accumulator += (value_0 + value_1) * scale
+
+        tl.store(output + token_idx * hidden_size + hidden_idx, accumulator, mask=hidden_mask)
+
+
+@lru_cache(maxsize=None)
+def _validate_device(device_index: int) -> None:
+    capability = torch.cuda.get_device_capability(device_index)
+    if capability != (9, 0):
+        name = torch.cuda.get_device_name(device_index)
+        raise RuntimeError(f"lightx2v_multi_micro_fused_moe only supports SM90 Hopper GPUs; device cuda:{device_index} is {name!r} with capability {capability}")
+
+
+def _require_tensor(
+    tensor: torch.Tensor,
+    name: str,
+    *,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    if tensor.device != device:
+        raise ValueError(f"{name} must be on {device}, got {tensor.device}")
+    if tensor.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    if tuple(tensor.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {tuple(tensor.shape)}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_inputs(
+    input: torch.Tensor,
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    fc1_micro_weights: torch.Tensor,
+    fc2_micro_weights: torch.Tensor,
+    output: torch.Tensor | None,
+    backend: str,
+) -> torch.Tensor:
+    if backend != "grouped_mm":
+        raise ValueError(f"unsupported multi-micro MoE backend {backend!r}; expected 'grouped_mm'")
+    if not hasattr(torch, "_grouped_mm"):
+        raise RuntimeError("this PyTorch build does not provide torch._grouped_mm; the H200 grouped_mm backend is unavailable")
+    if not input.is_cuda:
+        raise ValueError("input must be a CUDA tensor")
+    if input.dtype != torch.bfloat16:
+        raise TypeError(f"input must have dtype torch.bfloat16, got {input.dtype}")
+    if input.ndim != 2 or input.shape[1] != _HIDDEN_SIZE:
+        raise ValueError(f"input must have shape [num_tokens, {_HIDDEN_SIZE}], got {tuple(input.shape)}")
+    if input.shape[0] == 0:
+        raise ValueError("input must contain at least one token")
+    if not input.is_contiguous():
+        raise ValueError("input must be contiguous")
+
+    device = input.device
+    _validate_device(device.index if device.index is not None else torch.cuda.current_device())
+    num_tokens = input.shape[0]
+    _require_tensor(
+        token_selected_experts,
+        "token_selected_experts",
+        shape=(num_tokens, _TOP_K),
+        dtype=torch.int32,
+        device=device,
+    )
+    _require_tensor(
+        token_final_scales,
+        "token_final_scales",
+        shape=(num_tokens, _TOP_K),
+        dtype=torch.float32,
+        device=device,
+    )
+    _require_tensor(
+        fc1_micro_weights,
+        "fc1_micro_weights",
+        shape=(_MICRO_SHARDS, _NUM_EXPERTS, _FC1_SIZE, _HIDDEN_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    _require_tensor(
+        fc2_micro_weights,
+        "fc2_micro_weights",
+        shape=(_MICRO_SHARDS, _NUM_EXPERTS, _HIDDEN_SIZE, _INTERMEDIATE_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    if output is None:
+        return torch.empty_like(input)
+    _require_tensor(
+        output,
+        "output",
+        shape=(num_tokens, _HIDDEN_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    return output
+
+
+def _finalize_with_triton(
+    permuted_expert_output_0: torch.Tensor,
+    permuted_expert_output_1: torch.Tensor,
+    permuted_to_expanded: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    num_routes = permuted_to_expanded.numel()
+    expanded_to_permuted = torch.empty_like(permuted_to_expanded)
+    inverse_block = 256
+    _invert_permutation_kernel[(triton.cdiv(num_routes, inverse_block),)](
+        permuted_to_expanded,
+        expanded_to_permuted,
+        num_routes,
+        BLOCK_SIZE=inverse_block,
+        num_warps=4,
+    )
+
+    finalize_block = 256
+    grid = (output.shape[0], triton.cdiv(_HIDDEN_SIZE, finalize_block))
+    _multi_micro_finalize_kernel[grid](
+        permuted_expert_output_0,
+        permuted_expert_output_1,
+        expanded_to_permuted,
+        token_final_scales,
+        output,
+        hidden_size=_HIDDEN_SIZE,
+        TOP_K=_TOP_K,
+        BLOCK_SIZE=finalize_block,
+        num_warps=4,
+    )
+
+
+def _finalize_with_torch(
+    permuted_expert_output_0: torch.Tensor,
+    permuted_expert_output_1: torch.Tensor,
+    permuted_to_expanded: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Correctness fallback for installations without Triton."""
+
+    permuted_expert_output = permuted_expert_output_0.float()
+    permuted_expert_output.add_(permuted_expert_output_1.float())
+    expanded_output = torch.empty_like(permuted_expert_output)
+    expanded_output.index_copy_(0, permuted_to_expanded, permuted_expert_output)
+    weighted = expanded_output.view(-1, _TOP_K, _HIDDEN_SIZE)
+    weighted.mul_(token_final_scales.unsqueeze(-1))
+    output.copy_(weighted.sum(dim=1))
+
+
+def lightx2v_multi_micro_fused_moe(
+    input: torch.Tensor,
+    token_selected_experts: torch.Tensor,
+    token_final_scales: torch.Tensor,
+    fc1_micro_weights: torch.Tensor,
+    fc2_micro_weights: torch.Tensor,
+    *,
+    output: torch.Tensor | None = None,
+    backend: str = "grouped_mm",
+) -> torch.Tensor:
+    """Run the HunyuanImage-3 two-micro-shard MoE without weight movement.
+
+    Expert weights retain a leading micro-shard dimension. ``output`` is
+    optional; when supplied it is filled in-place and returned.
+
+    Notes
+    -----
+    Expert ids are a trusted router result and must be in ``[0, 64)``.  The
+    range is not checked here because reading a CUDA min/max in Python would
+    introduce a device synchronization into every MoE layer.
+    """
+
+    output = _validate_inputs(
+        input,
+        token_selected_experts,
+        token_final_scales,
+        fc1_micro_weights,
+        fc2_micro_weights,
+        output,
+        backend,
+    )
+
+    # Shared routing: sorted route i maps to expanded route
+    # (token=i//top_k, slot=i%top_k).  Both micro shards reuse this exact
+    # permutation and the same cumulative expert offsets.
+    flat_experts = token_selected_experts.reshape(-1)
+    permuted_to_expanded = torch.argsort(flat_experts)
+    permuted_token_indices = torch.div(permuted_to_expanded, _TOP_K, rounding_mode="floor")
+    permuted_input = input.index_select(0, permuted_token_indices)
+    expert_offsets = torch.bincount(flat_experts, minlength=_NUM_EXPERTS).cumsum(0).to(torch.int32)
+
+    micro_activations: list[torch.Tensor] = []
+    for micro_idx in range(_MICRO_SHARDS):
+        projected = torch._grouped_mm(
+            permuted_input,
+            fc1_micro_weights[micro_idx].transpose(1, 2),
+            offs=expert_offsets,
+        )
+        gate, up = projected.chunk(2, dim=-1)
+        # FlashInfer/TensorRT-LLM's default SwiGLU convention for the packed
+        # Hunyuan weights is first-half * SiLU(second-half).
+        activated = F.silu(up)
+        activated.mul_(gate)
+        micro_activations.append(activated)
+
+    permuted_expert_outputs = (
+        torch._grouped_mm(
+            micro_activations[0],
+            fc2_micro_weights[0].transpose(1, 2),
+            offs=expert_offsets,
+        ),
+        torch._grouped_mm(
+            micro_activations[1],
+            fc2_micro_weights[1].transpose(1, 2),
+            offs=expert_offsets,
+        ),
+    )
+
+    if _TRITON_AVAILABLE:
+        _finalize_with_triton(
+            permuted_expert_outputs[0],
+            permuted_expert_outputs[1],
+            permuted_to_expanded,
+            token_final_scales,
+            output,
+        )
+    else:  # pragma: no cover - production environment includes Triton.
+        _finalize_with_torch(
+            permuted_expert_outputs[0],
+            permuted_expert_outputs[1],
+            permuted_to_expanded,
+            token_final_scales,
+            output,
+        )
+    return output

--- a/lightx2v/models/networks/hunyuan_image3/infer/post_infer.py
+++ b/lightx2v/models/networks/hunyuan_image3/infer/post_infer.py
@@ -8,12 +8,45 @@ from lightx2v.models.networks.hunyuan_image3.infer.utils import apply_linear, ap
 class HunyuanImage3PostInfer:
     def __init__(self, config):
         self.config = config
+        self.parallel_context = config.get("parallel_context")
         if config.get("tensor_parallel", False):
             self.tp_group = config["device_mesh"].get_group(mesh_dim="tensor_p")
             self.tp_size = dist.get_world_size(self.tp_group)
         else:
             self.tp_group = None
             self.tp_size = 1
+
+    @staticmethod
+    def _parallel_context_value(context, *names, default=None):
+        if context is None:
+            return default
+        for name in names:
+            if not hasattr(context, name):
+                continue
+            value = getattr(context, name)
+            if callable(value):
+                value = value()
+            if value is not None:
+                return value
+        return default
+
+    def _active_tp_state(self):
+        group = self._parallel_context_value(self.parallel_context, "active_tp_group", "tp_group", default=self.tp_group)
+        size = self._parallel_context_value(self.parallel_context, "active_tp_size", "tp_size")
+        if size is None:
+            size = dist.get_world_size(group) if group is not None and dist.is_available() and dist.is_initialized() else self.tp_size
+        return group, int(size)
+
+    def _logical_gather_order(self, tp_size):
+        order = self._parallel_context_value(self.parallel_context, "logical_gather_order")
+        if order is None:
+            return tuple(range(tp_size))
+        if torch.is_tensor(order):
+            order = order.detach().cpu().tolist()
+        order = tuple(int(rank) for rank in order)
+        if len(order) != tp_size or sorted(order) != list(range(tp_size)):
+            raise ValueError(f"HunyuanImage3 logical_gather_order must be a permutation of [0, {tp_size}), got {order}.")
+        return order
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler
@@ -62,12 +95,16 @@ class HunyuanImage3PostInfer:
         # Autoregressive generation only consumes the last position. Limiting
         # the TP vocabulary projection to that token avoids materializing and
         # gathering prompt-length logits on every rank.
-        logits_hidden_states = hidden_states[:, -1:, :] if self.tp_size > 1 else hidden_states
+        tp_group, tp_size = self._active_tp_state()
+        logits_hidden_states = hidden_states[:, -1:, :] if tp_size > 1 else hidden_states
         normed = weights.final_norm.apply(logits_hidden_states)
         logits = apply_linear(weights.lm_head, normed.reshape(-1, normed.shape[-1])).reshape(*normed.shape[:-1], -1)
-        if self.tp_size > 1:
+        if tp_size > 1:
+            if tp_group is None:
+                raise RuntimeError("HunyuanImage3 active tensor parallelism requires an active TP process group for LM logits.")
             local_logits = logits.contiguous()
-            gathered_logits = [torch.empty_like(local_logits) for _ in range(self.tp_size)]
-            dist.all_gather(gathered_logits, local_logits, group=self.tp_group)
-            logits = torch.cat(gathered_logits, dim=-1)
+            gathered_logits = [torch.empty_like(local_logits) for _ in range(tp_size)]
+            dist.all_gather(gathered_logits, local_logits, group=tp_group)
+            gather_order = self._logical_gather_order(tp_size)
+            logits = torch.cat([gathered_logits[rank] for rank in gather_order], dim=-1)
         return {"logits": logits}

--- a/lightx2v/models/networks/hunyuan_image3/infer/transformer_infer.py
+++ b/lightx2v/models/networks/hunyuan_image3/infer/transformer_infer.py
@@ -1,3 +1,5 @@
+import inspect
+
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
@@ -5,6 +7,7 @@ from loguru import logger
 
 from lightx2v.common.ops.attn import *  # noqa: F403,F401 - registers LightX2V attention kernels
 from lightx2v.common.ops.attn.utils.all2all import all2all_head2seq, all2all_seq2head
+from lightx2v.common.ops.moe import lightx2v_multi_micro_fused_moe
 from lightx2v.common.transformer_infer.transformer_infer import BaseTransformerInfer
 from lightx2v.models.networks.hunyuan_image3.infer.utils import apply_linear, apply_mlp, apply_rotary_pos_emb, first_weight_device, repeat_kv, to_device
 from lightx2v.utils.registry_factory import ATTN_WEIGHT_REGISTER
@@ -35,6 +38,7 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
 
     def __init__(self, config):
         self.config = config
+        self.parallel_context = config.get("parallel_context")
         self.num_layers = int(config.get("num_layers") or config["num_hidden_layers"])
         self.hidden_size = config["hidden_size"]
         self.global_num_heads = int(config.get("num_attention_heads") or config["num_heads"])
@@ -53,6 +57,8 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
         self.num_key_value_heads = self.global_num_key_value_heads // self.tp_size
         self.hidden_act = config.get("hidden_act", "silu")
         self.flashinfer_tune_max_num_tokens = int(config.get("flashinfer_tune_max_num_tokens", 8192))
+        self.flashinfer_multi_micro = bool(config.get("flashinfer_multi_micro", False))
+        self.flashinfer_multi_micro_backend = str(config.get("flashinfer_multi_micro_backend", "grouped_mm")).strip().lower()
         self.attn_impl = self._normalize_attention_impl(config.get("attn_impl", "torch_sdpa"))
         self.attn_kernel = None if self.attn_impl == "torch_sdpa" else self._build_attention_kernel(self.attn_impl)
         self._attn_cu_seqlens_cache = {}
@@ -69,6 +75,52 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
         else:
             self.seq_p_group = None
             self.sequence_parallel_attn_type = None
+
+    @staticmethod
+    def _parallel_context_value(context, *names, default=None):
+        if context is None:
+            return default
+        for name in names:
+            if not hasattr(context, name):
+                continue
+            value = getattr(context, name)
+            if callable(value):
+                value = value()
+            if value is not None:
+                return value
+        return default
+
+    def _active_phase(self):
+        return str(self._parallel_context_value(self.parallel_context, "phase", default="legacy"))
+
+    def _active_tp_state(self):
+        group = self._parallel_context_value(self.parallel_context, "active_tp_group", "tp_group", default=self.tp_group)
+        size = self._parallel_context_value(self.parallel_context, "active_tp_size", "tp_size")
+        if size is None:
+            size = dist.get_world_size(group) if group is not None and dist.is_available() and dist.is_initialized() else self.tp_size
+        rank = self._parallel_context_value(self.parallel_context, "active_tp_rank", "tp_rank")
+        if rank is None:
+            rank = dist.get_rank(group) if group is not None and dist.is_available() and dist.is_initialized() else self.tp_rank
+        logical_rank = self._parallel_context_value(self.parallel_context, "logical_tp_rank", default=rank)
+        return group, int(rank), int(size), int(logical_rank)
+
+    def _active_seq_group(self):
+        return self._parallel_context_value(self.parallel_context, "active_seq_group", "seq_p_group", default=self.seq_p_group)
+
+    def _active_seq_size(self):
+        size = self._parallel_context_value(self.parallel_context, "active_seq_size", "seq_p_size", "seq_size")
+        if size is not None:
+            return int(size)
+        group = self._active_seq_group()
+        return dist.get_world_size(group) if group is not None and dist.is_available() and dist.is_initialized() else 1
+
+    def _active_seq_parallel(self):
+        active = self._parallel_context_value(self.parallel_context, "active_seq_parallel")
+        if active is not None:
+            return bool(active) and self._active_seq_size() > 1
+        if self.parallel_context is not None:
+            return self._active_seq_size() > 1
+        return self.seq_p_group is not None
 
     def set_scheduler(self, scheduler):
         self.scheduler = scheduler
@@ -401,18 +453,23 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
         segment_specs=None,
     ):
         batch, q_len, _ = hidden_states.shape
+        _, _, active_tp_size, _ = self._active_tp_state()
+        if self.global_num_heads % active_tp_size or self.global_num_key_value_heads % active_tp_size:
+            raise ValueError(f"HunyuanImage3 active TP size must divide Q and KV heads: Q={self.global_num_heads}, KV={self.global_num_key_value_heads}, active_tp_size={active_tp_size}.")
+        num_heads = self.global_num_heads // active_tp_size
+        num_key_value_heads = self.global_num_key_value_heads // active_tp_size
         qkv_states = apply_linear(phase.qkv_proj, hidden_states.reshape(-1, hidden_states.shape[-1]))
         qkv_states = qkv_states.reshape(
             batch,
             q_len,
-            self.num_key_value_heads,
+            num_key_value_heads,
             self.num_key_value_groups + 2,
             self.head_dim,
         )
         query_states, key_states, value_states = torch.split(qkv_states, [self.num_key_value_groups, 1, 1], dim=3)
-        query_states = query_states.reshape(batch, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.reshape(batch, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.reshape(batch, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        query_states = query_states.reshape(batch, q_len, num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.reshape(batch, q_len, num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.reshape(batch, q_len, num_key_value_heads, self.head_dim).transpose(1, 2)
 
         if custom_pos_emb is not None:
             cos, sin = custom_pos_emb
@@ -546,15 +603,18 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
         return cached
 
     def _sequence_parallel_gather_kv(self, key_states, value_states, state):
-        world_size = dist.get_world_size(self.seq_p_group)
+        seq_group = self._active_seq_group()
+        if seq_group is None:
+            raise RuntimeError("HunyuanImage3 sequence parallel is active without an active sequence process group.")
+        world_size = dist.get_world_size(seq_group)
         local = torch.stack((key_states, value_states), dim=2).permute(3, 0, 2, 1, 4).contiguous()
         output_shape = (local.shape[0] * world_size, *local.shape[1:])
-        buffer_key = ("kv", local.device, local.dtype, output_shape)
+        buffer_key = ("kv", self._active_phase(), id(seq_group), local.device, local.dtype, output_shape)
         gathered = self._sp_gather_buffers.get(buffer_key)
         if gathered is None or gathered.shape != output_shape:
             gathered = torch.empty(output_shape, device=local.device, dtype=local.dtype)
             self._sp_gather_buffers[buffer_key] = gathered
-        dist.all_gather_into_tensor(gathered, local, group=self.seq_p_group)
+        dist.all_gather_into_tensor(gathered, local, group=seq_group)
         valid = gathered[: state.original_seq_len]
         key_value = valid.permute(2, 1, 3, 0, 4).contiguous()
         return key_value[0], key_value[1]
@@ -562,9 +622,12 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
     def _sequence_parallel_ulysses_seq_to_head(self, query_states, key_states, value_states, state):
         if query_states.shape[0] != 1:
             raise ValueError("HunyuanImage3 Ulysses expects batch size 1; use parallel.cfg_mode='serial' when cfg_p_size=1 (including TP+SP), or 'parallel' for CFG+SP.")
-        query = all2all_seq2head(query_states[0].transpose(0, 1).contiguous(), group=self.seq_p_group)
-        key = all2all_seq2head(key_states[0].transpose(0, 1).contiguous(), group=self.seq_p_group)
-        value = all2all_seq2head(value_states[0].transpose(0, 1).contiguous(), group=self.seq_p_group)
+        seq_group = self._active_seq_group()
+        if seq_group is None:
+            raise RuntimeError("HunyuanImage3 Ulysses is active without an active sequence process group.")
+        query = all2all_seq2head(query_states[0].transpose(0, 1).contiguous(), group=seq_group)
+        key = all2all_seq2head(key_states[0].transpose(0, 1).contiguous(), group=seq_group)
+        value = all2all_seq2head(value_states[0].transpose(0, 1).contiguous(), group=seq_group)
         original_seq_len = state.original_seq_len
         query = query[:original_seq_len].transpose(0, 1).unsqueeze(0).contiguous()
         key = key[:original_seq_len].transpose(0, 1).unsqueeze(0).contiguous()
@@ -577,12 +640,30 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
         if padding_size:
             padding = output.new_zeros(padding_size, output.shape[1], output.shape[2])
             output = torch.cat((output, padding), dim=0)
-        output = all2all_head2seq(output, group=self.seq_p_group)
+        seq_group = self._active_seq_group()
+        if seq_group is None:
+            raise RuntimeError("HunyuanImage3 Ulysses is active without an active sequence process group.")
+        output = all2all_head2seq(output, group=seq_group)
         return output.unsqueeze(0).transpose(1, 2).contiguous()
+
+    def _apply_phase_mlp(self, gate_and_up_proj, down_proj, hidden_states):
+        phase_mlp = getattr(gate_and_up_proj, "apply_phase_mlp", None)
+        if callable(phase_mlp):
+            return phase_mlp(hidden_states, down_proj, self.hidden_act)
+
+        gate_up_activation = getattr(gate_and_up_proj, "apply_gate_up_activation", None)
+        if callable(gate_up_activation):
+            original_shape = hidden_states.shape
+            flat = hidden_states.reshape(-1, original_shape[-1])
+            activated = gate_up_activation(flat)
+            output = apply_linear(down_proj, activated)
+            return output.reshape(*original_shape)
+
+        return apply_mlp(gate_and_up_proj, down_proj, hidden_states, self.hidden_act)
 
     def infer_mlp(self, phase, hidden_states):
         if not phase.is_moe:
-            return apply_mlp(phase.gate_and_up_proj, phase.down_proj, hidden_states, self.hidden_act)
+            return self._apply_phase_mlp(phase.gate_and_up_proj, phase.down_proj, hidden_states)
 
         moe = phase.moe
         moe_impl = getattr(moe, "moe_impl", self.config.get("moe_impl", "eager"))
@@ -593,8 +674,11 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
         else:
             raise ValueError(f"Unsupported HunyuanImage3 moe_impl={moe_impl!r}. Expected 'eager' or 'flashinfer'.")
 
-        if self.tp_size > 1:
-            dist.all_reduce(output, op=dist.ReduceOp.SUM, group=self.tp_group)
+        tp_group, _, tp_size, _ = self._active_tp_state()
+        if tp_size > 1:
+            if tp_group is None:
+                raise RuntimeError("HunyuanImage3 active tensor parallelism requires an active TP process group.")
+            dist.all_reduce(output, op=dist.ReduceOp.SUM, group=tp_group)
         return output
 
     def _moe_easy_topk(self, moe, hidden_states):
@@ -613,21 +697,91 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
             mask = flat_topk_idx == expert_idx
             if not torch.any(mask):
                 continue
-            expert_out = apply_mlp(expert.gate_and_up_proj, expert.down_proj, repeated[mask], self.hidden_act)
+            expert_out = self._apply_phase_mlp(expert.gate_and_up_proj, expert.down_proj, repeated[mask])
             expert_outputs[mask] = expert_out.to(expert_outputs.dtype)
         combined = (expert_outputs.reshape(flat.shape[0], moe.moe_topk, -1) * topk_weight.to(expert_outputs.dtype).unsqueeze(-1)).sum(dim=1)
         output = combined.reshape_as(hidden_states)
         if getattr(moe, "shared_mlp", None) is not None:
-            shared_out = apply_mlp(moe.shared_mlp.gate_and_up_proj, moe.shared_mlp.down_proj, hidden_states, self.hidden_act)
+            shared_out = self._apply_phase_mlp(moe.shared_mlp.gate_and_up_proj, moe.shared_mlp.down_proj, hidden_states)
             output = output + shared_out.to(output.dtype)
         return output
 
+    @staticmethod
+    def _call_phase_weight_method(method, *args):
+        try:
+            signature = inspect.signature(method)
+        except (TypeError, ValueError):
+            return method(*args)
+        parameters = list(signature.parameters.values())
+        if any(parameter.kind == inspect.Parameter.VAR_POSITIONAL for parameter in parameters):
+            return method(*args)
+        positional = [parameter for parameter in parameters if parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)]
+        return method(*args[: len(positional)])
+
+    @staticmethod
+    def _normalize_flashinfer_weight_shards(shards):
+        if not isinstance(shards, (tuple, list)) or not shards:
+            raise RuntimeError("HunyuanImage3 phase-aware FlashInfer weights must be a non-empty tuple/list.")
+        if len(shards) == 4 and torch.is_tensor(shards[2]) and torch.is_tensor(shards[3]):
+            shards = (shards,)
+
+        normalized = []
+        for shard in shards:
+            if not isinstance(shard, (tuple, list)) or len(shard) != 4:
+                raise RuntimeError("Each HunyuanImage3 FlashInfer shard must be (micro_id, canonical_tp_rank, w1, w2).")
+            micro_id, canonical_tp_rank, weight_1, weight_2 = shard
+            if not torch.is_tensor(weight_1) or not torch.is_tensor(weight_2):
+                raise RuntimeError("HunyuanImage3 FlashInfer shard weights must be tensors.")
+            normalized.append((int(micro_id), int(canonical_tp_rank), weight_1, weight_2))
+        return tuple(normalized)
+
+    def _active_flashinfer_weight_shards(self, moe, device, dtype):
+        active_shards = getattr(moe, "active_flashinfer_weight_shards", None)
+        ensure_weights = getattr(moe, "ensure_flashinfer_weights", None)
+        if callable(active_shards):
+            shards = self._call_phase_weight_method(active_shards, device, dtype)
+            return self._normalize_flashinfer_weight_shards(shards)
+
+        if not callable(ensure_weights):
+            raise RuntimeError("HunyuanImage3 moe_impl='flashinfer' requires phase-aware weights or ensure_flashinfer_weights().")
+        weight_1, weight_2 = ensure_weights(device, dtype)
+        _, _, _, logical_tp_rank = self._active_tp_state()
+        return ((0, logical_tp_rank, weight_1, weight_2),)
+
+    def _active_flashinfer_multi_micro_weights(self, moe, device, dtype):
+        active_weights = getattr(moe, "active_flashinfer_multi_micro_weights", None)
+        if not callable(active_weights):
+            raise RuntimeError("HunyuanImage3 flashinfer_multi_micro requires active_flashinfer_multi_micro_weights(device, dtype).")
+        weights = self._call_phase_weight_method(active_weights, device, dtype)
+        if not isinstance(weights, (tuple, list)) or len(weights) != 2:
+            raise RuntimeError("HunyuanImage3 multi-micro weights must be a (w1_pack, w2_pack) pair.")
+        weight_1, weight_2 = weights
+        if not torch.is_tensor(weight_1) or not torch.is_tensor(weight_2):
+            raise RuntimeError("HunyuanImage3 multi-micro weight packs must be tensors.")
+        return weight_1, weight_2
+
+    def _flashinfer_micro_tp_size(self, moe, shard_count, active_tp_size):
+        configured_size = self._parallel_context_value(self.parallel_context, "ar_tp_size", "logical_tp_size")
+        if configured_size is None:
+            configured_size = getattr(moe, "flashinfer_logical_tp_size", getattr(moe, "micro_tp_size", None))
+        if configured_size is None:
+            configured_size = active_tp_size * shard_count
+        configured_size = int(configured_size)
+        if configured_size < 1:
+            raise ValueError(f"HunyuanImage3 FlashInfer micro TP size must be positive, got {configured_size}.")
+        return configured_size
+
     def _infer_mlp_flashinfer(self, moe, hidden_states):
-        if flashinfer_cutlass_fused_moe is None:
-            raise ImportError("HunyuanImage3 moe_impl='flashinfer' requires flashinfer.fused_moe.cutlass_fused_moe.")
         if self.hidden_act != "silu":
             raise NotImplementedError("HunyuanImage3 moe_impl='flashinfer' currently supports only silu/SwiGLU experts.")
-        if not hasattr(moe, "ensure_flashinfer_weights"):
+        if not any(
+            hasattr(moe, name)
+            for name in (
+                "ensure_flashinfer_weights",
+                "active_flashinfer_weight_shards",
+                "active_flashinfer_multi_micro_weights",
+            )
+        ):
             raise RuntimeError("HunyuanImage3 moe_impl='flashinfer' requires HunyuanImage3MoEWeights.")
 
         if hidden_states.device.type == "cuda" and hidden_states.device.index is not None:
@@ -635,25 +789,62 @@ class HunyuanImage3TransformerInfer(BaseTransformerInfer):
 
         original_dtype = hidden_states.dtype
         compute_dtype = original_dtype if original_dtype in (torch.float16, torch.bfloat16) else torch.bfloat16
+        if self.flashinfer_multi_micro and compute_dtype != torch.bfloat16:
+            raise TypeError(f"HunyuanImage3 flashinfer_multi_micro requires BF16 inference; got compute dtype {compute_dtype}.")
         flat, topk_weight, topk_idx = self._moe_easy_topk(moe, hidden_states)
         fused_input = flat.to(dtype=compute_dtype).contiguous()
-        moe_weight, moe_weight_2 = moe.ensure_flashinfer_weights(fused_input.device, compute_dtype)
-        combined_output = torch.zeros_like(fused_input)
-        flashinfer_cutlass_fused_moe(
-            fused_input,
-            topk_idx.to(torch.int32).contiguous(),
-            topk_weight.to(torch.float32).contiguous(),
-            moe_weight,
-            moe_weight_2,
-            compute_dtype,
-            output=combined_output,
-            quant_scales=None,
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
-            tune_max_num_tokens=self.flashinfer_tune_max_num_tokens,
-        )
+        topk_idx = topk_idx.to(torch.int32).contiguous()
+        topk_weight = topk_weight.to(torch.float32).contiguous()
+
+        use_multi_micro = self.flashinfer_multi_micro and self._active_phase().strip().lower() == "denoise"
+
+        if use_multi_micro:
+            moe_weight, moe_weight_2 = self._active_flashinfer_multi_micro_weights(
+                moe,
+                fused_input.device,
+                compute_dtype,
+            )
+            combined_output = torch.empty_like(fused_input)
+            combined_output = lightx2v_multi_micro_fused_moe(
+                fused_input,
+                topk_idx,
+                topk_weight,
+                moe_weight,
+                moe_weight_2,
+                output=combined_output,
+                backend=self.flashinfer_multi_micro_backend,
+            )
+        else:
+            shards = self._active_flashinfer_weight_shards(moe, fused_input.device, compute_dtype)
+            if flashinfer_cutlass_fused_moe is None:
+                raise ImportError("HunyuanImage3 moe_impl='flashinfer' requires flashinfer.fused_moe.cutlass_fused_moe.")
+            _, _, active_tp_size, _ = self._active_tp_state()
+            micro_tp_size = self._flashinfer_micro_tp_size(moe, len(shards), active_tp_size)
+            combined_output = None
+            for _, canonical_tp_rank, moe_weight, moe_weight_2 in shards:
+                if canonical_tp_rank < 0 or canonical_tp_rank >= micro_tp_size:
+                    raise ValueError(f"HunyuanImage3 FlashInfer canonical TP rank {canonical_tp_rank} is outside micro TP size {micro_tp_size}.")
+                shard_output = torch.zeros_like(fused_input)
+                flashinfer_cutlass_fused_moe(
+                    fused_input,
+                    topk_idx,
+                    topk_weight,
+                    moe_weight,
+                    moe_weight_2,
+                    compute_dtype,
+                    output=shard_output,
+                    quant_scales=None,
+                    tp_size=micro_tp_size,
+                    tp_rank=canonical_tp_rank,
+                    tune_max_num_tokens=self.flashinfer_tune_max_num_tokens,
+                )
+                if combined_output is None:
+                    combined_output = shard_output
+                else:
+                    combined_output.add_(shard_output)
+            assert combined_output is not None
         output = combined_output.reshape_as(hidden_states).to(original_dtype)
         if getattr(moe, "shared_mlp", None) is not None:
-            shared_out = apply_mlp(moe.shared_mlp.gate_and_up_proj, moe.shared_mlp.down_proj, hidden_states, self.hidden_act)
+            shared_out = self._apply_phase_mlp(moe.shared_mlp.gate_and_up_proj, moe.shared_mlp.down_proj, hidden_states)
             output = output + shared_out.to(output.dtype)
         return output

--- a/lightx2v/models/networks/hunyuan_image3/model.py
+++ b/lightx2v/models/networks/hunyuan_image3/model.py
@@ -12,6 +12,14 @@ from lightx2v.models.networks.hunyuan_image3.infer.module_io import HunyuanImage
 from lightx2v.models.networks.hunyuan_image3.infer.post_infer import HunyuanImage3PostInfer
 from lightx2v.models.networks.hunyuan_image3.infer.pre_infer import HunyuanImage3PreInfer
 from lightx2v.models.networks.hunyuan_image3.infer.transformer_infer import HunyuanImage3TransformerInfer
+from lightx2v.models.networks.hunyuan_image3.weights.hybrid_tp import (
+    resolve_micro_shard_count,
+    resolve_storage_tp,
+    select_column_storage_shard,
+    select_fused_gate_up_storage_shard,
+    select_grouped_qkv_storage_shard,
+    select_row_storage_shard,
+)
 from lightx2v.models.networks.hunyuan_image3.weights.post_weights import HunyuanImage3PostWeights
 from lightx2v.models.networks.hunyuan_image3.weights.pre_weights import HunyuanImage3PreWeights
 from lightx2v.models.networks.hunyuan_image3.weights.transformer_weights import HunyuanImage3TransformerWeights
@@ -175,15 +183,19 @@ class HunyuanImage3Model(BaseTransformerModel):
         # HunyuanImage3 shards safetensors locally on every TP rank instead of
         # using BaseTransformerModel's rank-0 loading and broadcast path.
         self.use_tp = False
-        self.tensor_parallel = bool(self.config.get("tensor_parallel", False))
+        self.parallel_context, storage_group, storage_rank, storage_size = resolve_storage_tp(self.config)
+        self.tensor_parallel = bool(self.config.get("tensor_parallel", False) or storage_size > 1)
         if self.tensor_parallel:
-            self.tp_group = self.config["device_mesh"].get_group(mesh_dim="tensor_p")
-            self.tp_rank = dist.get_rank(self.tp_group)
-            self.tp_size = dist.get_world_size(self.tp_group)
+            # These model-level fields intentionally describe resident weight
+            # topology, never the phase-dependent active AR topology.
+            self.tp_group = storage_group
+            self.tp_rank = storage_rank
+            self.tp_size = storage_size
         else:
             self.tp_group = None
             self.tp_rank = 0
             self.tp_size = 1
+        self.micro_shard_count = resolve_micro_shard_count(self.config, self.tp_size)
 
     @staticmethod
     def _iter_config_ints(value):
@@ -228,10 +240,11 @@ class HunyuanImage3Model(BaseTransformerModel):
                 moe_intermediate *= len(shared_experts)
             divisibility_checks["shared_mlp_intermediate_size"] = [experts * intermediate for experts, intermediate in zip(shared_experts, moe_intermediate)]
 
+        finest_tp_size = self.tp_size * self.micro_shard_count
         for name, values in divisibility_checks.items():
-            invalid = sorted({value for value in values if value % self.tp_size})
+            invalid = sorted({value for value in values if value % finest_tp_size})
             if invalid:
-                raise ValueError(f"HunyuanImage3 TP size {self.tp_size} must divide every {name}; invalid values: {invalid}.")
+                raise ValueError(f"HunyuanImage3 storage TP size {self.tp_size} * micro_shard_count {self.micro_shard_count} must divide every {name}; invalid values: {invalid}.")
 
     @staticmethod
     def _tp_split_type(key):
@@ -256,25 +269,26 @@ class HunyuanImage3Model(BaseTransformerModel):
 
         if split_type == "row":
             # Row-parallel biases are replicated and added after the reduction.
-            if tensor.ndim == 1:
-                return tensor
-            if tensor.ndim != 2 or tensor.shape[1] % self.tp_size:
-                raise ValueError(f"Cannot row-shard HunyuanImage3 tensor {key} with shape {tuple(tensor.shape)} across TP size {self.tp_size}.")
-            return torch.chunk(tensor, self.tp_size, dim=1)[self.tp_rank].contiguous()
+            return select_row_storage_shard(tensor, self.tp_rank, self.tp_size)
+
+        if split_type == "qkv_col":
+            num_heads = int(self.config.get("num_attention_heads") or self.config["num_heads"])
+            num_kv_heads = int(self.config.get("num_key_value_heads") or num_heads)
+            head_dim = int(self.config.get("attention_head_dim", self.config["hidden_size"] // num_heads))
+            return select_grouped_qkv_storage_shard(
+                tensor,
+                self.tp_rank,
+                self.tp_size,
+                self.micro_shard_count,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            )
 
         if split_type == "gate_up_col":
-            if tensor.shape[0] % 2:
-                raise ValueError(f"HunyuanImage3 fused gate/up tensor {key} has an odd output dimension: {tuple(tensor.shape)}.")
-            gate, up = tensor.chunk(2, dim=0)
-            if gate.shape[0] % self.tp_size:
-                raise ValueError(f"Cannot shard HunyuanImage3 fused gate/up tensor {key} with shape {tuple(tensor.shape)} across TP size {self.tp_size}.")
-            gate_shard = torch.chunk(gate, self.tp_size, dim=0)[self.tp_rank]
-            up_shard = torch.chunk(up, self.tp_size, dim=0)[self.tp_rank]
-            return torch.cat((gate_shard, up_shard), dim=0).contiguous()
+            return select_fused_gate_up_storage_shard(tensor, self.tp_rank, self.tp_size, self.micro_shard_count)
 
-        if tensor.shape[0] % self.tp_size:
-            raise ValueError(f"Cannot column-shard HunyuanImage3 tensor {key} with shape {tuple(tensor.shape)} across TP size {self.tp_size}.")
-        return torch.chunk(tensor, self.tp_size, dim=0)[self.tp_rank].contiguous()
+        return select_column_storage_shard(tensor, self.tp_rank, self.tp_size)
 
     def _resolve_sequence_parallel_attn_type(self):
         if not self.config.get("seq_parallel", False):
@@ -369,6 +383,28 @@ class HunyuanImage3Model(BaseTransformerModel):
         if hasattr(self.transformer_infer, "offload_manager"):
             self._init_offload_manager()
 
+    def _active_seq_group(self):
+        if self.parallel_context is not None:
+            return getattr(self.parallel_context, "active_seq_group", getattr(self.parallel_context, "seq_p_group", None))
+        return self.seq_p_group
+
+    def _active_seq_size(self):
+        if self.parallel_context is not None:
+            return int(getattr(self.parallel_context, "active_seq_size", getattr(self.parallel_context, "seq_p_size", 1)))
+        group = self._active_seq_group()
+        return dist.get_world_size(group) if group is not None else 1
+
+    def _active_seq_rank(self):
+        if self.parallel_context is not None:
+            return int(getattr(self.parallel_context, "active_seq_rank", getattr(self.parallel_context, "seq_p_rank", 0)))
+        group = self._active_seq_group()
+        return dist.get_rank(group) if group is not None else 0
+
+    def _active_seq_parallel(self):
+        if self.parallel_context is not None:
+            return bool(getattr(self.parallel_context, "active_seq_parallel", self._active_seq_size() > 1)) and self._active_seq_size() > 1
+        return bool(self.config.get("seq_parallel", False))
+
     def reset_taylor_cache(self):
         self.taylor_cache = None
         self.taylor_counter = 0
@@ -386,7 +422,7 @@ class HunyuanImage3Model(BaseTransformerModel):
 
     def _infer_transformer(self, pre_infer_out):
         hidden_states = self.transformer_infer.infer(self.transformer_weights, pre_infer_out)
-        if self.config["seq_parallel"]:
+        if self._active_seq_parallel():
             hidden_states = self._seq_parallel_post_process(hidden_states, pre_infer_out.sequence_parallel_state)
         return hidden_states
 
@@ -423,7 +459,7 @@ class HunyuanImage3Model(BaseTransformerModel):
             self.scheduler.infer_condition = infer_condition
         pre_infer_out = self.pre_infer.infer(self.pre_weight, inputs)
         # in default setting seq_parallel is False
-        if self.config["seq_parallel"]:
+        if self._active_seq_parallel():
             pre_infer_out = self._seq_parallel_pre_process(pre_infer_out)
         if inputs.get("cache_dic") is not None:
             hidden_states = self._infer_transformer_with_taylor_cache(pre_infer_out, inputs["cache_dic"])
@@ -439,8 +475,11 @@ class HunyuanImage3Model(BaseTransformerModel):
                 "HunyuanImage3 sequence parallel expects batch size 1 per transformer forward; use parallel.cfg_mode='serial' when cfg_p_size=1 (including TP+SP), or 'parallel' for CFG+SP."
             )
 
-        world_size = dist.get_world_size(self.seq_p_group)
-        rank = dist.get_rank(self.seq_p_group)
+        seq_group = self._active_seq_group()
+        if seq_group is None:
+            raise RuntimeError("HunyuanImage3 sequence parallel is active without an active sequence process group.")
+        world_size = self._active_seq_size()
+        rank = self._active_seq_rank()
         original_seq_len = int(pre_infer_out.hidden_states.shape[1])
         padding_size = (-original_seq_len) % world_size
         padded_seq_len = original_seq_len + padding_size
@@ -489,15 +528,19 @@ class HunyuanImage3Model(BaseTransformerModel):
     def _seq_parallel_post_process(self, x, sequence_parallel_state):
         if sequence_parallel_state is None:
             raise RuntimeError("HunyuanImage3 sequence parallel post-process is missing sequence metadata.")
-        world_size = dist.get_world_size(self.seq_p_group)
+        seq_group = self._active_seq_group()
+        if seq_group is None:
+            raise RuntimeError("HunyuanImage3 sequence parallel is active without an active sequence process group.")
+        world_size = self._active_seq_size()
         local = x.transpose(0, 1).contiguous()
         output_shape = (local.shape[0] * world_size, *local.shape[1:])
-        key = ("hidden", local.device, local.dtype, output_shape)
+        phase = getattr(self.parallel_context, "phase", "legacy") if self.parallel_context is not None else "legacy"
+        key = ("hidden", phase, id(seq_group), local.device, local.dtype, output_shape)
         gathered = self._sp_gather_buffers.get(key)
         if gathered is None or gathered.shape != output_shape:
             gathered = torch.empty(output_shape, device=local.device, dtype=local.dtype)
             self._sp_gather_buffers[key] = gathered
-        dist.all_gather_into_tensor(gathered, local, group=self.seq_p_group)
+        dist.all_gather_into_tensor(gathered, local, group=seq_group)
         return gathered[: sequence_parallel_state.original_seq_len].transpose(0, 1).contiguous()
 
     @staticmethod

--- a/lightx2v/models/networks/hunyuan_image3/parallel.py
+++ b/lightx2v/models/networks/hunyuan_image3/parallel.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Mapping
+
+import torch
+import torch.distributed as dist
+from loguru import logger
+from torch.distributed.tensor.device_mesh import DeviceMesh, init_device_mesh
+
+from lightx2v_platform.base.global_var import AI_DEVICE
+
+_PHASE_ALIASES = {
+    "ar": "ar",
+    "autoregressive": "ar",
+    "denoise": "denoise",
+    "diffusion": "denoise",
+}
+
+
+@dataclass(frozen=True)
+class _PhaseParallelState:
+    tp_group: dist.ProcessGroup
+    tp_rank: int
+    tp_size: int
+    seq_group: dist.ProcessGroup | None
+    seq_rank: int
+    seq_size: int
+    logical_tp_rank: int
+    logical_gather_order: tuple[int, ...]
+
+
+class HunyuanImage3ParallelContext:
+    """Static process groups with a lightweight AR/denoise phase selector.
+
+    The storage and denoise tensor-parallel layouts are identical. Sequence
+    ranks therefore hold replicas of the same storage shard (``ABAB`` for the
+    four-rank TP2+SP2 layout). AR further slices each storage shard locally and
+    uses every process as one logical TP rank without redistributing weights.
+
+    ``active_tp_rank`` is the rank in the physical process group. AR's logical
+    weight order differs from that physical order, so weight selection must use
+    ``logical_tp_rank`` and ordered gathers must apply
+    ``logical_gather_order``.
+    """
+
+    def __init__(
+        self,
+        *,
+        device_mesh: DeviceMesh,
+        storage_tp_group: dist.ProcessGroup,
+        storage_tp_rank: int,
+        storage_tp_size: int,
+        local_micro_shard_id: int,
+        micro_shard_count: int,
+        ar_tp_size: int,
+        denoise_tp_size: int,
+        denoise_seq_size: int,
+        phase_states: Mapping[str, _PhaseParallelState],
+        initial_phase: str = "denoise",
+    ):
+        self.device_mesh = device_mesh
+        self.denoise_device_mesh = device_mesh
+        self.storage_tp_group = storage_tp_group
+        self.storage_tp_rank = int(storage_tp_rank)
+        self.storage_tp_size = int(storage_tp_size)
+        self.local_micro_shard_id = int(local_micro_shard_id)
+        self.micro_shard_count = int(micro_shard_count)
+        self.ar_tp_size = int(ar_tp_size)
+        self.denoise_tp_size = int(denoise_tp_size)
+        self.denoise_seq_size = int(denoise_seq_size)
+        self._phase_states = dict(phase_states)
+        self._phase = self._normalize_phase(initial_phase)
+
+    @staticmethod
+    def _normalize_phase(name: str) -> str:
+        normalized = _PHASE_ALIASES.get(str(name).strip().lower())
+        if normalized is None:
+            supported = ", ".join(sorted(_PHASE_ALIASES))
+            raise ValueError(f"Unsupported HunyuanImage3 parallel phase {name!r}; expected one of: {supported}.")
+        return normalized
+
+    @property
+    def phase(self) -> str:
+        return self._phase
+
+    def _assert_distributed_phase_consensus(self, target_phase: str | None) -> None:
+        """Fail all ranks together when local phase state or target diverges.
+
+        A rank-local early return is unsafe if another rank believes it still
+        needs to enter the transition barrier.  This small WORLD collective is
+        therefore also executed for no-op activations.
+        """
+
+        if not dist.is_available() or not dist.is_initialized() or dist.get_world_size() == 1:
+            return
+
+        phase_codes = {"ar": 0, "denoise": 1}
+        status_device = torch.device("cpu")
+        if dist.get_backend() == "nccl":
+            if not torch.cuda.is_available():
+                raise RuntimeError("HunyuanImage3 NCCL phase consensus requires CUDA.")
+            status_device = torch.device("cuda", torch.cuda.current_device())
+        local_status = torch.tensor(
+            [phase_codes.get(self._phase, -1), phase_codes.get(target_phase, -1)],
+            device=status_device,
+            dtype=torch.int32,
+        )
+        world_size = dist.get_world_size()
+        gathered_status = torch.empty(world_size * 2, device=status_device, dtype=torch.int32)
+        dist.all_gather_into_tensor(gathered_status, local_status, group=dist.group.WORLD)
+        gathered_status = gathered_status.view(world_size, 2).cpu().tolist()
+        current_codes = {int(status[0]) for status in gathered_status}
+        target_codes = {int(status[1]) for status in gathered_status}
+        code_names = {value: key for key, value in phase_codes.items()} | {-1: "<invalid>"}
+        if len(current_codes) != 1 or len(target_codes) != 1 or -1 in current_codes or -1 in target_codes:
+            current_names = sorted(code_names.get(code, f"<invalid:{code}>") for code in current_codes)
+            target_names = sorted(code_names.get(code, f"<invalid:{code}>") for code in target_codes)
+            raise RuntimeError(f"HunyuanImage3 distributed phase state diverged across ranks: current={current_names}, target={target_names}.")
+
+    def activate_phase(self, name: str) -> HunyuanImage3ParallelContext:
+        """Synchronize all ranks, then select a pre-built compute topology.
+
+        No process group or weight tensor is created here.  The synchronization
+        prevents one rank from entering a collective for the next phase while
+        another rank still has work queued for the previous topology.
+        """
+
+        phase = _PHASE_ALIASES.get(str(name).strip().lower())
+        self._assert_distributed_phase_consensus(phase)
+        if phase is None:
+            # Single-process callers do not enter the consensus collective;
+            # preserve the detailed public validation error for that case.
+            self._normalize_phase(name)
+            raise AssertionError("Unreachable HunyuanImage3 phase validation path.")
+        if phase == self._phase:
+            return self
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        if dist.is_available() and dist.is_initialized():
+            if dist.get_backend() == "nccl" and torch.cuda.is_available():
+                dist.barrier(device_ids=[torch.cuda.current_device()])
+            else:
+                dist.barrier()
+
+        self._phase = phase
+        allocated_gib = reserved_gib = 0.0
+        if torch.cuda.is_available():
+            allocated_gib = torch.cuda.memory_allocated() / 2**30
+            reserved_gib = torch.cuda.memory_reserved() / 2**30
+        logger.info(
+            "HunyuanImage3 activated phase={} global_rank={} active_tp_rank={}/{} logical_tp_rank={} active_sp_rank={}/{} cuda_allocated_gib={:.3f} cuda_reserved_gib={:.3f}",
+            phase,
+            dist.get_rank() if dist.is_available() and dist.is_initialized() else 0,
+            self.active_tp_rank,
+            self.active_tp_size,
+            self.logical_tp_rank,
+            self.active_seq_rank,
+            self.active_seq_size,
+            allocated_gib,
+            reserved_gib,
+        )
+        return self
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[HunyuanImage3ParallelContext]:
+        """Temporarily activate a phase and restore the previous phase."""
+
+        previous = self._phase
+        self.activate_phase(name)
+        try:
+            yield self
+        finally:
+            self.activate_phase(previous)
+
+    @property
+    def _active(self) -> _PhaseParallelState:
+        return self._phase_states[self._phase]
+
+    @property
+    def active_tp_group(self) -> dist.ProcessGroup:
+        return self._active.tp_group
+
+    @property
+    def active_tp_rank(self) -> int:
+        return self._active.tp_rank
+
+    @property
+    def active_tp_size(self) -> int:
+        return self._active.tp_size
+
+    @property
+    def active_seq_group(self) -> dist.ProcessGroup | None:
+        return self._active.seq_group
+
+    @property
+    def active_seq_rank(self) -> int:
+        return self._active.seq_rank
+
+    @property
+    def active_seq_size(self) -> int:
+        return self._active.seq_size
+
+    @property
+    def active_seq_parallel(self) -> bool:
+        return self.active_seq_size > 1
+
+    @property
+    def logical_tp_rank(self) -> int:
+        return self._active.logical_tp_rank
+
+    @property
+    def logical_gather_order(self) -> tuple[int, ...]:
+        return self._active.logical_gather_order
+
+    # Compatibility aliases used by existing HunyuanImage3 model/infer code.
+    @property
+    def tp_group(self) -> dist.ProcessGroup:
+        return self.active_tp_group
+
+    @property
+    def tp_rank(self) -> int:
+        return self.active_tp_rank
+
+    @property
+    def tp_size(self) -> int:
+        return self.active_tp_size
+
+    @property
+    def seq_p_group(self) -> dist.ProcessGroup | None:
+        return self.active_seq_group
+
+    @property
+    def seq_p_rank(self) -> int:
+        return self.active_seq_rank
+
+    @property
+    def seq_p_size(self) -> int:
+        return self.active_seq_size
+
+
+# The context owns both the static topology and the active phase selector. Keep
+# this semantic alias for callers that prefer the topology-oriented name.
+HunyuanImage3ParallelTopology = HunyuanImage3ParallelContext
+
+
+def _positive_int(value, name: str) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"HunyuanImage3 {name} must be a positive integer, got {value!r}.") from error
+    if result < 1:
+        raise ValueError(f"HunyuanImage3 {name} must be a positive integer, got {result}.")
+    return result
+
+
+def build_hunyuan_image3_parallel_context(config) -> HunyuanImage3ParallelContext:
+    """Create all groups for the phase-aware four-rank topology once.
+
+    The canonical rank matrix is ``[denoise_seq, denoise_tensor]``. With the
+    requested sizes this is ``[[0, 1], [2, 3]]``: storage/denoise TP groups are
+    ``[0, 1]`` and ``[2, 3]`` while SP groups are ``[0, 2]`` and ``[1, 3]``.
+    AR uses WORLD in physical rank order and exposes the logical permutation
+    ``(0, 2, 1, 3)`` for ordered outputs such as vocabulary logits.
+    """
+
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError("HunyuanImage3 phase-aware parallelism requires torch.distributed initialization.")
+
+    parallel = config.get("parallel") or {}
+    if not parallel.get("phase_aware", False):
+        raise ValueError("HunyuanImage3 phase-aware parallel context requires parallel.phase_aware=true.")
+
+    storage_tp_size = _positive_int(parallel.get("storage_tensor_p_size"), "parallel.storage_tensor_p_size")
+    ar = parallel.get("ar") or {}
+    denoise = parallel.get("denoise") or {}
+    ar_tp_size = _positive_int(ar.get("tensor_p_size"), "parallel.ar.tensor_p_size")
+    ar_seq_size = _positive_int(ar.get("seq_p_size", 1), "parallel.ar.seq_p_size")
+    denoise_tp_size = _positive_int(denoise.get("tensor_p_size"), "parallel.denoise.tensor_p_size")
+    denoise_seq_size = _positive_int(denoise.get("seq_p_size"), "parallel.denoise.seq_p_size")
+
+    if ar_seq_size != 1:
+        raise ValueError(f"HunyuanImage3 phase-aware AR supports tensor parallel only; parallel.ar.seq_p_size must be 1, got {ar_seq_size}.")
+    if storage_tp_size != denoise_tp_size:
+        raise ValueError(f"HunyuanImage3 phase-aware storage TP must equal denoise TP so denoise can reuse the loaded shards: storage={storage_tp_size}, denoise_tp={denoise_tp_size}.")
+    if ar_tp_size % storage_tp_size:
+        raise ValueError(f"HunyuanImage3 AR TP size ({ar_tp_size}) must be divisible by storage TP size ({storage_tp_size}).")
+
+    micro_shard_count = ar_tp_size // storage_tp_size
+    if micro_shard_count != denoise_seq_size:
+        raise ValueError(f"HunyuanImage3 local micro-shard count must equal denoise SP size for the ABAB layout: ar_tp/storage_tp={micro_shard_count}, denoise_sp={denoise_seq_size}.")
+
+    world_size = dist.get_world_size()
+    if ar_tp_size != world_size or denoise_tp_size * denoise_seq_size != world_size:
+        raise ValueError(f"HunyuanImage3 phase sizes must each cover the distributed world: ar_tp={ar_tp_size}, denoise_tp={denoise_tp_size}, denoise_sp={denoise_seq_size}, world_size={world_size}.")
+
+    device_mesh = init_device_mesh(
+        AI_DEVICE,
+        (denoise_seq_size, denoise_tp_size),
+        mesh_dim_names=("seq_p", "tensor_p"),
+    )
+    storage_tp_group = device_mesh.get_group(mesh_dim="tensor_p")
+    storage_tp_rank = dist.get_rank(storage_tp_group)
+    if denoise_seq_size > 1:
+        denoise_seq_group = device_mesh.get_group(mesh_dim="seq_p")
+        denoise_seq_rank = dist.get_rank(denoise_seq_group)
+    else:
+        denoise_seq_group = None
+        denoise_seq_rank = 0
+
+    local_micro_shard_id = denoise_seq_rank
+    logical_tp_rank = storage_tp_rank * micro_shard_count + local_micro_shard_id
+
+    # WORLD gathers in physical global-rank order. Map those positions to the
+    # logical contiguous shard order required by lm_head and similar outputs.
+    physical_to_logical = []
+    for physical_rank in range(world_size):
+        storage_rank = physical_rank % denoise_tp_size
+        micro_shard_id = physical_rank // denoise_tp_size
+        physical_to_logical.append(storage_rank * micro_shard_count + micro_shard_id)
+    if sorted(physical_to_logical) != list(range(ar_tp_size)):
+        raise RuntimeError(f"Invalid HunyuanImage3 AR logical TP mapping: {physical_to_logical}.")
+    logical_gather_order = tuple(sorted(range(world_size), key=physical_to_logical.__getitem__))
+
+    phase_states = {
+        "ar": _PhaseParallelState(
+            tp_group=dist.group.WORLD,
+            tp_rank=dist.get_rank(),
+            tp_size=world_size,
+            seq_group=None,
+            seq_rank=0,
+            seq_size=1,
+            logical_tp_rank=logical_tp_rank,
+            logical_gather_order=logical_gather_order,
+        ),
+        "denoise": _PhaseParallelState(
+            tp_group=storage_tp_group,
+            tp_rank=storage_tp_rank,
+            tp_size=denoise_tp_size,
+            seq_group=denoise_seq_group,
+            seq_rank=denoise_seq_rank,
+            seq_size=denoise_seq_size,
+            logical_tp_rank=storage_tp_rank,
+            logical_gather_order=tuple(range(denoise_tp_size)),
+        ),
+    }
+
+    return HunyuanImage3ParallelContext(
+        device_mesh=device_mesh,
+        storage_tp_group=storage_tp_group,
+        storage_tp_rank=storage_tp_rank,
+        storage_tp_size=storage_tp_size,
+        local_micro_shard_id=local_micro_shard_id,
+        micro_shard_count=micro_shard_count,
+        ar_tp_size=ar_tp_size,
+        denoise_tp_size=denoise_tp_size,
+        denoise_seq_size=denoise_seq_size,
+        phase_states=phase_states,
+    )
+
+
+def build_hunyuan_image3_parallel_topology(config) -> HunyuanImage3ParallelContext:
+    return build_hunyuan_image3_parallel_context(config)
+
+
+def get_hunyuan_image3_parallel_context(config, *, required: bool = False) -> HunyuanImage3ParallelContext | None:
+    context = config.get("parallel_context") or config.get("hunyuan_image3_parallel_context")
+    if context is None and required:
+        raise RuntimeError("HunyuanImage3 phase-aware parallel context is not initialized.")
+    return context

--- a/lightx2v/models/networks/hunyuan_image3/weights/common.py
+++ b/lightx2v/models/networks/hunyuan_image3/weights/common.py
@@ -1,11 +1,18 @@
 import math
 
 import torch
-import torch.distributed as dist
 import torch.nn.functional as F
 
 import lightx2v.common.ops  # noqa: F401
 from lightx2v.common.modules.weight_module import WeightModule, WeightModuleList
+from lightx2v.models.networks.hunyuan_image3.weights.hybrid_tp import (
+    FUSED_GATE_UP_LAYOUT,
+    GROUPED_QKV_LAYOUT,
+    PLAIN_LAYOUT,
+    HunyuanImage3HybridTensorParallelLinear,
+    resolve_micro_shard_count,
+    resolve_storage_tp,
+)
 from lightx2v.utils.registry_factory import MM_WEIGHT_REGISTER, RMS_WEIGHT_REGISTER
 from lightx2v_platform.base.global_var import AI_DEVICE
 
@@ -41,6 +48,7 @@ def hunyuan_image3_mm_weight(
     weight_name,
     bias_name=None,
     split_dim=None,
+    weight_layout=PLAIN_LAYOUT,
     reduce_output=True,
     create_cuda_buffer=False,
     create_cpu_buffer=False,
@@ -50,14 +58,45 @@ def hunyuan_image3_mm_weight(
     lora_path=None,
 ):
     if config.get("tensor_parallel", False) and split_dim is not None:
-        tp_group = config["device_mesh"].get_group(mesh_dim="tensor_p")
+        parallel_context, tp_group, tp_rank, tp_size = resolve_storage_tp(config)
+        if parallel_context is not None:
+            micro_shard_count = resolve_micro_shard_count(config, tp_size)
+            qkv_group_width = None
+            if weight_layout == GROUPED_QKV_LAYOUT:
+                heads = int(config.get("num_attention_heads") or config["num_heads"])
+                kv_heads = int(config.get("num_key_value_heads") or heads)
+                head_dim = int(config.get("attention_head_dim", config["hidden_size"] // heads))
+                if heads % kv_heads:
+                    raise ValueError(f"HunyuanImage3 Q heads ({heads}) must be divisible by KV heads ({kv_heads}).")
+                qkv_group_width = (heads // kv_heads + 2) * head_dim
+            return HunyuanImage3HybridTensorParallelLinear(
+                weight_name=weight_name,
+                bias_name=bias_name,
+                mm_type=mm_type,
+                tp_group=tp_group,
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+                split_dim=split_dim,
+                parallel_context=parallel_context,
+                micro_shard_count=micro_shard_count,
+                weight_layout=weight_layout,
+                qkv_group_width=qkv_group_width,
+                hidden_act=config.get("hidden_act", "silu"),
+                create_cuda_buffer=create_cuda_buffer,
+                create_cpu_buffer=create_cpu_buffer,
+                lazy_load=lazy_load,
+                lazy_load_file=lazy_load_file,
+                lora_prefix=lora_prefix,
+                lora_path=lora_path,
+                reduce_output=reduce_output,
+            )
         return MM_WEIGHT_REGISTER["TensorParallel"](
             weight_name=weight_name,
             bias_name=bias_name,
             mm_type=mm_type,
             tp_group=tp_group,
-            tp_rank=dist.get_rank(tp_group),
-            tp_size=dist.get_world_size(tp_group),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
             split_dim=split_dim,
             create_cuda_buffer=create_cuda_buffer,
             create_cpu_buffer=create_cpu_buffer,
@@ -311,6 +350,7 @@ class HunyuanImage3DenseMLPWeights(WeightModule):
                 f"{prefix}.gate_and_up_proj.weight",
                 gate_and_up_bias,
                 split_dim="col",
+                weight_layout=FUSED_GATE_UP_LAYOUT,
                 create_cuda_buffer=create_cuda_buffer,
                 create_cpu_buffer=create_cpu_buffer,
                 lazy_load=lazy_load,
@@ -355,6 +395,9 @@ class HunyuanImage3MoEWeights(WeightModule):
         self.num_experts = int(_moe_value(config, "num_experts", block_index, 1))
         self.moe_topk = int(_moe_value(config, "moe_topk", block_index, 1))
         self.moe_impl = config.get("moe_impl", "eager")
+        self.parallel_context, _, self.storage_tp_rank, self.storage_tp_size = resolve_storage_tp(config)
+        self.micro_shard_count = resolve_micro_shard_count(config, self.storage_tp_size) if self.parallel_context is not None else 1
+        self.flashinfer_logical_tp_size = self.storage_tp_size * self.micro_shard_count
         self.moe_weight = None
         self.moe_weight_2 = None
         self._flashinfer_weights_initialized = False
@@ -446,7 +489,10 @@ class HunyuanImage3MoEWeights(WeightModule):
             raise RuntimeError("HunyuanImage3 moe_impl='flashinfer' expects bias-free expert MLP weights.")
 
         # LightX2V MM weights are stored as [in, out] for torch.mm(input, weight).
-        # FlashInfer follows torch.nn.Linear/checkpoint layout [out, in].
+        # FlashInfer follows torch.nn.Linear/checkpoint layout [out, in].  For
+        # the default loader the transpose is already a contiguous view of the
+        # checkpoint tensor, so this does not allocate unless device/dtype
+        # conversion is genuinely required during one-time initialization.
         return weight.t().to(device=device, dtype=dtype).contiguous()
 
     @classmethod
@@ -458,30 +504,80 @@ class HunyuanImage3MoEWeights(WeightModule):
                 setattr(linear, attr, empty)
 
     def ensure_flashinfer_weights(self, device, dtype):
+        """Build the single phase-neutral ``[micro, expert, ...]`` pack.
+
+        AR selects one leading-axis view.  Denoising selects both views and
+        sums their partial outputs before its storage-TP all-reduce.  The pack
+        is never rebuilt or converted when the active phase changes.
+        """
+
         device = torch.device(device)
         if dtype not in (torch.float16, torch.bfloat16):
             dtype = torch.bfloat16
 
         if self._flashinfer_weights_initialized:
-            if self.moe_weight.device != device:
-                self.moe_weight = self.moe_weight.to(device=device)
-                self.moe_weight_2 = self.moe_weight_2.to(device=device)
-            if self.moe_weight.dtype != dtype:
-                self.moe_weight = self.moe_weight.to(dtype=dtype)
-                self.moe_weight_2 = self.moe_weight_2.to(dtype=dtype)
-            self._flashinfer_weight_device = self.moe_weight.device
-            self._flashinfer_weight_dtype = self.moe_weight.dtype
+            if self.moe_weight.device != device or self.moe_weight.dtype != dtype:
+                raise RuntimeError(
+                    "HunyuanImage3 phase-neutral FlashInfer weights cannot be converted after initialization: "
+                    f"resident=({self.moe_weight.device}, {self.moe_weight.dtype}), requested=({device}, {dtype})."
+                )
+            if self.parallel_context is None:
+                return self.moe_weight[0], self.moe_weight_2[0]
             return self.moe_weight, self.moe_weight_2
 
-        expert_weights_gate_up = []
-        expert_weights_down = []
-        for expert in self.experts:
-            expert_weights_gate_up.append(self._linear_weight_for_flashinfer(expert.gate_and_up_proj, device, dtype))
-            expert_weights_down.append(self._linear_weight_for_flashinfer(expert.down_proj, device, dtype))
+        first_gate_up = self._linear_weight_for_flashinfer(self.experts[0].gate_and_up_proj, device, dtype)
+        first_down = self._linear_weight_for_flashinfer(self.experts[0].down_proj, device, dtype)
+        if first_gate_up.ndim != 2 or first_gate_up.shape[0] % (2 * self.micro_shard_count):
+            raise RuntimeError(f"Invalid HunyuanImage3 FlashInfer gate/up resident shape {tuple(first_gate_up.shape)} for {self.micro_shard_count} micro shards.")
+        micro_intermediate = first_gate_up.shape[0] // (2 * self.micro_shard_count)
+        hidden_size = first_gate_up.shape[1]
+        if first_down.shape != (hidden_size, self.micro_shard_count * micro_intermediate):
+            raise RuntimeError(f"HunyuanImage3 FlashInfer down weight does not match gate/up micro shards: gate_up={tuple(first_gate_up.shape)}, down={tuple(first_down.shape)}.")
 
-        self.moe_weight = torch.stack(expert_weights_gate_up, dim=0).contiguous()
-        self.moe_weight_2 = torch.stack(expert_weights_down, dim=0).contiguous()
+        # Allocate the final resident pack once and copy experts into it
+        # directly. This avoids retaining a second list of expert tensors;
+        # sources are released together after the full pack is validated.
+        self.moe_weight = torch.empty(
+            self.micro_shard_count,
+            self.num_experts,
+            2 * micro_intermediate,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        self.moe_weight_2 = torch.empty(
+            self.micro_shard_count,
+            self.num_experts,
+            hidden_size,
+            micro_intermediate,
+            device=device,
+            dtype=dtype,
+        )
 
+        for expert_index, expert in enumerate(self.experts):
+            if expert_index == 0:
+                gate_up = first_gate_up
+                down = first_down
+            else:
+                gate_up = self._linear_weight_for_flashinfer(expert.gate_and_up_proj, device, dtype)
+                down = self._linear_weight_for_flashinfer(expert.down_proj, device, dtype)
+            if gate_up.shape != first_gate_up.shape or down.shape != first_down.shape:
+                raise RuntimeError(f"HunyuanImage3 expert {expert_index} shape differs while building the universal FlashInfer pack: gate_up={tuple(gate_up.shape)}, down={tuple(down.shape)}.")
+
+            # gate_up was organized by the checkpoint loader as
+            # [g_micro0,u_micro0,g_micro1,u_micro1,...].  Down remains
+            # [hidden, intermediate_micro0, intermediate_micro1,...].
+            gate_up_micro = gate_up.reshape(self.micro_shard_count, 2 * micro_intermediate, hidden_size)
+            down_micro = down.reshape(hidden_size, self.micro_shard_count, micro_intermediate).permute(1, 0, 2)
+            self.moe_weight[:, expert_index].copy_(gate_up_micro)
+            self.moe_weight_2[:, expert_index].copy_(down_micro)
+
+        if not all(self.moe_weight[index].is_contiguous() and self.moe_weight_2[index].is_contiguous() for index in range(self.micro_shard_count)):
+            raise RuntimeError("HunyuanImage3 FlashInfer micro-shard views must be contiguous.")
+
+        # Release source tensors only after every expert has been validated and
+        # copied. A malformed checkpoint therefore cannot leave a half-built,
+        # non-retryable pack behind.
         for expert in self.experts:
             self._release_linear_weight(expert.gate_and_up_proj, self.moe_weight.device, self.moe_weight.dtype)
             self._release_linear_weight(expert.down_proj, self.moe_weight_2.device, self.moe_weight_2.dtype)
@@ -489,6 +585,60 @@ class HunyuanImage3MoEWeights(WeightModule):
         self._flashinfer_weights_initialized = True
         self._flashinfer_weight_device = self.moe_weight.device
         self._flashinfer_weight_dtype = self.moe_weight.dtype
+        if self.parallel_context is None:
+            return self.moe_weight[0], self.moe_weight_2[0]
+        return self.moe_weight, self.moe_weight_2
+
+    def _active_flashinfer_micro_shard_ids(self):
+        if self.parallel_context is None or self.micro_shard_count == 1:
+            return (0,)
+        active_tp_size = int(getattr(self.parallel_context, "active_tp_size", getattr(self.parallel_context, "tp_size", self.storage_tp_size)))
+        if active_tp_size == self.storage_tp_size:
+            return tuple(range(self.micro_shard_count))
+        if active_tp_size == self.flashinfer_logical_tp_size:
+            micro_id = int(getattr(self.parallel_context, "local_micro_shard_id"))
+            if not 0 <= micro_id < self.micro_shard_count:
+                raise RuntimeError(f"Invalid HunyuanImage3 local FlashInfer micro shard id {micro_id}.")
+            return (micro_id,)
+        raise RuntimeError(f"HunyuanImage3 FlashInfer active TP size must be {self.storage_tp_size} or {self.flashinfer_logical_tp_size}; got {active_tp_size}.")
+
+    def canonical_flashinfer_tp_rank(self, micro_shard_id):
+        micro_shard_id = int(micro_shard_id)
+        if not 0 <= micro_shard_id < self.micro_shard_count:
+            raise ValueError(f"Invalid HunyuanImage3 FlashInfer micro shard id {micro_shard_id}.")
+        return self.storage_tp_rank * self.micro_shard_count + micro_shard_id
+
+    def active_flashinfer_weight_shards(self, device, dtype):
+        """Return active zero-copy FI views as ``(micro, tp_rank, w1, w2)``."""
+
+        self.ensure_flashinfer_weights(device, dtype)
+        return tuple(
+            (
+                micro_id,
+                self.canonical_flashinfer_tp_rank(micro_id),
+                self.moe_weight[micro_id],
+                self.moe_weight_2[micro_id],
+            )
+            for micro_id in self._active_flashinfer_micro_shard_ids()
+        )
+
+    def active_flashinfer_multi_micro_weights(self, device, dtype):
+        """Return the resident multi-micro packs without copying or reordering.
+
+        The multi-micro MoE path is valid only when every resident micro shard
+        is active (the denoising TP2 phase in the phase-aware topology).  AR
+        continues to select one zero-copy leading-axis view through
+        :meth:`active_flashinfer_weight_shards` and uses the official
+        FlashInfer operator.
+        """
+
+        if self.micro_shard_count != 2:
+            raise RuntimeError(f"HunyuanImage3 multi-micro MoE requires exactly two resident micro shards; got {self.micro_shard_count}.")
+        self.ensure_flashinfer_weights(device, dtype)
+        active_micro_ids = self._active_flashinfer_micro_shard_ids()
+        expected_micro_ids = tuple(range(self.micro_shard_count))
+        if active_micro_ids != expected_micro_ids:
+            raise RuntimeError(f"HunyuanImage3 multi-micro FlashInfer weights require all resident micro shards to be active: active={active_micro_ids}, resident={expected_micro_ids}.")
         return self.moe_weight, self.moe_weight_2
 
 
@@ -527,6 +677,7 @@ class HunyuanImage3AttentionWeights(WeightModule):
                 f"{prefix}.self_attn.qkv_proj.weight",
                 attn_bias and f"{prefix}.self_attn.qkv_proj{attn_bias}",
                 split_dim="col",
+                weight_layout=GROUPED_QKV_LAYOUT,
                 create_cuda_buffer=create_cuda_buffer,
                 create_cpu_buffer=create_cpu_buffer,
                 lazy_load=lazy_load,

--- a/lightx2v/models/networks/hunyuan_image3/weights/hybrid_tp.py
+++ b/lightx2v/models/networks/hunyuan_image3/weights/hybrid_tp.py
@@ -1,0 +1,370 @@
+"""Phase-neutral tensor-parallel weights for HunyuanImage3.
+
+The 80B checkpoint is loaded once with a storage TP degree (two for the
+four-GPU AR/denoise topology).  Every storage shard contains a fixed number
+of contiguous *micro shards*.  Denoising consumes the whole storage shard,
+whereas autoregressive inference consumes the local micro shard selected by
+``parallel_context.local_micro_shard_id``.
+
+Only views are selected when the phase changes.  The one-time checkpoint to
+storage-layout transformation still happens while weights are initialized.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from lightx2v.common.ops.mm.mm_weight import MMWeightTP
+
+PLAIN_LAYOUT = "plain"
+GROUPED_QKV_LAYOUT = "grouped_qkv"
+FUSED_GATE_UP_LAYOUT = "fused_gate_up_micro_major"
+
+
+def _context_value(context: Any, name: str, default=None):
+    if context is None:
+        return default
+    return getattr(context, name, default)
+
+
+def resolve_storage_tp(config):
+    """Return ``(context, group, rank, size)`` for the resident weights.
+
+    The runtime context deliberately owns two topologies.  Loading must use
+    ``storage_tp_*`` and must never consult the phase-dependent active TP
+    aliases.  Falling back to the original device mesh keeps legacy TP
+    configurations working.
+    """
+
+    context = config.get("parallel_context")
+    if context is not None:
+        group = _context_value(context, "storage_tp_group")
+        rank = int(_context_value(context, "storage_tp_rank", 0))
+        size = int(_context_value(context, "storage_tp_size", 1))
+        if size < 1 or not 0 <= rank < size:
+            raise ValueError(f"Invalid HunyuanImage3 storage TP rank/size: rank={rank}, size={size}.")
+        return context, group, rank, size
+
+    if config.get("tensor_parallel", False):
+        group = config["device_mesh"].get_group(mesh_dim="tensor_p")
+        return None, group, dist.get_rank(group), dist.get_world_size(group)
+    return None, None, 0, 1
+
+
+def resolve_micro_shard_count(config, storage_tp_size=None):
+    """Resolve the number of resident micro shards per storage TP rank."""
+
+    context = config.get("parallel_context")
+    if storage_tp_size is None:
+        _, _, _, storage_tp_size = resolve_storage_tp(config)
+
+    value = _context_value(context, "micro_shard_count")
+    if value is not None:
+        count = int(value)
+    else:
+        ar_tp_size = _context_value(context, "ar_tp_size")
+        parallel = config.get("parallel") or {}
+        if ar_tp_size is None:
+            ar_tp_size = parallel.get("ar_tp_size", config.get("ar_tp_size"))
+        if ar_tp_size is not None:
+            ar_tp_size = int(ar_tp_size)
+            if ar_tp_size % storage_tp_size:
+                raise ValueError(f"HunyuanImage3 ar_tp_size={ar_tp_size} must be divisible by storage_tp_size={storage_tp_size}.")
+            count = ar_tp_size // storage_tp_size
+        elif context is None:
+            count = 1
+        else:
+            raise ValueError("HunyuanImage3 parallel_context must expose micro_shard_count (or ar_tp_size) before weights are initialized.")
+
+    if count < 1:
+        raise ValueError(f"HunyuanImage3 micro_shard_count must be positive, got {count}.")
+    return count
+
+
+def select_row_storage_shard(tensor, storage_tp_rank, storage_tp_size):
+    """Select a checkpoint-layout row-parallel shard (split input dim)."""
+
+    if tensor.ndim == 1:
+        return tensor
+    if tensor.ndim != 2 or tensor.shape[1] % storage_tp_size:
+        raise ValueError(f"Cannot row-shard tensor with shape {tuple(tensor.shape)} across storage TP size {storage_tp_size}.")
+    width = tensor.shape[1] // storage_tp_size
+    return tensor.narrow(1, storage_tp_rank * width, width).contiguous()
+
+
+def select_column_storage_shard(tensor, storage_tp_rank, storage_tp_size):
+    """Select a checkpoint-layout column-parallel shard (split output dim)."""
+
+    if tensor.shape[0] % storage_tp_size:
+        raise ValueError(f"Cannot column-shard tensor with shape {tuple(tensor.shape)} across storage TP size {storage_tp_size}.")
+    width = tensor.shape[0] // storage_tp_size
+    return tensor.narrow(0, storage_tp_rank * width, width).contiguous()
+
+
+def select_grouped_qkv_storage_shard(
+    tensor,
+    storage_tp_rank,
+    storage_tp_size,
+    micro_shard_count,
+    num_attention_heads,
+    num_key_value_heads,
+    head_dim,
+):
+    """Shard official HunyuanImage3 QKV by complete KV-head groups.
+
+    The checkpoint output order is
+    ``[kv_head, q_heads_per_kv + key + value, head_dim]``.  Treating a raw
+    fraction of the fused output as the semantic unit is fragile; this helper
+    validates and slices whole KV groups explicitly.
+    """
+
+    if num_attention_heads % num_key_value_heads:
+        raise ValueError(f"HunyuanImage3 Q heads ({num_attention_heads}) must be divisible by KV heads ({num_key_value_heads}).")
+    total_tp_size = storage_tp_size * micro_shard_count
+    if num_key_value_heads % total_tp_size:
+        raise ValueError(f"HunyuanImage3 KV heads ({num_key_value_heads}) must be divisible by storage_tp_size * micro_shard_count ({total_tp_size}).")
+    q_per_kv = num_attention_heads // num_key_value_heads
+    group_width = (q_per_kv + 2) * head_dim
+    expected = num_key_value_heads * group_width
+    if tensor.shape[0] != expected:
+        raise ValueError(f"Unexpected HunyuanImage3 grouped QKV shape {tuple(tensor.shape)}; expected first dimension {expected}.")
+
+    groups_per_storage_rank = num_key_value_heads // storage_tp_size
+    grouped = tensor.reshape(num_key_value_heads, group_width, *tensor.shape[1:])
+    local = grouped.narrow(0, storage_tp_rank * groups_per_storage_rank, groups_per_storage_rank)
+    return local.reshape(groups_per_storage_rank * group_width, *tensor.shape[1:]).contiguous()
+
+
+def select_fused_gate_up_storage_shard(tensor, storage_tp_rank, storage_tp_size, micro_shard_count):
+    """Build one resident gate/up shard in micro-shard-major order.
+
+    Official order is ``[gate_all, up_all]``.  Resident order is
+    ``[gate_micro0, up_micro0, gate_micro1, up_micro1, ...]`` so every AR
+    micro shard is one contiguous view.
+    """
+
+    if tensor.shape[0] % 2:
+        raise ValueError(f"HunyuanImage3 fused gate/up tensor has an odd output dimension: {tuple(tensor.shape)}.")
+    gate, up = tensor.chunk(2, dim=0)
+    total_tp_size = storage_tp_size * micro_shard_count
+    if gate.shape[0] % total_tp_size:
+        raise ValueError(f"Cannot shard fused gate/up tensor with shape {tuple(tensor.shape)} across total TP size {total_tp_size}.")
+
+    micro_width = gate.shape[0] // total_tp_size
+    first_micro = storage_tp_rank * micro_shard_count
+    parts = []
+    for local_micro in range(micro_shard_count):
+        global_micro = first_micro + local_micro
+        start = global_micro * micro_width
+        parts.extend((gate.narrow(0, start, micro_width), up.narrow(0, start, micro_width)))
+    return torch.cat(parts, dim=0).contiguous()
+
+
+def restore_gate_up_projection_order(projected, micro_shard_count):
+    """Convert micro-major projection output back to ``[gate_all, up_all]``."""
+
+    if micro_shard_count == 1:
+        return projected
+    if projected.shape[-1] % (2 * micro_shard_count):
+        raise ValueError(f"Fused gate/up projection width {projected.shape[-1]} is not divisible by 2 * micro_shard_count ({2 * micro_shard_count}).")
+    micro_width = projected.shape[-1] // (2 * micro_shard_count)
+    leading_shape = projected.shape[:-1]
+    return projected.reshape(*leading_shape, micro_shard_count, 2, micro_width).transpose(-3, -2).reshape(*leading_shape, 2 * micro_shard_count * micro_width)
+
+
+class HunyuanImage3HybridTensorParallelLinear(MMWeightTP):
+    """Storage-TP linear with phase-dependent, zero-copy weight views."""
+
+    def __init__(
+        self,
+        *,
+        parallel_context,
+        micro_shard_count,
+        weight_layout=PLAIN_LAYOUT,
+        qkv_group_width=None,
+        hidden_act="silu",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        if kwargs.get("mm_type", "Default") != "Default":
+            raise NotImplementedError("HunyuanImage3 hybrid TP currently supports unquantized Default MM weights only.")
+        self.parallel_context = parallel_context
+        self.micro_shard_count = int(micro_shard_count)
+        self.weight_layout = weight_layout
+        self.qkv_group_width = qkv_group_width
+        self.hidden_act = str(hidden_act).strip().lower()
+        self.storage_tp_group = self.tp_group
+        self.storage_tp_rank = self.tp_rank
+        self.storage_tp_size = self.tp_size
+        self.gate_up_layout = FUSED_GATE_UP_LAYOUT if weight_layout == FUSED_GATE_UP_LAYOUT else None
+
+    def set_config(self, config=None):
+        config = {} if config is None else config
+        self.config = config
+        self._mm.set_config(config)
+
+    def state_dict(self, destination=None):
+        return self._mm.state_dict(destination)
+
+    def load_state_dict(self, destination, block_index, adapter_block_index=None):
+        return self._mm.load_state_dict(destination, block_index, adapter_block_index)
+
+    def load_state_dict_from_disk(self, block_index, adapter_block_index=None):
+        return self._mm.load_state_dict_from_disk(block_index, adapter_block_index)
+
+    def to_cuda(self, non_blocking=False):
+        return self._mm.to_cuda(non_blocking=non_blocking)
+
+    def to_cpu(self, non_blocking=False):
+        return self._mm.to_cpu(non_blocking=non_blocking)
+
+    @property
+    def active_tp_group(self):
+        return _context_value(self.parallel_context, "active_tp_group", _context_value(self.parallel_context, "tp_group", self.storage_tp_group))
+
+    @property
+    def active_tp_size(self):
+        return int(_context_value(self.parallel_context, "active_tp_size", _context_value(self.parallel_context, "tp_size", self.storage_tp_size)))
+
+    @property
+    def uses_micro_shard(self):
+        if self.micro_shard_count == 1:
+            return False
+        active_size = self.active_tp_size
+        if active_size == self.storage_tp_size:
+            return False
+        expected = self.storage_tp_size * self.micro_shard_count
+        if active_size != expected:
+            raise RuntimeError(f"HunyuanImage3 active TP size must be storage_tp_size ({self.storage_tp_size}) or full micro TP size ({expected}); got {active_size}.")
+        return True
+
+    @property
+    def active_micro_shard_id(self):
+        micro_id = int(_context_value(self.parallel_context, "local_micro_shard_id", 0)) if self.uses_micro_shard else None
+        if micro_id is not None and not 0 <= micro_id < self.micro_shard_count:
+            raise RuntimeError(f"Invalid HunyuanImage3 local micro shard id {micro_id} for count {self.micro_shard_count}.")
+        return micro_id
+
+    def canonical_tp_rank(self, micro_shard_id=None):
+        if micro_shard_id is None:
+            micro_shard_id = self.active_micro_shard_id
+        if micro_shard_id is None:
+            raise RuntimeError("A canonical TP rank is only defined for a selected micro shard.")
+        return self.storage_tp_rank * self.micro_shard_count + int(micro_shard_id)
+
+    def _micro_view(self, tensor, split_dim, micro_shard_id):
+        if tensor is None:
+            return None
+        dim = 1 if split_dim == "col" and tensor.ndim == 2 else 0
+        extent = tensor.shape[dim]
+        if self.weight_layout == GROUPED_QKV_LAYOUT:
+            if self.qkv_group_width is None or extent % self.qkv_group_width:
+                raise RuntimeError(f"Invalid grouped-QKV tensor shape {tuple(tensor.shape)}.")
+            local_groups = extent // self.qkv_group_width
+            if local_groups % self.micro_shard_count:
+                raise RuntimeError(f"Grouped-QKV local KV groups ({local_groups}) must be divisible by micro_shard_count ({self.micro_shard_count}).")
+            groups_per_micro = local_groups // self.micro_shard_count
+            start = micro_shard_id * groups_per_micro * self.qkv_group_width
+            width = groups_per_micro * self.qkv_group_width
+        else:
+            if extent % self.micro_shard_count:
+                raise RuntimeError(f"HunyuanImage3 local {self.split_dim}-parallel extent {extent} must be divisible by micro_shard_count {self.micro_shard_count}.")
+            width = extent // self.micro_shard_count
+            start = micro_shard_id * width
+        return tensor.narrow(dim, start, width)
+
+    @property
+    def active_weight(self):
+        weight = getattr(self._mm, "weight", None)
+        if weight is None:
+            weight = getattr(self._mm, "pin_weight", None)
+        if weight is None:
+            raise RuntimeError(f"HunyuanImage3 TP weight {self.weight_name} is not materialized.")
+        micro_id = self.active_micro_shard_id
+        return weight if micro_id is None else self._micro_view(weight, self.split_dim, micro_id)
+
+    def _active_column_bias(self):
+        bias = getattr(self._mm, "bias", None)
+        if bias is None:
+            bias = getattr(self._mm, "pin_bias", None)
+        micro_id = self.active_micro_shard_id
+        return bias if micro_id is None else self._micro_view(bias, "col", micro_id)
+
+    def load(self, weight_dict):
+        super().load(weight_dict)
+        weight = getattr(self._mm, "weight", None)
+        if weight is None:
+            weight = getattr(self._mm, "pin_weight", None)
+        if weight is None:
+            return
+        split_axis = 1 if self.split_dim == "col" else 0
+        if weight.shape[split_axis] % self.micro_shard_count:
+            raise ValueError(f"HunyuanImage3 resident weight {self.weight_name} shape {tuple(weight.shape)} cannot expose {self.micro_shard_count} micro shards.")
+        if self.weight_layout == FUSED_GATE_UP_LAYOUT and weight.shape[1] % (2 * self.micro_shard_count):
+            raise ValueError(f"HunyuanImage3 fused gate/up weight {self.weight_name} has invalid resident width {weight.shape[1]} for {self.micro_shard_count} micro shards.")
+
+    def apply(self, input_tensor):
+        if getattr(self._mm, "has_lora_branch", False) or getattr(self._mm, "has_diff", False):
+            raise NotImplementedError("HunyuanImage3 hybrid TP does not support LoRA or diff weights.")
+
+        weight = self.active_weight
+        if self.split_dim == "col":
+            bias = self._active_column_bias()
+            output = torch.mm(input_tensor, weight) if bias is None else torch.addmm(bias, input_tensor, weight)
+            if self.weight_layout == FUSED_GATE_UP_LAYOUT and not self.uses_micro_shard:
+                # Only activations are reordered.  The resident weight and all
+                # AR views remain untouched across phase switches.
+                output = restore_gate_up_projection_order(output, self.micro_shard_count)
+            return output
+
+        output = torch.mm(input_tensor, weight)
+        if self.reduce_output:
+            if self.active_tp_size > 1 and self.active_tp_group is not None:
+                dist.all_reduce(output, op=dist.ReduceOp.SUM, group=self.active_tp_group)
+            if self._row_split_bias is not None:
+                output = output + self._row_split_bias
+        return output
+
+    def apply_gate_up_activation(self, input_tensor):
+        """Project and apply SwiGLU directly in resident micro-major order.
+
+        The returned intermediate is in canonical local order
+        ``[micro0, micro1, ...]``, which matches the resident down-projection
+        input rows.  This avoids both a weight transformation and the
+        compatibility ``restore_gate_up_projection_order`` activation copy.
+        """
+
+        if self.weight_layout != FUSED_GATE_UP_LAYOUT:
+            raise RuntimeError(f"apply_gate_up_activation is only valid for fused gate/up weights, got {self.weight_layout!r}.")
+        if self.hidden_act != "silu":
+            raise NotImplementedError(f"HunyuanImage3 phase-aware fused gate/up currently supports silu/SwiGLU, got {self.hidden_act!r}.")
+
+        weight = self.active_weight
+        bias = self._active_column_bias()
+        projected = torch.mm(input_tensor, weight) if bias is None else torch.addmm(bias, input_tensor, weight)
+        if self.uses_micro_shard:
+            gate, up = projected.chunk(2, dim=-1)
+            return gate * F.silu(up)
+
+        micro_width = projected.shape[-1] // (2 * self.micro_shard_count)
+        parts = projected.reshape(*projected.shape[:-1], self.micro_shard_count, 2, micro_width)
+        return (parts[..., 0, :] * F.silu(parts[..., 1, :])).reshape(*projected.shape[:-1], self.micro_shard_count * micro_width)
+
+
+__all__ = [
+    "PLAIN_LAYOUT",
+    "GROUPED_QKV_LAYOUT",
+    "FUSED_GATE_UP_LAYOUT",
+    "HunyuanImage3HybridTensorParallelLinear",
+    "resolve_micro_shard_count",
+    "resolve_storage_tp",
+    "restore_gate_up_projection_order",
+    "select_column_storage_shard",
+    "select_fused_gate_up_storage_shard",
+    "select_grouped_qkv_storage_shard",
+    "select_row_storage_shard",
+]

--- a/lightx2v/models/runners/hunyuan_image3/hunyuan_image3_runner.py
+++ b/lightx2v/models/runners/hunyuan_image3/hunyuan_image3_runner.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -381,14 +382,116 @@ class HunyuanImage3Runner(DefaultRunner):
             is_cache_writer=self._is_output_rank() if distributed_parallel_active else False,
         )
         return FlashInferAutotuneController.from_config(
-            config=self.config,
+            config=self._flashinfer_autotune_config(),
             distributed_context=distributed_context,
         )
 
+    def _flashinfer_autotune_config(self):
+        """Select a topology-specific cache without changing legacy configs."""
+        context = self._parallel_context()
+        phase = str(self._parallel_context_value(context, "phase", default="")).strip().lower()
+        if context is None or phase not in ("ar", "denoise"):
+            return self.config
+
+        # The grouped multi-micro denoise path does not invoke FlashInfer.
+        # Keep AR on its topology-specific FlashInfer cache, but avoid opening
+        # an irrelevant denoise autotune context for the grouped backend.
+        if phase == "denoise" and bool(self.config.get("flashinfer_multi_micro", False)):
+            controller_config = dict(self.config)
+            controller_config["flashinfer_autotune_mode"] = "off"
+            return controller_config
+
+        phase_caches = self.config.get("flashinfer_autotune_cache_by_phase")
+        if phase_caches is not None:
+            if not isinstance(phase_caches, Mapping):
+                raise ValueError("flashinfer_autotune_cache_by_phase must be a mapping with 'ar' and 'denoise' entries.")
+            if phase not in phase_caches:
+                raise ValueError(f"flashinfer_autotune_cache_by_phase is missing the active phase {phase!r}.")
+            phase_cache = phase_caches[phase]
+        else:
+            base_cache = self.config.get("flashinfer_autotune_cache")
+            if base_cache in (None, ""):
+                return self.config
+            base_cache = os.fspath(base_cache)
+            if "{phase}" in base_cache:
+                phase_cache = base_cache.format(phase=phase)
+            else:
+                cache_path = Path(base_cache)
+                phase_cache = cache_path.with_name(f"{cache_path.stem}_{phase}{cache_path.suffix}")
+
+        controller_config = dict(self.config)
+        controller_config["flashinfer_autotune_cache"] = phase_cache
+        return controller_config
+
+    def _parallel_context(self):
+        return self.config.get("parallel_context")
+
+    @staticmethod
+    def _parallel_context_value(context, *names, default=None):
+        if context is None:
+            return default
+        for name in names:
+            if not hasattr(context, name):
+                continue
+            value = getattr(context, name)
+            if callable(value):
+                value = value()
+            if value is not None:
+                return value
+        return default
+
+    def _activate_parallel_phase(self, phase):
+        context = self._parallel_context()
+        if context is None:
+            return
+        activate_phase = getattr(context, "activate_phase", None)
+        if not callable(activate_phase):
+            raise RuntimeError("HunyuanImage3 parallel_context must provide activate_phase(name).")
+        activate_phase(phase)
+
+    def _active_tp_group(self):
+        context = self._parallel_context()
+        group = self._parallel_context_value(context, "active_tp_group", "tp_group")
+        if group is not None:
+            return group
+        return getattr(self.model, "tp_group", None)
+
+    def _active_tp_size(self):
+        context = self._parallel_context()
+        size = self._parallel_context_value(context, "active_tp_size", "tp_size")
+        if size is not None:
+            return int(size)
+        group = self._active_tp_group()
+        return dist.get_world_size(group) if group is not None and dist.is_available() and dist.is_initialized() else 1
+
+    def _active_seq_group(self):
+        context = self._parallel_context()
+        group = self._parallel_context_value(context, "active_seq_group", "seq_p_group")
+        if group is not None:
+            return group
+        return getattr(self.model, "seq_p_group", None)
+
+    def _active_seq_size(self):
+        context = self._parallel_context()
+        size = self._parallel_context_value(context, "active_seq_size", "seq_p_size", "seq_size")
+        if size is not None:
+            return int(size)
+        group = self._active_seq_group()
+        return dist.get_world_size(group) if group is not None and dist.is_available() and dist.is_initialized() else 1
+
     def _sequence_parallel_enabled(self):
+        context = self._parallel_context()
+        active = self._parallel_context_value(context, "active_seq_parallel")
+        if active is not None:
+            return bool(active) and self._active_seq_size() > 1
+        if context is not None:
+            return self._active_seq_size() > 1
         return bool(self.config.get("seq_parallel", False) and dist.is_available() and dist.is_initialized() and getattr(self.model, "seq_p_group", None) is not None)
 
     def _tensor_parallel_enabled(self):
+        context = self._parallel_context()
+        if context is not None:
+            return self._active_tp_size() > 1
         return bool(self.config.get("tensor_parallel", False) and dist.is_available() and dist.is_initialized() and getattr(self.model, "tp_group", None) is not None)
 
     def _parallel_control_group(self):
@@ -406,9 +509,9 @@ class HunyuanImage3Runner(DefaultRunner):
         if sum((tensor_parallel_active, sequence_parallel_active, cfg_parallel_active)) > 1:
             return dist.group.WORLD
         if tensor_parallel_active:
-            return self.model.tp_group
+            return self._active_tp_group()
         if sequence_parallel_active:
-            return self.model.seq_p_group
+            return self._active_seq_group()
         return None
 
     def _is_output_rank(self):
@@ -560,6 +663,8 @@ class HunyuanImage3Runner(DefaultRunner):
             raise ValueError(f"HunyuanImage3 parallel.cfg_mode must be one of batch/serial/parallel, got {mode!r}.")
         if mode == "parallel" and not self._cfg_parallel_enabled():
             raise ValueError("HunyuanImage3 parallel.cfg_mode='parallel' requires enable_cfg=true and parallel.cfg_p_size=2.")
+        if self._sequence_parallel_enabled() and not self._cfg_parallel_enabled() and mode != "serial":
+            raise ValueError("HunyuanImage3 denoise TP+SP with CFG requires parallel.cfg_mode='serial'.")
         return mode
 
     def _prepare_cfg_parallel_branch_inputs(self, prepared_inputs, cfg_p_rank, mark_parallel_branch=True):
@@ -962,6 +1067,7 @@ class HunyuanImage3Runner(DefaultRunner):
             self._print_text_generation_chunk(prefix)
 
     def _generate_text(self, input_info, batch_cond_images=None, cond_inputs=None):
+        self._activate_parallel_phase("ar")
         bot_task = str(getattr(input_info, "bot_task", None) or self._resolve_bot_task()).strip().lower()
         if bot_task == "image":
             raise ValueError("HunyuanImage3 text generation requires bot_task='auto', 'think', 'recaption', or 'think_recaption'.")
@@ -998,6 +1104,7 @@ class HunyuanImage3Runner(DefaultRunner):
         return self._decode_text_result(generated_tokens, plan)
 
     def _generate_cot_text(self, prompt, image_size, batch_cond_images=None, cond_inputs=None):
+        self._activate_parallel_phase("ar")
         bot_task = self._resolve_bot_task()
         if bot_task == "image":
             return None
@@ -1244,6 +1351,7 @@ class HunyuanImage3Runner(DefaultRunner):
         return torch.randn(shape, generator=generator, device=latent_device, dtype=torch.bfloat16)
 
     def _denoise_latents(self, prepared_inputs, image_size):
+        self._activate_parallel_phase("denoise")
         cfg_mode = self._resolve_denoise_cfg_mode(prepared_inputs)
         serial_branch_inputs = None
         if cfg_mode == "parallel":

--- a/lightx2v/utils/set_config.py
+++ b/lightx2v/utils/set_config.py
@@ -35,6 +35,136 @@ def get_default_config():
     return default_config
 
 
+def _hunyuan_image3_config_ints(value):
+    if isinstance(value, (list, tuple)):
+        return [int(item) for item in value]
+    if value is None:
+        return []
+    return [int(value)]
+
+
+def _hunyuan_image3_multi_micro_enabled(config):
+    value = config.get("flashinfer_multi_micro", False)
+    if not isinstance(value, bool):
+        raise ValueError(f"HunyuanImage3 flashinfer_multi_micro must be a boolean, got {value!r}.")
+    return value
+
+
+def _normalize_hunyuan_image3_phase_parallel(config, parallel_config):
+    """Normalize the phase-aware schema while keeping denoise flat aliases.
+
+    Existing model code reads ``parallel.tensor_p_size`` / ``seq_p_size``.
+    For a phase-aware run those aliases intentionally describe denoise (and
+    storage) topology; AR-specific values remain under ``parallel.ar``.
+    """
+
+    multi_micro = _hunyuan_image3_multi_micro_enabled(config)
+
+    phase_keys_present = any(key in parallel_config for key in ("storage_tensor_p_size", "ar", "denoise"))
+    raw_phase_aware = parallel_config.get("phase_aware")
+    if raw_phase_aware is None:
+        phase_aware = phase_keys_present
+    elif not isinstance(raw_phase_aware, bool):
+        raise ValueError(f"HunyuanImage3 parallel.phase_aware must be a boolean, got {raw_phase_aware!r}.")
+    else:
+        phase_aware = raw_phase_aware
+    if phase_keys_present and not phase_aware:
+        raise ValueError("HunyuanImage3 phase-specific parallel fields require parallel.phase_aware=true.")
+    if not phase_aware:
+        if multi_micro:
+            raise ValueError("HunyuanImage3 flashinfer_multi_micro requires parallel.phase_aware=true.")
+        parallel_config["phase_aware"] = False
+        return False
+
+    ar_config = parallel_config.get("ar")
+    denoise_config = parallel_config.get("denoise")
+    if not isinstance(ar_config, dict) or not isinstance(denoise_config, dict):
+        raise ValueError("HunyuanImage3 phase-aware parallelism requires parallel.ar and parallel.denoise objects.")
+    ar_config = dict(ar_config)
+    denoise_config = dict(denoise_config)
+
+    legacy_tensor_p_size = parallel_config.get("tensor_p_size")
+    legacy_seq_p_size = parallel_config.get("seq_p_size")
+    denoise_tensor_p_size = int(denoise_config.get("tensor_p_size", legacy_tensor_p_size or 1))
+    denoise_seq_p_size = int(denoise_config.get("seq_p_size", legacy_seq_p_size or 1))
+    if legacy_tensor_p_size is not None and int(legacy_tensor_p_size) != denoise_tensor_p_size:
+        raise ValueError(
+            f"HunyuanImage3 phase-aware parallel.tensor_p_size is a denoise compatibility alias and must equal parallel.denoise.tensor_p_size ({denoise_tensor_p_size}), got {legacy_tensor_p_size}."
+        )
+    if legacy_seq_p_size is not None and int(legacy_seq_p_size) != denoise_seq_p_size:
+        raise ValueError(f"HunyuanImage3 phase-aware parallel.seq_p_size is a denoise compatibility alias and must equal parallel.denoise.seq_p_size ({denoise_seq_p_size}), got {legacy_seq_p_size}.")
+
+    storage_tensor_p_size = int(parallel_config.get("storage_tensor_p_size", denoise_tensor_p_size))
+    ar_tensor_p_size = int(ar_config.get("tensor_p_size", storage_tensor_p_size * denoise_seq_p_size))
+    ar_seq_p_size = int(ar_config.get("seq_p_size", 1))
+    named_sizes = {
+        "parallel.storage_tensor_p_size": storage_tensor_p_size,
+        "parallel.ar.tensor_p_size": ar_tensor_p_size,
+        "parallel.ar.seq_p_size": ar_seq_p_size,
+        "parallel.denoise.tensor_p_size": denoise_tensor_p_size,
+        "parallel.denoise.seq_p_size": denoise_seq_p_size,
+    }
+    invalid_sizes = {name: value for name, value in named_sizes.items() if value < 1}
+    if invalid_sizes:
+        raise ValueError(f"HunyuanImage3 phase parallel sizes must be >= 1, got {invalid_sizes}.")
+    if ar_seq_p_size != 1:
+        raise ValueError(f"HunyuanImage3 AR phase supports tensor parallel only; parallel.ar.seq_p_size must be 1, got {ar_seq_p_size}.")
+    if storage_tensor_p_size != denoise_tensor_p_size:
+        raise ValueError(f"HunyuanImage3 storage TP must equal denoise TP so denoise can directly reuse AB shards: storage={storage_tensor_p_size}, denoise_tp={denoise_tensor_p_size}.")
+    if ar_tensor_p_size % storage_tensor_p_size:
+        raise ValueError(f"HunyuanImage3 parallel.ar.tensor_p_size ({ar_tensor_p_size}) must be divisible by parallel.storage_tensor_p_size ({storage_tensor_p_size}).")
+    micro_shard_count = ar_tensor_p_size // storage_tensor_p_size
+    if micro_shard_count != denoise_seq_p_size:
+        raise ValueError(f"HunyuanImage3 AR micro-shards must match denoise SP replicas: ar_tp/storage_tp={micro_shard_count}, denoise_sp={denoise_seq_p_size}.")
+    if ar_tensor_p_size != denoise_tensor_p_size * denoise_seq_p_size:
+        raise ValueError(f"HunyuanImage3 AR and denoise phases must cover the same ranks: ar_tp={ar_tensor_p_size}, denoise_tp={denoise_tensor_p_size}, denoise_sp={denoise_seq_p_size}.")
+    if multi_micro:
+        moe_impl = str(config.get("moe_impl", "eager")).strip().lower()
+        if moe_impl != "flashinfer":
+            raise ValueError(f"HunyuanImage3 flashinfer_multi_micro requires moe_impl='flashinfer', got {moe_impl!r}.")
+        backend = str(config.get("flashinfer_multi_micro_backend", "grouped_mm")).strip().lower()
+        if backend != "grouped_mm":
+            raise ValueError(f"HunyuanImage3 flashinfer_multi_micro only supports backend='grouped_mm'; got {backend!r}.")
+        if micro_shard_count != 2:
+            raise ValueError(f"HunyuanImage3 flashinfer_multi_micro requires exactly two micro shards; got {micro_shard_count}.")
+        config["flashinfer_multi_micro_backend"] = backend
+
+    # AR takes one local micro-shard from each storage shard. Every dimension
+    # physically split by TP must therefore also be divisible by AR TP.
+    divisibility_checks = {
+        "num_attention_heads": _hunyuan_image3_config_ints(config.get("num_attention_heads") or config.get("num_heads")),
+        "num_key_value_heads": _hunyuan_image3_config_ints(config.get("num_key_value_heads") or config.get("num_attention_heads") or config.get("num_heads")),
+        "intermediate_size": _hunyuan_image3_config_ints(config.get("intermediate_size")),
+        "moe_intermediate_size": _hunyuan_image3_config_ints(config.get("moe_intermediate_size")),
+        "vocab_size": _hunyuan_image3_config_ints(config.get("vocab_size")),
+    }
+    shared_experts = _hunyuan_image3_config_ints(config.get("num_shared_expert"))
+    moe_intermediate = _hunyuan_image3_config_ints(config.get("moe_intermediate_size"))
+    if shared_experts and moe_intermediate:
+        if len(shared_experts) == 1:
+            shared_experts *= len(moe_intermediate)
+        if len(moe_intermediate) == 1:
+            moe_intermediate *= len(shared_experts)
+        divisibility_checks["shared_mlp_intermediate_size"] = [experts * intermediate for experts, intermediate in zip(shared_experts, moe_intermediate)]
+    for name, values in divisibility_checks.items():
+        invalid = sorted({value for value in values if value % ar_tensor_p_size})
+        if invalid:
+            raise ValueError(f"HunyuanImage3 AR TP size {ar_tensor_p_size} must divide every {name}; invalid values: {invalid}.")
+
+    ar_config["tensor_p_size"] = ar_tensor_p_size
+    ar_config["seq_p_size"] = ar_seq_p_size
+    denoise_config["tensor_p_size"] = denoise_tensor_p_size
+    denoise_config["seq_p_size"] = denoise_seq_p_size
+    parallel_config["phase_aware"] = True
+    parallel_config["storage_tensor_p_size"] = storage_tensor_p_size
+    parallel_config["micro_shard_count"] = micro_shard_count
+    parallel_config["ar"] = ar_config
+    parallel_config["denoise"] = denoise_config
+    parallel_config["tensor_p_size"] = denoise_tensor_p_size
+    parallel_config["seq_p_size"] = denoise_seq_p_size
+    return True
+
+
 def validate_model_task_args(args):
     """Validate model/task combinations before assembling the runtime config."""
     task = getattr(args, "task", None)
@@ -334,8 +464,12 @@ def auto_calc_config(config):
             if isinstance(vae_downsample_factor, list) and vae_downsample_factor:
                 config["vae_scale_factor"] = int(vae_downsample_factor[0])
         parallel_config = config.get("parallel")
+        if not isinstance(parallel_config, dict):
+            if _hunyuan_image3_multi_micro_enabled(config):
+                raise ValueError("HunyuanImage3 flashinfer_multi_micro requires a phase-aware parallel configuration.")
         if isinstance(parallel_config, dict):
             parallel_config = dict(parallel_config)
+            phase_aware = _normalize_hunyuan_image3_phase_parallel(config, parallel_config)
             tensor_p_size = int(parallel_config.get("tensor_p_size", 1))
             cfg_p_size = int(parallel_config.get("cfg_p_size", 1))
             seq_p_size = int(parallel_config.get("seq_p_size", 1))
@@ -364,6 +498,8 @@ def auto_calc_config(config):
                 raise ValueError(f"HunyuanImage3 parallel.tensor_p_size must be >= 1, got {tensor_p_size}.")
             if cfg_p_size not in (1, 2):
                 raise ValueError(f"HunyuanImage3 parallel.cfg_p_size must be 1 or 2, got {cfg_p_size}.")
+            if phase_aware and cfg_p_size != 1:
+                raise ValueError("HunyuanImage3 phase-aware TP4/TP2+SP2 uses all ranks and requires parallel.cfg_p_size=1; use serial CFG.")
             if seq_p_size < 1:
                 raise ValueError(f"HunyuanImage3 parallel.seq_p_size must be >= 1, got {seq_p_size}.")
             if tensor_p_size > 1:
@@ -397,6 +533,7 @@ def auto_calc_config(config):
             # compatible while JSON files use the canonical parallel branch.
             config["pipeline_parallel"] = pipeline_parallel
             config["hunyuan_cfg_mode"] = cfg_mode
+            config["hunyuan_image3_phase_aware_parallel"] = phase_aware
 
             if cfg_p_size == 2 and cfg_mode != "parallel":
                 raise ValueError("HunyuanImage3 parallel.cfg_p_size=2 requires parallel.cfg_mode='parallel'.")
@@ -484,7 +621,20 @@ def set_parallel_config(config):
                 f"Parallel sizes must match the distributed world size: tensor_p_size ({tensor_p_size}) * cfg_p_size ({cfg_p_size}) * seq_p_size ({seq_p_size}) != world_size ({world_size})."
             )
 
-        if tensor_p_size > 1:
+        phase_aware = bool(config.get("model_cls") == "hunyuan_image3" and config["parallel"].get("phase_aware", False))
+        if phase_aware:
+            from lightx2v.models.networks.hunyuan_image3.parallel import build_hunyuan_image3_parallel_context
+
+            parallel_context = build_hunyuan_image3_parallel_context(config)
+            config["parallel_context"] = parallel_context
+            config["hunyuan_image3_parallel_context"] = parallel_context
+            # Existing HunyuanImage3 components use device_mesh as the denoise
+            # topology. Phase-aware components read dynamic groups from context.
+            config["device_mesh"] = parallel_context.denoise_device_mesh
+            config["tensor_parallel"] = parallel_context.storage_tp_size > 1
+            config["seq_parallel"] = parallel_context.denoise_seq_size > 1
+            config["cfg_parallel"] = False
+        elif tensor_p_size > 1:
             # Tensor parallel is the innermost dimension. Optional CFG and
             # sequence dimensions are prepended so ranks with the same
             # non-TP coordinates form contiguous TP groups. For TP+SP+CFG:

--- a/scripts/hunyuan_image3/run_hunyuan_image3_t2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.sh
+++ b/scripts/hunyuan_image3/run_hunyuan_image3_t2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Set paths first.
+lightx2v_path=/data/liuhongda/LightX2V
+model_path=/data/liuhongda/HunyuanImage-3-Instruct
+hunyuan_image3_path=/data/liuhongda/HunyuanImage-3.0
+
+# Use an externally selected four-GPU set when provided; otherwise use 0-3.
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
+export PYTHONPATH="${hunyuan_image3_path}:${PYTHONPATH:-}"
+TORCHRUN_BIN=${TORCHRUN_BIN:-/opt/conda/bin/torchrun}
+# FlashInfer invokes ``ninja`` by name when materializing its JIT module, so
+# keep the selected conda toolchain visible to torchrun's child processes.
+export PATH="/opt/conda/bin:${PATH}"
+
+source "${lightx2v_path}/scripts/base/base.sh"
+# This production entry intentionally disables the base profiling wrapper.
+export PROFILING_DEBUG_LEVEL=0
+
+"${TORCHRUN_BIN}" --standalone --nproc_per_node=4 -m lightx2v.infer \
+    --model_cls hunyuan_image3 \
+    --task t2i \
+    --model_path "${model_path}" \
+    --config_json "${lightx2v_path}/configs/hunyuan_image3/hunyuan_image3_t2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.json" \
+    --prompt "生成图片：一辆汽车行驶在高速公路上，驾驶员在打电话，副驾驶坐着一只狗" \
+    --save_result_path "${lightx2v_path}/save_results/hunyuan_image3_t2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.png" \
+    --seed 42

--- a/scripts/hunyuan_image3/run_hunyuan_image3_ti2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.sh
+++ b/scripts/hunyuan_image3/run_hunyuan_image3_ti2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Set paths first.
+lightx2v_path=/data/liuhongda/LightX2V
+model_path=/data/liuhongda/HunyuanImage-3-Instruct
+hunyuan_image3_path=/data/liuhongda/HunyuanImage-3.0
+
+# Use an externally selected four-GPU set when provided; otherwise use 0-3.
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
+export PYTHONPATH="${hunyuan_image3_path}:${PYTHONPATH:-}"
+TORCHRUN_BIN=${TORCHRUN_BIN:-/opt/conda/bin/torchrun}
+# FlashInfer invokes ``ninja`` by name when materializing its JIT module, so
+# keep the selected conda toolchain visible to torchrun's child processes.
+export PATH="/opt/conda/bin:${PATH}"
+
+source "${lightx2v_path}/scripts/base/base.sh"
+# This production entry intentionally disables the base profiling wrapper.
+export PROFILING_DEBUG_LEVEL=0
+
+"${TORCHRUN_BIN}" --standalone --nproc_per_node=4 -m lightx2v.infer \
+    --model_cls hunyuan_image3 \
+    --task ti2i \
+    --model_path "${model_path}" \
+    --config_json "${lightx2v_path}/configs/hunyuan_image3/hunyuan_image3_ti2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.json" \
+    --prompt "新年宠物海报，Q版圆润的可爱标题“新年快乐汪”，副标题“HAPPY NEW YEAR”。鱼眼镜头，背景是房间门口，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清绒毛细节，面部特写，宝丽莱相纸，写实胶片摄影，复古颗粒感。" \
+    --image_path "${hunyuan_image3_path}/assets/demo_instruct_imgs/input_0_0.png" \
+    --save_result_path "${lightx2v_path}/save_results/hunyuan_image3_ti2i_ar_tp4_denoise_tp2_sp2_multi_micro_flashinfer.png" \
+    --seed 42

--- a/test_cases/test_hunyuan_image3_hybrid_tp_weights.py
+++ b/test_cases/test_hunyuan_image3_hybrid_tp_weights.py
@@ -1,0 +1,157 @@
+from types import SimpleNamespace
+
+import torch
+
+from lightx2v.models.networks.hunyuan_image3.weights.common import HunyuanImage3MoEWeights
+from lightx2v.models.networks.hunyuan_image3.weights.hybrid_tp import (
+    FUSED_GATE_UP_LAYOUT,
+    GROUPED_QKV_LAYOUT,
+    HunyuanImage3HybridTensorParallelLinear,
+    select_fused_gate_up_storage_shard,
+    select_grouped_qkv_storage_shard,
+    select_row_storage_shard,
+)
+
+
+def _hybrid_linear(context, split_dim, layout="plain", qkv_group_width=None, storage_rank=0):
+    return HunyuanImage3HybridTensorParallelLinear(
+        weight_name="weight",
+        bias_name=None,
+        mm_type="Default",
+        tp_group=None,
+        tp_rank=storage_rank,
+        tp_size=2,
+        split_dim=split_dim,
+        parallel_context=context,
+        micro_shard_count=2,
+        weight_layout=layout,
+        qkv_group_width=qkv_group_width,
+        reduce_output=False,
+    )
+
+
+def _same_storage(left, right):
+    return left.untyped_storage().data_ptr() == right.untyped_storage().data_ptr()
+
+
+def test_fused_gate_up_is_micro_major_and_phase_switch_uses_views():
+    gate = torch.arange(8, dtype=torch.float32).reshape(8, 1)
+    up = gate + 100
+    resident_checkpoint = select_fused_gate_up_storage_shard(torch.cat((gate, up)), 0, 2, 2)
+    assert resident_checkpoint[:, 0].tolist() == [0, 1, 100, 101, 2, 3, 102, 103]
+
+    context = SimpleNamespace(active_tp_size=4, active_tp_group=None, local_micro_shard_id=1)
+    linear = _hybrid_linear(context, "col", FUSED_GATE_UP_LAYOUT)
+    linear._mm.weight = resident_checkpoint.t()
+    linear._mm.bias = None
+
+    ar_weight = linear.active_weight
+    assert _same_storage(ar_weight, linear._mm.weight)
+    assert linear.apply(torch.ones(1, 1)).tolist() == [[2, 3, 102, 103]]
+    expected_ar_hidden = torch.tensor([[2.0, 3.0]]) * torch.nn.functional.silu(torch.tensor([[102.0, 103.0]]))
+    assert torch.allclose(linear.apply_gate_up_activation(torch.ones(1, 1)), expected_ar_hidden)
+
+    context.active_tp_size = 2
+    denoise_weight = linear.active_weight
+    assert _same_storage(denoise_weight, linear._mm.weight)
+    assert linear.apply(torch.ones(1, 1)).tolist() == [[0, 1, 2, 3, 100, 101, 102, 103]]
+    expected_denoise_hidden = torch.tensor([[0.0, 1.0, 2.0, 3.0]]) * torch.nn.functional.silu(torch.tensor([[100.0, 101.0, 102.0, 103.0]]))
+    assert torch.allclose(linear.apply_gate_up_activation(torch.ones(1, 1)), expected_denoise_hidden)
+
+
+def test_grouped_qkv_splits_only_at_complete_kv_groups():
+    # Q32/KV8/head_dim1 gives six output values per KV group.
+    checkpoint = torch.arange(48 * 2, dtype=torch.float32).reshape(48, 2)
+    resident_checkpoint = select_grouped_qkv_storage_shard(checkpoint, 1, 2, 2, 32, 8, 1)
+    assert torch.equal(resident_checkpoint, checkpoint[24:])
+
+    context = SimpleNamespace(active_tp_size=4, active_tp_group=None, local_micro_shard_id=0)
+    linear = _hybrid_linear(context, "col", GROUPED_QKV_LAYOUT, qkv_group_width=6, storage_rank=1)
+    linear._mm.weight = resident_checkpoint.t()
+    linear._mm.bias = None
+    assert _same_storage(linear.active_weight, linear._mm.weight)
+    assert torch.equal(linear.active_weight, checkpoint[24:36].t())
+
+
+def test_down_projection_micro_view_matches_checkpoint_input_slice():
+    checkpoint = torch.arange(3 * 8, dtype=torch.float32).reshape(3, 8)
+    resident_checkpoint = select_row_storage_shard(checkpoint, 1, 2)
+    context = SimpleNamespace(active_tp_size=4, active_tp_group=None, local_micro_shard_id=1)
+    linear = _hybrid_linear(context, "row", storage_rank=1)
+    linear._mm.weight = resident_checkpoint.t()
+    linear._mm.bias = None
+    assert _same_storage(linear.active_weight, linear._mm.weight)
+    assert torch.equal(linear.active_weight, checkpoint[:, 6:8].t())
+
+
+def test_flashinfer_pack_is_phase_neutral_and_micro_views_are_contiguous():
+    context = SimpleNamespace(active_tp_size=4, local_micro_shard_id=1)
+    moe = HunyuanImage3MoEWeights.__new__(HunyuanImage3MoEWeights)
+    moe.num_experts = 2
+    moe.parallel_context = context
+    moe.storage_tp_rank = 1
+    moe.storage_tp_size = 2
+    moe.micro_shard_count = 2
+    moe.flashinfer_logical_tp_size = 4
+    moe.moe_weight = None
+    moe.moe_weight_2 = None
+    moe._flashinfer_weights_initialized = False
+    moe._flashinfer_weight_device = None
+    moe._flashinfer_weight_dtype = None
+
+    expected_gate_up = []
+    expected_down = []
+    experts = []
+    for expert_index in range(2):
+        base = expert_index * 100
+        gate_up = (torch.arange(8 * 3).reshape(8, 3) + base).to(torch.bfloat16)
+        down = (torch.arange(3 * 4).reshape(3, 4) + base).to(torch.bfloat16)
+        expected_gate_up.append(gate_up.clone())
+        expected_down.append(down.clone())
+        experts.append(
+            SimpleNamespace(
+                gate_and_up_proj=SimpleNamespace(weight=gate_up.t(), bias=None, has_lora_branch=False, has_diff=False),
+                down_proj=SimpleNamespace(weight=down.t(), bias=None, has_lora_branch=False, has_diff=False),
+            )
+        )
+    moe.experts = experts
+
+    pack_w1, pack_w2 = moe.ensure_flashinfer_weights("cpu", torch.bfloat16)
+    assert pack_w1.shape == (2, 2, 4, 3)
+    assert pack_w2.shape == (2, 2, 3, 2)
+    for micro_id in range(2):
+        for expert_id in range(2):
+            assert torch.equal(pack_w1[micro_id, expert_id], expected_gate_up[expert_id].reshape(2, 4, 3)[micro_id])
+            expected_w2 = expected_down[expert_id].reshape(3, 2, 2).permute(1, 0, 2)[micro_id]
+            assert torch.equal(pack_w2[micro_id, expert_id], expected_w2)
+
+    ar_shards = moe.active_flashinfer_weight_shards("cpu", torch.bfloat16)
+    assert len(ar_shards) == 1
+    micro_id, canonical_rank, ar_w1, ar_w2 = ar_shards[0]
+    assert (micro_id, canonical_rank) == (1, 3)
+    assert ar_w1.is_contiguous() and ar_w2.is_contiguous()
+    assert _same_storage(ar_w1, pack_w1) and _same_storage(ar_w2, pack_w2)
+
+    context.active_tp_size = 2
+    denoise_shards = moe.active_flashinfer_weight_shards("cpu", torch.bfloat16)
+    assert [(item[0], item[1]) for item in denoise_shards] == [(0, 2), (1, 3)]
+    assert all(_same_storage(item[2], pack_w1) and _same_storage(item[3], pack_w2) for item in denoise_shards)
+
+    multi_w1, multi_w2 = moe.active_flashinfer_multi_micro_weights("cpu", torch.bfloat16)
+    assert multi_w1 is moe.moe_weight
+    assert multi_w2 is moe.moe_weight_2
+    assert multi_w1.shape == (2, 2, 4, 3)
+    assert multi_w2.shape == (2, 2, 3, 2)
+    assert multi_w1.is_contiguous() and multi_w2.is_contiguous()
+    assert _same_storage(multi_w1, pack_w1)
+    assert _same_storage(multi_w2, pack_w2)
+    assert multi_w1.storage_offset() == pack_w1.storage_offset() == 0
+    assert multi_w2.storage_offset() == pack_w2.storage_offset() == 0
+
+    moe.micro_shard_count = 1
+    try:
+        moe.active_flashinfer_multi_micro_weights("cpu", torch.bfloat16)
+    except RuntimeError as error:
+        assert "exactly two" in str(error)
+    else:
+        raise AssertionError("multi-micro accessor must reject a resident pack with micro_shard_count != 2")

--- a/test_cases/test_hunyuan_image3_phase_execution.py
+++ b/test_cases/test_hunyuan_image3_phase_execution.py
@@ -1,0 +1,333 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from lightx2v.models.networks.hunyuan_image3.infer.post_infer import HunyuanImage3PostInfer
+from lightx2v.models.networks.hunyuan_image3.infer.transformer_infer import HunyuanImage3TransformerInfer
+from lightx2v.models.runners.hunyuan_image3.hunyuan_image3_runner import HunyuanImage3Runner
+from lightx2v.utils.set_config import _normalize_hunyuan_image3_phase_parallel
+
+
+class _ParallelContext:
+    def __init__(self, phase="denoise", tp_size=2, seq_size=2):
+        self.phase = phase
+        self.active_tp_group = object()
+        self.active_tp_rank = 0
+        self.active_tp_size = tp_size
+        self.logical_tp_rank = 0
+        self.active_seq_group = object() if seq_size > 1 else None
+        self.active_seq_size = seq_size
+        self.active_seq_parallel = seq_size > 1
+        self.logical_gather_order = (0, 2, 1, 3) if tp_size == 4 else tuple(range(tp_size))
+        self.ar_tp_size = 4
+        self.activations = []
+
+    def activate_phase(self, phase):
+        self.phase = phase
+        self.activations.append(phase)
+
+
+class _Linear:
+    weight = None
+    bias = None
+
+    def __init__(self, fn):
+        self._fn = fn
+
+    def apply(self, value):
+        return self._fn(value)
+
+
+class HunyuanImage3PhaseExecutionTests(unittest.TestCase):
+    def test_multi_micro_config_requires_the_production_topology(self):
+        def parallel(ar_tp=4, denoise_sp=2):
+            return {
+                "phase_aware": True,
+                "storage_tensor_p_size": 2,
+                "ar": {"tensor_p_size": ar_tp, "seq_p_size": 1},
+                "denoise": {"tensor_p_size": 2, "seq_p_size": denoise_sp},
+            }
+
+        config = {
+            "moe_impl": "flashinfer",
+            "flashinfer_multi_micro": True,
+            "flashinfer_multi_micro_backend": "grouped_mm",
+        }
+        normalized = parallel()
+        self.assertTrue(_normalize_hunyuan_image3_phase_parallel(config, normalized))
+        self.assertEqual(normalized["micro_shard_count"], 2)
+
+        invalid_cases = (
+            ({**config, "moe_impl": "eager"}, parallel(), "moe_impl='flashinfer'"),
+            ({**config, "flashinfer_multi_micro_backend": "auto"}, parallel(), "backend='grouped_mm'"),
+            (config, parallel(ar_tp=6, denoise_sp=3), "exactly two micro shards"),
+            (config, {}, "parallel.phase_aware=true"),
+        )
+        for invalid_config, invalid_parallel, message in invalid_cases:
+            with self.subTest(message=message), self.assertRaisesRegex(ValueError, message):
+                _normalize_hunyuan_image3_phase_parallel(invalid_config, invalid_parallel)
+
+    def test_runner_activates_ar_and_denoise_before_stage_work(self):
+        context = _ParallelContext()
+        runner = HunyuanImage3Runner.__new__(HunyuanImage3Runner)
+        runner.config = {"parallel_context": context}
+        runner._resolve_bot_task = lambda: "image"
+
+        self.assertIsNone(runner._generate_cot_text("prompt", (1024, 1024)))
+        self.assertEqual(context.activations, ["ar"])
+
+        class _DenoiseReached(RuntimeError):
+            pass
+
+        def stop_after_activation(_prepared_inputs):
+            raise _DenoiseReached
+
+        runner._resolve_denoise_cfg_mode = stop_after_activation
+        with self.assertRaises(_DenoiseReached):
+            runner._denoise_latents({}, (1024, 1024))
+        self.assertEqual(context.activations, ["ar", "denoise"])
+
+    def test_sp_cfg_requires_serial_mode_without_cfg_parallel(self):
+        context = _ParallelContext(phase="denoise", tp_size=2, seq_size=2)
+        runner = HunyuanImage3Runner.__new__(HunyuanImage3Runner)
+        runner.config = {
+            "parallel_context": context,
+            "parallel": {"cfg_mode": "batch"},
+            "cfg_parallel": False,
+            "enable_cfg": True,
+        }
+        runner.model = SimpleNamespace()
+
+        with self.assertRaisesRegex(ValueError, "cfg_mode='serial'"):
+            runner._resolve_denoise_cfg_mode({"do_cfg": True})
+
+        runner.config["parallel"]["cfg_mode"] = "serial"
+        self.assertEqual(runner._resolve_denoise_cfg_mode({"do_cfg": True}), "serial")
+
+    def test_flashinfer_cache_isolated_by_phase_and_legacy_is_unchanged(self):
+        context = _ParallelContext(phase="ar", tp_size=4, seq_size=1)
+        runner = HunyuanImage3Runner.__new__(HunyuanImage3Runner)
+        runner.config = {"parallel_context": context, "flashinfer_autotune_cache": "results/cache.json"}
+
+        ar_config = runner._flashinfer_autotune_config()
+        self.assertEqual(Path(ar_config["flashinfer_autotune_cache"]), Path("results/cache_ar.json"))
+        context.phase = "denoise"
+        denoise_config = runner._flashinfer_autotune_config()
+        self.assertEqual(Path(denoise_config["flashinfer_autotune_cache"]), Path("results/cache_denoise.json"))
+
+        runner.config["flashinfer_autotune_cache_by_phase"] = {"ar": "ar.json", "denoise": "denoise.json"}
+        self.assertEqual(runner._flashinfer_autotune_config()["flashinfer_autotune_cache"], "denoise.json")
+
+        runner.config.update(flashinfer_multi_micro=True, flashinfer_autotune_mode="auto")
+        multi_micro_denoise_config = runner._flashinfer_autotune_config()
+        self.assertIsNot(multi_micro_denoise_config, runner.config)
+        self.assertEqual(multi_micro_denoise_config["flashinfer_autotune_mode"], "off")
+        context.phase = "ar"
+        multi_micro_ar_config = runner._flashinfer_autotune_config()
+        self.assertEqual(multi_micro_ar_config["flashinfer_autotune_mode"], "auto")
+        self.assertEqual(multi_micro_ar_config["flashinfer_autotune_cache"], "ar.json")
+
+        legacy_config = {"flashinfer_autotune_cache": "results/cache.json"}
+        runner.config = legacy_config
+        self.assertIs(runner._flashinfer_autotune_config(), legacy_config)
+
+    def test_post_infer_restores_canonical_vocab_shard_order(self):
+        context = _ParallelContext(phase="ar", tp_size=4, seq_size=1)
+        infer = HunyuanImage3PostInfer({"parallel_context": context})
+        weights = SimpleNamespace(
+            final_norm=_Linear(lambda value: value),
+            lm_head=_Linear(lambda value: torch.zeros(value.shape[0], 1, dtype=value.dtype)),
+        )
+        pre_infer_out = SimpleNamespace(image_mask=None, timesteps=None, token_hw=None)
+
+        def fake_all_gather(outputs, _local, group):
+            self.assertIs(group, context.active_tp_group)
+            for physical_rank, output in enumerate(outputs):
+                output.fill_(physical_rank)
+
+        with patch("lightx2v.models.networks.hunyuan_image3.infer.post_infer.dist.all_gather", side_effect=fake_all_gather):
+            output = infer.infer(weights, torch.ones(1, 3, 1), pre_infer_out)["logits"]
+        self.assertEqual(output.flatten().tolist(), [0.0, 2.0, 1.0, 3.0])
+
+    def test_attention_head_partition_tracks_active_tp_size(self):
+        context = _ParallelContext(phase="ar", tp_size=4, seq_size=1)
+        infer = HunyuanImage3TransformerInfer.__new__(HunyuanImage3TransformerInfer)
+        infer.parallel_context = context
+        infer.tp_group = None
+        infer.tp_rank = 0
+        infer.tp_size = 1
+        infer.global_num_heads = 32
+        infer.global_num_key_value_heads = 8
+        infer.num_key_value_groups = 4
+        infer.head_dim = 2
+        captured_heads = []
+
+        def qkv_projection(value):
+            local_kv_heads = infer.global_num_key_value_heads // context.active_tp_size
+            width = local_kv_heads * (infer.num_key_value_groups + 2) * infer.head_dim
+            return torch.zeros(value.shape[0], width, dtype=value.dtype)
+
+        def registered_attention(query, _key, _value, _mask, **_kwargs):
+            captured_heads.append(query.shape[1])
+            return query
+
+        infer._registered_attention = registered_attention
+        phase = SimpleNamespace(
+            qkv_proj=_Linear(qkv_projection),
+            o_proj=_Linear(lambda value: torch.zeros(value.shape[0], 64, dtype=value.dtype)),
+            query_layernorm=None,
+        )
+        hidden_states = torch.zeros(1, 3, 64)
+
+        ar_output = infer.infer_attention(0, phase, hidden_states, None, None, None)
+        context.phase = "denoise"
+        context.active_tp_size = 2
+        denoise_output = infer.infer_attention(0, phase, hidden_states, None, None, None)
+
+        self.assertEqual(captured_heads, [8, 16])
+        self.assertEqual(ar_output.shape, hidden_states.shape)
+        self.assertEqual(denoise_output.shape, hidden_states.shape)
+
+    @staticmethod
+    def _configure_flashinfer_test_infer(context, *, multi_micro=False):
+        infer = HunyuanImage3TransformerInfer.__new__(HunyuanImage3TransformerInfer)
+        infer.config = {
+            "moe_impl": "flashinfer",
+            "flashinfer_multi_micro": multi_micro,
+        }
+        infer.parallel_context = context
+        infer.tp_group = None
+        infer.tp_rank = 0
+        infer.tp_size = 1
+        infer.hidden_act = "silu"
+        infer.flashinfer_tune_max_num_tokens = 123
+        infer.flashinfer_multi_micro = multi_micro
+        infer.flashinfer_multi_micro_backend = "grouped_mm"
+        infer._moe_easy_topk = lambda _moe, states: (
+            states.reshape(-1, states.shape[-1]),
+            torch.ones(states.numel() // states.shape[-1], 1),
+            torch.zeros(states.numel() // states.shape[-1], 1, dtype=torch.long),
+        )
+        return infer
+
+    def test_flashinfer_multi_micro_disabled_keeps_legacy_two_call_path(self):
+        context = _ParallelContext(phase="denoise", tp_size=2, seq_size=2)
+        infer = self._configure_flashinfer_test_infer(context, multi_micro=False)
+        hidden_states = torch.zeros(1, 2, 4, dtype=torch.bfloat16)
+        dummy_weight = torch.empty(1, 1, 1, 1, dtype=torch.bfloat16)
+        moe = SimpleNamespace(
+            moe_impl="flashinfer",
+            shared_mlp=None,
+            flashinfer_logical_tp_size=4,
+            active_flashinfer_weight_shards=lambda _device, _dtype: (
+                (0, 0, dummy_weight, dummy_weight),
+                (1, 1, dummy_weight, dummy_weight),
+            ),
+        )
+        calls = []
+
+        def fake_flashinfer(_input, _topk_idx, _topk_weight, _w1, _w2, _dtype, *, output, tp_size, tp_rank, **kwargs):
+            calls.append((tp_size, tp_rank, kwargs["tune_max_num_tokens"]))
+            output.fill_(tp_rank + 1)
+
+        with patch("lightx2v.models.networks.hunyuan_image3.infer.transformer_infer.flashinfer_cutlass_fused_moe", fake_flashinfer):
+            local_output = infer._infer_mlp_flashinfer(moe, hidden_states)
+        self.assertTrue(torch.equal(local_output, torch.full_like(hidden_states, 3)))
+        self.assertEqual(calls, [(4, 0, 123), (4, 1, 123)])
+
+    def test_flashinfer_multi_micro_ar_still_uses_one_official_call(self):
+        context = _ParallelContext(phase="ar", tp_size=4, seq_size=1)
+        infer = self._configure_flashinfer_test_infer(context, multi_micro=True)
+        hidden_states = torch.zeros(1, 2, 4, dtype=torch.bfloat16)
+        dummy_weight = torch.empty(1, 1, 1, 1, dtype=torch.bfloat16)
+        moe = SimpleNamespace(
+            moe_impl="flashinfer",
+            shared_mlp=None,
+            flashinfer_logical_tp_size=4,
+            active_flashinfer_weight_shards=lambda _device, _dtype: ((0, 2, dummy_weight, dummy_weight),),
+            active_flashinfer_multi_micro_weights=lambda _device, _dtype: (_ for _ in ()).throw(AssertionError("AR must not request the denoise multi-micro pack")),
+        )
+        official_calls = []
+
+        def fake_flashinfer(_input, _topk_idx, _topk_weight, _w1, _w2, _dtype, *, output, tp_size, tp_rank, **kwargs):
+            official_calls.append((tp_size, tp_rank, kwargs["tune_max_num_tokens"]))
+            output.fill_(7)
+
+        def fail_custom(*_args, **_kwargs):
+            raise AssertionError("AR must continue to use the official single-micro FlashInfer path")
+
+        with (
+            patch(
+                "lightx2v.models.networks.hunyuan_image3.infer.transformer_infer.flashinfer_cutlass_fused_moe",
+                fake_flashinfer,
+            ),
+            patch(
+                "lightx2v.models.networks.hunyuan_image3.infer.transformer_infer.lightx2v_multi_micro_fused_moe",
+                fail_custom,
+            ),
+        ):
+            output = infer._infer_mlp_flashinfer(moe, hidden_states)
+
+        self.assertTrue(torch.equal(output, torch.full_like(hidden_states, 7)))
+        self.assertEqual(official_calls, [(4, 2, 123)])
+
+    def test_flashinfer_multi_micro_denoise_uses_custom_once_and_allreduces_once(self):
+        context = _ParallelContext(phase="denoise", tp_size=2, seq_size=2)
+        infer = self._configure_flashinfer_test_infer(context, multi_micro=True)
+        hidden_states = torch.zeros(1, 2, 4, dtype=torch.bfloat16)
+        w1_pack = torch.empty(2, 1, 2, 4, dtype=torch.bfloat16)
+        w2_pack = torch.empty(2, 1, 4, 1, dtype=torch.bfloat16)
+        accessor_calls = []
+
+        def multi_micro_weights(device, dtype):
+            accessor_calls.append((device, dtype))
+            return w1_pack, w2_pack
+
+        moe = SimpleNamespace(
+            moe_impl="flashinfer",
+            shared_mlp=None,
+            flashinfer_logical_tp_size=4,
+            active_flashinfer_multi_micro_weights=multi_micro_weights,
+            active_flashinfer_weight_shards=lambda _device, _dtype: (_ for _ in ()).throw(AssertionError("fused denoise must not enter the legacy shard loop")),
+        )
+        custom_calls = []
+
+        def fake_custom(input, topk_idx, topk_weight, fc1_weights, fc2_weights, *, output, backend):
+            custom_calls.append((input, topk_idx, topk_weight, fc1_weights, fc2_weights, output, backend))
+            output.fill_(5)
+            return output
+
+        def fail_official(*_args, **_kwargs):
+            raise AssertionError("fused denoise must not call official FlashInfer directly")
+
+        with (
+            patch(
+                "lightx2v.models.networks.hunyuan_image3.infer.transformer_infer.flashinfer_cutlass_fused_moe",
+                fail_official,
+            ),
+            patch(
+                "lightx2v.models.networks.hunyuan_image3.infer.transformer_infer.lightx2v_multi_micro_fused_moe",
+                fake_custom,
+            ),
+        ):
+            local_output = infer._infer_mlp_flashinfer(moe, hidden_states)
+
+        self.assertTrue(torch.equal(local_output, torch.full_like(hidden_states, 5)))
+        self.assertEqual(len(accessor_calls), 1)
+        self.assertEqual(len(custom_calls), 1)
+        call = custom_calls[0]
+        self.assertIs(call[3], w1_pack)
+        self.assertIs(call[4], w2_pack)
+        self.assertEqual(call[6], "grouped_mm")
+
+        phase = SimpleNamespace(is_moe=True, moe=moe)
+        with patch.object(infer, "_infer_mlp_flashinfer", return_value=local_output), patch("lightx2v.models.networks.hunyuan_image3.infer.transformer_infer.dist.all_reduce") as all_reduce:
+            infer.infer_mlp(phase, hidden_states)
+        all_reduce.assert_called_once_with(local_output, op=torch.distributed.ReduceOp.SUM, group=context.active_tp_group)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_cases/test_hunyuan_image3_phase_topology_distributed.py
+++ b/test_cases/test_hunyuan_image3_phase_topology_distributed.py
@@ -1,0 +1,110 @@
+"""Four-rank NCCL smoke test for HunyuanImage3 phase-aware parallelism.
+
+Run with::
+
+    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 \
+        -m test_cases.test_hunyuan_image3_phase_topology_distributed
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import torch
+import torch.distributed as dist
+
+from lightx2v.models.networks.hunyuan_image3.parallel import build_hunyuan_image3_parallel_context
+
+
+def _assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def main():
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+
+    config = {
+        "parallel": {
+            "phase_aware": True,
+            "storage_tensor_p_size": 2,
+            "ar": {"tensor_p_size": 4, "seq_p_size": 1},
+            "denoise": {"tensor_p_size": 2, "seq_p_size": 2},
+        }
+    }
+    context = build_hunyuan_image3_parallel_context(config)
+
+    expected_logical_rank = (0, 2, 1, 3)[rank]
+    _assert_equal(context.storage_tp_rank, rank % 2, "storage_tp_rank")
+    _assert_equal(context.local_micro_shard_id, rank // 2, "local_micro_shard_id")
+    _assert_equal(context.logical_tp_rank, rank % 2, "initial denoise logical_tp_rank")
+
+    context.activate_phase("ar")
+    _assert_equal(context.active_tp_size, 4, "AR TP size")
+    _assert_equal(context.active_seq_size, 1, "AR SP size")
+    _assert_equal(context.logical_tp_rank, expected_logical_rank, "AR logical TP rank")
+    _assert_equal(context.logical_gather_order, (0, 2, 1, 3), "AR gather order")
+
+    logical = torch.tensor([context.logical_tp_rank], device="cuda", dtype=torch.int64)
+    gathered = [torch.empty_like(logical) for _ in range(4)]
+    dist.all_gather(gathered, logical, group=context.active_tp_group)
+    canonical = [int(gathered[index].item()) for index in context.logical_gather_order]
+    _assert_equal(canonical, [0, 1, 2, 3], "canonical AR gather")
+
+    context.activate_phase("denoise")
+    _assert_equal(context.active_tp_size, 2, "denoise TP size")
+    _assert_equal(context.active_seq_size, 2, "denoise SP size")
+
+    # A stale rank-local phase must fail on every rank before any subset can
+    # early-return while the rest enters a transition barrier.
+    if rank == 0:
+        context._phase = "ar"
+    try:
+        context.activate_phase("denoise")
+    except RuntimeError as error:
+        if "phase state diverged" not in str(error):
+            raise
+    else:
+        raise AssertionError("Diverged phase state was not rejected on every rank.")
+    context._phase = "denoise"
+
+    invalid_target = "invalid" if rank == 0 else "denoise"
+    try:
+        context.activate_phase(invalid_target)
+    except RuntimeError as error:
+        if "phase state diverged" not in str(error):
+            raise
+    else:
+        raise AssertionError("Invalid rank-local phase target was not rejected on every rank.")
+
+    tp_value = torch.tensor([rank], device="cuda", dtype=torch.int64)
+    dist.all_reduce(tp_value, group=context.active_tp_group)
+    _assert_equal(int(tp_value.item()), (1, 1, 5, 5)[rank], "denoise TP pair sum")
+
+    sp_value = torch.tensor([rank], device="cuda", dtype=torch.int64)
+    dist.all_reduce(sp_value, group=context.active_seq_group)
+    _assert_equal(int(sp_value.item()), (2, 4, 2, 4)[rank], "denoise SP pair sum")
+
+    dist.barrier(device_ids=[local_rank])
+    if rank == 0:
+        print(
+            json.dumps(
+                {
+                    "status": "ok",
+                    "physical_to_logical": [0, 2, 1, 3],
+                    "ar_tp": [0, 1, 2, 3],
+                    "denoise_tp": [[0, 1], [2, 3]],
+                    "denoise_sp": [[0, 2], [1, 3]],
+                },
+                sort_keys=True,
+            )
+        )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/test_cases/test_hunyuan_image3_ti2i_hybrid_parallel.py
+++ b/test_cases/test_hunyuan_image3_ti2i_hybrid_parallel.py
@@ -1,0 +1,221 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from lightx2v.models.runners.hunyuan_image3.hunyuan_image3_runner import HunyuanImage3Runner
+
+
+class HunyuanImage3Ti2iHybridParallelTests(unittest.TestCase):
+    def test_generate_ti2i_reuses_conditions_and_preserves_stage_order(self):
+        runner = HunyuanImage3Runner.__new__(HunyuanImage3Runner)
+        runner.config = {
+            "enable_cfg": True,
+            "cfg_distilled": False,
+            "seed": 42,
+        }
+        input_info = SimpleNamespace(
+            prompt="edit the reference image",
+            prompt_enhanced=None,
+            image_path="reference.png",
+            infer_align_image_size=True,
+            seed=23,
+        )
+
+        events = []
+        batch_cond_images = [[object()]]
+        text_cond_inputs = {"cond_vae_images": object(), "cond_vit_embeds": object()}
+        generation_cond_inputs = {"packed_cfg_conditions": object()}
+        prepared_inputs = {"generator": object()}
+        latents = object()
+        decoded_images = [object()]
+        final_images = [object()]
+
+        def record(name, result):
+            def invoke(*_args, **_kwargs):
+                events.append(name)
+                return result
+
+            return invoke
+
+        runner._ensure_pipeline_modules = Mock(side_effect=record("ensure_modules", None))
+        runner._split_image_paths = Mock(side_effect=record("split_paths", ["reference.png"]))
+        runner._build_batch_cond_images = Mock(side_effect=record("build_conditions", batch_cond_images))
+        runner._resolve_image_size = Mock(side_effect=record("resolve_requested_size", "auto"))
+        runner._resolve_ti2i_image_size = Mock(side_effect=record("resolve_ti2i_size", (768, 1024)))
+        runner._prepare_cond_inputs = Mock(side_effect=record("encode_conditions", text_cond_inputs))
+        runner._generate_cot_text = Mock(side_effect=record("ar", "generated recaption"))
+        runner._repeat_cond_inputs = Mock(side_effect=record("pack_cfg_conditions", generation_cond_inputs))
+        runner._prepare_text_to_image_inputs = Mock(side_effect=record("prepare_denoise", prepared_inputs))
+        runner._denoise_latents = Mock(side_effect=record("denoise", latents))
+        runner._is_output_rank = Mock(side_effect=record("check_output_rank", True))
+        runner._decode_latents = Mock(side_effect=record("decode", decoded_images))
+        runner.hunyuan_image_processor = SimpleNamespace(
+            postprocess_outputs=Mock(side_effect=record("postprocess", final_images))
+        )
+
+        result = runner.generate_ti2i(input_info)
+
+        self.assertIs(result, final_images)
+        self.assertEqual(
+            events,
+            [
+                "ensure_modules",
+                "split_paths",
+                "build_conditions",
+                "resolve_requested_size",
+                "resolve_ti2i_size",
+                "encode_conditions",
+                "ar",
+                "pack_cfg_conditions",
+                "prepare_denoise",
+                "denoise",
+                "check_output_rank",
+                "decode",
+                "postprocess",
+            ],
+        )
+
+        cot_call = runner._generate_cot_text.call_args
+        self.assertIs(cot_call.kwargs["batch_cond_images"], batch_cond_images)
+        self.assertIs(cot_call.kwargs["cond_inputs"], text_cond_inputs)
+
+        runner._repeat_cond_inputs.assert_called_once_with(text_cond_inputs, factor=2)
+        denoise_prepare_call = runner._prepare_text_to_image_inputs.call_args
+        self.assertIs(denoise_prepare_call.kwargs["batch_cond_images"], batch_cond_images)
+        self.assertIs(denoise_prepare_call.kwargs["cond_inputs"], generation_cond_inputs)
+        runner._denoise_latents.assert_called_once_with(prepared_inputs, (768, 1024))
+
+    def test_cfg_condition_replication_and_serial_branch_slicing(self):
+        runner = HunyuanImage3Runner.__new__(HunyuanImage3Runner)
+        source_vae = torch.tensor([[1.0, 2.0]])
+        source_timesteps = torch.tensor([3.0])
+        source_vit = [torch.tensor([[4.0, 5.0]])]
+        source_conditions = {
+            "cond_vae_images": source_vae,
+            "cond_timesteps": source_timesteps,
+            "cond_vit_embeds": source_vit,
+            "optional_metadata": None,
+        }
+
+        packed_conditions = runner._repeat_cond_inputs(source_conditions, factor=2)
+
+        self.assertEqual(packed_conditions["cond_vae_images"].tolist(), [[1.0, 2.0], [1.0, 2.0]])
+        self.assertEqual(packed_conditions["cond_timesteps"].tolist(), [3.0, 3.0])
+        self.assertEqual(len(packed_conditions["cond_vit_embeds"]), 2)
+        self.assertIs(packed_conditions["cond_vit_embeds"][0], source_vit[0])
+        self.assertIs(packed_conditions["cond_vit_embeds"][1], source_vit[0])
+        self.assertIsNone(packed_conditions["optional_metadata"])
+        self.assertEqual(source_vae.shape[0], 1)
+
+        prepared_inputs = {
+            "input_ids": torch.tensor([[10, 11], [20, 21]]),
+            "position_ids": torch.tensor([[0, 1], [2, 3]]),
+            "custom_pos_emb": object(),
+            "rope_image_info": ("cond-rope", "uncond-rope"),
+            "batch_size": 1,
+            "do_cfg": True,
+            **packed_conditions,
+        }
+        rebuilt_position_embeddings = [object(), object()]
+        runner._build_custom_pos_emb = Mock(side_effect=rebuilt_position_embeddings)
+
+        cond_branch = runner._prepare_cfg_parallel_branch_inputs(prepared_inputs, 0, mark_parallel_branch=False)
+        uncond_branch = runner._prepare_cfg_parallel_branch_inputs(prepared_inputs, 1, mark_parallel_branch=False)
+
+        self.assertEqual(cond_branch["input_ids"].tolist(), [[10, 11]])
+        self.assertEqual(uncond_branch["input_ids"].tolist(), [[20, 21]])
+        for branch in (cond_branch, uncond_branch):
+            self.assertEqual(branch["batch_size"], 1)
+            self.assertFalse(branch["do_cfg"])
+            self.assertNotIn("_cfg_parallel_branch", branch)
+            self.assertEqual(branch["cond_vae_images"].tolist(), [[1.0, 2.0]])
+            self.assertEqual(branch["cond_timesteps"].tolist(), [3.0])
+            self.assertEqual(len(branch["cond_vit_embeds"]), 1)
+            self.assertIs(branch["cond_vit_embeds"][0], source_vit[0])
+
+        self.assertIs(cond_branch["custom_pos_emb"], rebuilt_position_embeddings[0])
+        self.assertIs(uncond_branch["custom_pos_emb"], rebuilt_position_embeddings[1])
+
+    def test_denoise_condition_is_injected_only_on_first_cached_step(self):
+        runner = HunyuanImage3Runner.__new__(HunyuanImage3Runner)
+        runner.config = {}
+        rebuilt_position_embedding = object()
+        runner._build_custom_pos_emb = Mock(return_value=rebuilt_position_embedding)
+
+        condition_values = {
+            "cond_vae_images": torch.ones(1, 2, 2, 2),
+            "cond_vae_image_mask": torch.tensor([[True, False, False, False]]),
+            "cond_timesteps": torch.zeros(1),
+            "cond_timestep_index": torch.tensor([[0]]),
+            "cond_vit_embeds": [torch.ones(1, 2, 3)],
+            "cond_vit_image_mask": torch.tensor([[False, True, False, False]]),
+        }
+        prepared_inputs = {
+            "input_ids": torch.tensor([[10, 11, 12, 13]]),
+            "attention_mask": None,
+            "full_attn_slices": None,
+            "position_ids": torch.tensor([[0, 1, 2, 3]]),
+            "custom_pos_emb": object(),
+            "rope_image_info": object(),
+            "image_mask": torch.tensor([[False, False, True, True]]),
+            "timesteps_index": torch.tensor([[0]]),
+            "guidance_index": None,
+            "timesteps_r_index": None,
+            **condition_values,
+        }
+        cache = object()
+        cache_position_ids = torch.tensor([[0, 2, 3]])
+        cache_local_inputs = {
+            "image_mask": torch.tensor([[False, True, True]]),
+            "timesteps_index": torch.tensor([[0]]),
+            "guidance_index": None,
+            "timesteps_r_index": None,
+        }
+        kv_state = {
+            "kv_cache": cache,
+            "cache_position_ids": cache_position_ids,
+            "cache_local_inputs": cache_local_inputs,
+        }
+        latents = torch.zeros(1, 4, 2, 2)
+        timestep = torch.tensor(1.0)
+
+        first_step_inputs = runner._build_denoise_model_inputs(
+            prepared_inputs,
+            latents,
+            timestep,
+            step_index=0,
+            use_kv_cache=True,
+            kv_state=kv_state,
+            guidance_scale=1.0,
+        )
+        cached_step_inputs = runner._build_denoise_model_inputs(
+            prepared_inputs,
+            latents,
+            timestep,
+            step_index=1,
+            use_kv_cache=True,
+            kv_state=kv_state,
+            guidance_scale=1.0,
+        )
+
+        self.assertTrue(first_step_inputs["first_step"])
+        self.assertIs(first_step_inputs["input_ids"], prepared_inputs["input_ids"])
+        for key, value in condition_values.items():
+            self.assertIs(first_step_inputs[key], value)
+
+        self.assertFalse(cached_step_inputs["first_step"])
+        self.assertIsNone(cached_step_inputs["input_ids"])
+        for key in condition_values:
+            self.assertNotIn(key, cached_step_inputs)
+        self.assertIs(cached_step_inputs["position_ids"], cache_position_ids)
+        self.assertIs(cached_step_inputs["custom_pos_emb"], rebuilt_position_embedding)
+
+        for model_inputs in (first_step_inputs, cached_step_inputs):
+            self.assertTrue(model_inputs["use_cache"])
+            self.assertIs(model_inputs["past_key_values"], cache)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a four-GPU TI2I and T2I hybrid-parallel path that loads the official checkpoint once in a TP2 ABAB layout, runs autoregressive generation with TP4, and switches denoising to TP2+SP2 through the multi-micro fused MoE path without moving weights between phases. Includes regression coverage for condition reuse, serial CFG slicing, and KV-cache injection.