### PR TITLE
feat(ros): add RoboDojo FastWAM evaluation integration

### DIFF
--- a/configs/fastwam/robodojo_i2va.json
+++ b/configs/fastwam/robodojo_i2va.json
@@ -1,0 +1,18 @@
+{
+  "adapter_model_path": "REPLACE_WITH_ABSOLUTE_PATH_TO_ROBODOJO_STEP_020000_PT",
+  "dataset_stats_path": "REPLACE_WITH_ABSOLUTE_PATH_TO_ROBODOJO_DATASET_STATS_JSON",
+  "camera_size": 384,
+  "action_chunk_size": 32,
+  "actions_per_plan": 24,
+  "num_steps_wait": 0,
+  "action_infer_steps": 10,
+  "action_sample_shift": 5.0,
+  "action_dim_hidden": 1024,
+  "action_dim": 14,
+  "robot_state_dim": 14,
+  "policy_profile": "robodojo",
+  "normalize_mode": "z-score",
+  "binarize_gripper": false,
+  "gripper_postprocess": false,
+  "default_prompt": "A video recorded from a robot's point of view executing the following instruction: {task_prompt}"
+}

--- a/lightx2v/models/networks/wan/fastwam_model.py
+++ b/lightx2v/models/networks/wan/fastwam_model.py
@@ -52,8 +52,9 @@ class FastWAMNativeModel(BaseTransformerModel):
         adapter_path = adapter_path.resolve()
         if not adapter_path.exists():
             raise FileNotFoundError(str(adapter_path))
+        checkpoint_mmap = bool(self.config.get("checkpoint_mmap", False))
         logger.info(f"Loading FastWAM native weights from {adapter_path}")
-        payload = torch.load(str(adapter_path), map_location="cpu", weights_only=True)
+        payload = torch.load(str(adapter_path), map_location="cpu", weights_only=True, mmap=checkpoint_mmap)
         if "mot" not in payload:
             raise ValueError(f"FastWAM checkpoint must contain `mot`, got keys={list(payload.keys())}")
         state = dict(payload["mot"])

--- a/lightx2v/models/runners/wan/fastwam_runner.py
+++ b/lightx2v/models/runners/wan/fastwam_runner.py
@@ -25,6 +25,19 @@ def resize_rgb(image, width, height):
     return np.asarray(pil.resize((width, height), resample=Image.BILINEAR), dtype=np.uint8)
 
 
+def resize_rgb_area(image, width, height):
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ImportError("RoboDojo FastWAM preprocessing requires OpenCV (`cv2`).") from exc
+
+    array = np.asarray(image, dtype=np.uint8)
+    if array.ndim != 3 or array.shape[2] != 3:
+        raise ValueError(f"expected HWC RGB image with 3 channels, got shape {array.shape}")
+    resized = cv2.resize(array, (width, height), interpolation=cv2.INTER_AREA)
+    return np.ascontiguousarray(resized, dtype=np.uint8)
+
+
 def _canonical_norm_mode(mode):
     compact = str(mode).strip().lower().replace("-", "").replace("_", "").replace("/", "")
     if compact == "minmax":
@@ -144,6 +157,8 @@ class FastWAMPolicy:
         self.default_prompt = str(default_prompt)
         self.policy_profile = str(policy_profile).strip().lower()
         self.normalize_mode = _canonical_norm_mode(normalize_mode)
+        self.t5_cpu_offload = bool(config.get("t5_cpu_offload", False))
+        self.vae_cpu_offload = bool(config.get("vae_cpu_offload", False))
         # LIBERO post-processes the single gripper channel; RoboTwin (dual-arm qpos) does not.
         self.gripper_postprocess = (self.policy_profile == "libero") if gripper_postprocess is None else bool(gripper_postprocess)
         self.config = config
@@ -200,23 +215,25 @@ class FastWAMPolicy:
     def _load_text_encoder(self):
         t5_path = self._find_model_file("models_t5_umt5-xxl-enc-bf16.pth")
         tokenizer_path = self._find_model_dir("google/umt5-xxl")
+        t5_device = torch.device("cpu") if self.t5_cpu_offload else self.device
         return T5EncoderModel(
             text_len=128,
             dtype=GET_DTYPE(),
-            device=self.device,
+            device=t5_device,
             checkpoint_path=t5_path,
             tokenizer_path=str(tokenizer_path),
-            cpu_offload=False,
+            cpu_offload=self.t5_cpu_offload,
         )
 
     def _load_vae(self):
         vae_path = self._find_model_file("Wan2.2_VAE.pth")
+        vae_device = torch.device("cpu") if self.vae_cpu_offload else self.device
         return Wan2_2_VAE(
             vae_path=vae_path,
-            device=self.device,
+            device=vae_device,
             dtype=GET_DTYPE(),
             vae_type="wan2.2",
-            cpu_offload=False,
+            cpu_offload=self.vae_cpu_offload,
         )
 
     def _find_model_file(self, filename):
@@ -294,6 +311,9 @@ class FastWAMPolicy:
           - LIBERO   : [agentview | wrist] side-by-side, each camera_size x camera_size.
           - RoboTwin : head (320x256) on top, [left | right] (each 160x128) below,
                        i.e. final [384, 320, 3]; matches deploy_policy.py.
+          - RoboDojo : first normalizes each source RGB to 320x240 with OpenCV
+                       INTER_AREA, then applies the official RoboDojo FastWAM
+                       384x320 three-camera layout.
         """
         rgb = self._compose_rgb(images)
         tensor = torch.from_numpy(rgb).permute(2, 0, 1).to(device=self.device, dtype=GET_DTYPE())
@@ -311,6 +331,22 @@ class FastWAMPolicy:
             right = resize_rgb(_get("right_camera"), 160, 128)
             bottom = np.concatenate([left, right], axis=1)
             return np.concatenate([head, bottom], axis=0)
+
+        if self.policy_profile == "robodojo":
+            head_src = resize_rgb_area(_get("head_camera"), 320, 240)
+            left_src = resize_rgb_area(_get("left_camera"), 320, 240)
+            right_src = resize_rgb_area(_get("right_camera"), 320, 240)
+            head = resize_rgb(head_src, 320, 256)
+            left = resize_rgb(left_src, 160, 128)
+            right = resize_rgb(right_src, 160, 128)
+            bottom = np.concatenate([left, right], axis=1)
+            image = np.concatenate([head, bottom], axis=0)
+            if image.shape != (384, 320, 3):
+                raise RuntimeError(f"RoboDojo FastWAM image must be (384, 320, 3), got {image.shape}")
+            return image
+
+        if self.policy_profile != "libero":
+            raise ValueError(f"unsupported FastWAM policy_profile: {self.policy_profile!r}")
 
         primary = resize_rgb(_get("agentview"), self.camera_size, self.camera_size)
         wrist = resize_rgb(_get("wrist"), self.camera_size, self.camera_size)

--- a/lightx2v_ros/src/common/common/contract.py
+++ b/lightx2v_ros/src/common/common/contract.py
@@ -132,10 +132,28 @@ ROBOLAB_CONTRACT = EnvContract(
 )
 
 
+ROBODOJO_CONTRACT = EnvContract(
+    name="robodojo",
+    namespace="/robodojo",
+    # RoboDojo publishes 480x640 source RGB.  The scalar image_size is only an
+    # informational source-width hint here; FastWAM resizing is profile-driven.
+    cameras=("head_camera", "left_camera", "right_camera"),
+    policy_input_cameras=("head_camera", "left_camera", "right_camera"),
+    action_dim=14,
+    state_dim=14,
+    image_size=640,
+    policy_profile="robodojo",
+    normalize_mode="zscore",
+    gripper_postprocess=False,
+    description="RoboDojo dual-arm ARX-X5 joint evaluation with the official three-camera FastWAM preprocessing.",
+)
+
+
 CONTRACTS: Dict[str, EnvContract] = {
     LIBERO_CONTRACT.name: LIBERO_CONTRACT,
     ROBOTWIN_CONTRACT.name: ROBOTWIN_CONTRACT,
     ROBOLAB_CONTRACT.name: ROBOLAB_CONTRACT,
+    ROBODOJO_CONTRACT.name: ROBODOJO_CONTRACT,
 }
 
 

--- a/lightx2v_ros/src/simulator/setup.py
+++ b/lightx2v_ros/src/simulator/setup.py
@@ -20,6 +20,7 @@ setup(
         "console_scripts": [
             "libero_node = simulator.libero_node.main:main",
             "robolab_node = simulator.robolab_node.main:main",
+            "robodojo_node = simulator.robodojo_node.main:main",
             "robotwin_node = simulator.robotwin_node.main:main",
         ],
     },

--- a/lightx2v_ros/src/simulator/simulator/libero_node/env.py
+++ b/lightx2v_ros/src/simulator/simulator/libero_node/env.py
@@ -70,7 +70,8 @@ class LiberoEnv(BaseSimEnv):
 
     def step(self, action):
         _, _, success, _ = self.observer.step(action)
-        return self._observation(), bool(success)
+        success = bool(success)
+        return self._observation(), success, success
 
     def _observation(self) -> Observation:
         obs = self.observer.obs

--- a/lightx2v_ros/src/simulator/simulator/robodojo_node/__init__.py
+++ b/lightx2v_ros/src/simulator/simulator/robodojo_node/__init__.py
@@ -1,0 +1,1 @@
+"""RoboDojo/Isaac ROS simulator node."""

--- a/lightx2v_ros/src/simulator/simulator/robodojo_node/env.py
+++ b/lightx2v_ros/src/simulator/simulator/robodojo_node/env.py
@@ -1,0 +1,355 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from common.contract import EnvContract
+
+from simulator.sim.base_env import BaseSimEnv, Observation
+
+
+DEFAULT_TASK_NAME = "stack_bowls"
+DEFAULT_ENV_CFG_TYPE = "arx_x5"
+
+
+def default_robodojo_root() -> Path:
+    return Path(os.environ.get("ROBODOJO_ROOT", "/app/RoboDojo"))
+
+
+def resolve_robodojo_root(path=None) -> Path:
+    raw_path = str(path).strip() if path is not None else ""
+    if not raw_path:
+        return default_robodojo_root().resolve()
+    return Path(os.path.expandvars(raw_path)).expanduser().resolve()
+
+
+def add_robodojo_python_paths(root: Path) -> None:
+    # Official eval_policy.sh adds both entries for env/task/utils and
+    # client_server.ws imports.
+    paths = [str(root), str(root / "XPolicyLab")]
+    for path in paths:
+        while path in sys.path:
+            sys.path.remove(path)
+    sys.path[:0] = paths
+
+
+class NoopModelClient:
+    """Small stand-in for EvalEnv construction; policy inference happens via ROS."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def call(self, func_name=None, obs=None, **kwargs):
+        return None
+
+    def close(self):
+        return None
+
+
+def _to_numpy(value):
+    if hasattr(value, "detach"):
+        value = value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def _as_vector(value, expected_dim, key):
+    arr = _to_numpy(value).astype(np.float32, copy=False)
+    if arr.ndim > 1 and arr.shape[0] == 1:
+        arr = arr[0]
+    arr = arr.reshape(-1)
+    if arr.size != expected_dim:
+        raise ValueError(f"RoboDojo state key '{key}' expected {expected_dim} values, got {arr.size}")
+    return arr
+
+
+def _as_rgb(value, key):
+    image = _to_numpy(value)
+    if image.ndim == 4 and image.shape[0] == 1:
+        image = image[0]
+    if image.ndim != 3 or image.shape[-1] < 3:
+        raise ValueError(f"RoboDojo camera '{key}' must be HxWx3 RGB, got {image.shape}")
+    image = image[..., :3]
+    if np.issubdtype(image.dtype, np.floating):
+        if image.size and float(np.nanmax(image)) <= 1.0:
+            image = image * 255.0
+        image = np.clip(image, 0, 255).round().astype(np.uint8)
+    else:
+        image = image.astype(np.uint8, copy=False)
+    return np.ascontiguousarray(image)
+
+
+def _first_bool(value):
+    arr = _to_numpy(value)
+    if arr.shape == ():
+        return bool(arr.item())
+    return bool(arr.reshape(-1)[0])
+
+
+def _as_text(value):
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple)):
+        return _as_text(value[0]) if value else ""
+    if hasattr(value, "item"):
+        value = value.item()
+    return str(value)
+
+
+def split_joint_action(action):
+    action = np.asarray(action, dtype=np.float32).reshape(-1)
+    if action.size != 14:
+        raise ValueError(f"RoboDojo joint action expects 14 values, got {action.size}")
+    # Presence of arm_joint_state keys makes EvalEnv infer joint action mode.
+    return {
+        "left_arm_joint_state": action[0:6].copy(),
+        "left_ee_joint_state": action[6:7].copy(),
+        "right_arm_joint_state": action[7:13].copy(),
+        "right_ee_joint_state": action[13:14].copy(),
+    }
+
+
+class RoboDojoEnv(BaseSimEnv):
+    """RoboDojo official EvalEnv exposed through LightX2V's simulator contract."""
+
+    CAMERA_KEYS = {
+        "head_camera": ("cam_head", "color"),
+        "left_camera": ("cam_left_wrist", "color"),
+        "right_camera": ("cam_right_wrist", "color"),
+    }
+
+    STATE_KEYS = (
+        ("left_arm_joint_state", 6),
+        ("left_ee_joint_state", 1),
+        ("right_arm_joint_state", 6),
+        ("right_ee_joint_state", 1),
+    )
+
+    def __init__(
+        self,
+        contract: EnvContract,
+        *,
+        simulation_app,
+        robodojo_root=None,
+        task_name=DEFAULT_TASK_NAME,
+        env_cfg_type=DEFAULT_ENV_CFG_TYPE,
+        eval_seed=0,
+        layout_id=0,
+        device_id=None,
+        policy_name="FastWAM",
+        additional_info="lightx2v_ros,action_type=joint",
+    ):
+        super().__init__(contract)
+        if simulation_app is None:
+            raise ValueError("RoboDojoEnv requires an already-started Isaac simulation app.")
+        self.simulation_app = simulation_app
+        self.robodojo_root = resolve_robodojo_root(robodojo_root)
+        if not self.robodojo_root.is_dir():
+            raise FileNotFoundError(f"RoboDojo root does not exist: {self.robodojo_root}")
+        add_robodojo_python_paths(self.robodojo_root)
+
+        self.task_name = str(task_name)
+        self.env_cfg_type = str(env_cfg_type)
+        self.task_config = self.env_cfg_type
+        self.seed = int(eval_seed)
+        self.layout_id = int(layout_id)
+        self.device_id = 0 if device_id is None or str(device_id).strip() == "" else int(device_id)
+        self.policy_name = str(policy_name)
+        self.additional_info = str(additional_info)
+        self._raw_obs = None
+        self._last_instruction = ""
+
+        self._env_cfg = self._build_env_cfg()
+        self._env = self._create_eval_env(self._env_cfg)
+        self._validate_joint_robot()
+
+    def _build_env_cfg(self):
+        from omegaconf import OmegaConf
+
+        import env.global_configs as global_configs
+        from utils.load_file import load_yaml
+        from utils.pipeline_utils import process_config, process_randomization, resolve_random_task_num_envs
+
+        task_registry = importlib.import_module(f"task.{global_configs.BENCHMARK}.task_registry")
+        eval_cfg = load_yaml(os.path.join(global_configs.ENV_CONFIG_PATH, self.env_cfg_type + ".yml"))
+        eval_cfg["task_name"] = self.task_name
+        eval_cfg["num_envs"] = 1
+        eval_cfg["device_id"] = self.device_id
+        eval_cfg["eval_batch"] = False
+        eval_cfg["policy_name"] = self.policy_name
+        eval_cfg["additional_info"] = self.additional_info
+        eval_cfg["seed"] = self.seed
+        eval_cfg["physx_monitor_enabled"] = False
+
+        deploy_cfg = {
+            "policy_name": self.policy_name,
+            "port": 1,
+            "host": "localhost",
+            "protocol": "ws",
+            "policy_server_url": "ws://localhost:1",
+            "evaluation_id": os.environ.get("ROBODOJO_RUN_ID", "lightx2v_ros"),
+            "trial_id": f"{self.task_name}-lightx2v_ros",
+            "action_case_id": f"{self.task_name}_case",
+            "repeat_index": None,
+            "action_type": "joint",
+        }
+
+        benchmark_path = os.path.join(global_configs.ROOT_DIR, "task", global_configs.BENCHMARK)
+        env_cfg = OmegaConf.create(
+            {
+                "sim": load_yaml(os.path.join(global_configs.ENV_CONFIG_PATH, "sim", eval_cfg["config"]["sim"] + ".yml")),
+                "scene": load_yaml(os.path.join(global_configs.ENV_CONFIG_PATH, "scene", eval_cfg["config"]["scene"] + ".yml")),
+                "camera": load_yaml(os.path.join(global_configs.ENV_CONFIG_PATH, "camera", eval_cfg["config"]["camera"] + ".yml")),
+                "robot": load_yaml(os.path.join(global_configs.ENV_CONFIG_PATH, "robot", eval_cfg["config"]["robot"] + ".yml")),
+                "task_env": load_yaml(task_registry.task_config_path(os.path.join(benchmark_path, "config"), self.task_name)),
+                "eval_cfg": eval_cfg,
+                "deploy_cfg": deploy_cfg,
+            }
+        )
+
+        num_envs = resolve_random_task_num_envs(self.task_name, 1, env_cfg.sim)
+        eval_cfg["num_envs"] = num_envs
+        OmegaConf.update(env_cfg, "sim.scene.num_envs", num_envs, force_add=True)
+        OmegaConf.update(env_cfg, "eval_cfg.num_envs", num_envs, force_add=True)
+
+        env_cfg = process_randomization(env_cfg)
+        env_cfg, eval_num = process_config(env_cfg, task_name=self.task_name)
+        OmegaConf.update(env_cfg, "eval_cfg.eval_num", min(int(eval_num), 1), force_add=True)
+        OmegaConf.update(
+            env_cfg,
+            "camera.default_frequency",
+            eval_cfg["observation"].get("collect_freq", 0),
+            force_add=True,
+        )
+        env_cfg.sim.seed = [0 for _ in range(num_envs)]
+        return env_cfg
+
+    def _create_eval_env(self, env_cfg):
+        import src.eval_client.eval_env as eval_env_mod
+
+        old_client = eval_env_mod.WsModelClient
+        eval_env_mod.WsModelClient = NoopModelClient
+        try:
+            return eval_env_mod.create_eval_env(env_cfg, self.simulation_app)
+        finally:
+            eval_env_mod.WsModelClient = old_client
+
+    def _validate_joint_robot(self):
+        info = getattr(self._env, "robot_action_dim_info", {})
+        if list(info.get("arm_dim", [])) != [6, 6] or list(info.get("ee_dim", [])) != [1, 1]:
+            raise ValueError(f"RoboDojo FastWAM joint path requires dual 6D arms and 1D grippers, got {info}")
+
+    @property
+    def task_description(self):
+        if self._last_instruction:
+            return self._last_instruction
+        obs_manager = getattr(self._env, "obs_manager", None)
+        return _as_text(getattr(obs_manager, "instruction", ""))
+
+    @property
+    def max_steps(self):
+        step_lim = getattr(self._env, "step_lim", None)
+        return int(step_lim) if step_lim is not None else None
+
+    def reset(self):
+        return self._reset_layout(self.layout_id)
+
+    def new_episode(self):
+        self.layout_id = self._next_layout_id(self.layout_id)
+        return self._reset_layout(self.layout_id)
+
+    def _next_layout_id(self, current):
+        seed_info = getattr(getattr(self._env, "seed_manager", None), "seed_info", {})
+        layout_ids = sorted(int(value) for value in seed_info.keys())
+        if not layout_ids:
+            return int(current)
+        if int(current) not in layout_ids:
+            return layout_ids[0]
+        index = layout_ids.index(int(current))
+        return layout_ids[(index + 1) % len(layout_ids)]
+
+    def _reset_layout(self, layout_id):
+        self.layout_id = int(layout_id)
+        self.task_config = f"{self.env_cfg_type}/layout_{self.layout_id}"
+        self._env.reset(seed=[self.layout_id])
+        self._prepare_official_episode()
+        raw_obs = self._env.get_obs()
+        self._raw_obs = raw_obs
+        return self._convert_observation(raw_obs)
+
+    def _prepare_official_episode(self):
+        self._env.run_reward()
+        if hasattr(self._env, "get_score"):
+            self._env.get_score()
+        if getattr(self._env, "interact", False) and hasattr(self._env, "query_support_arm_traj"):
+            for env_idx in self._env.get_running_env_idx_list():
+                self._env.query_support_arm_traj(env_idx=env_idx)
+
+    def step(self, action):
+        action_dict = split_joint_action(action)
+        self._env.take_action(action_dict)
+        raw_obs = self._env.get_obs()
+        self._raw_obs = raw_obs
+        obs = self._convert_observation(raw_obs)
+        done = _first_bool(self._env.end_flag)
+        success = bool(done and _first_bool(self._env.success))
+        return obs, success, done
+
+    def _convert_observation(self, raw_obs):
+        self._last_instruction = _as_text(raw_obs.get("instruction", ""))
+        vision = raw_obs["vision"]
+        state_dict = raw_obs["state"]
+
+        images = {}
+        for logical_name, (camera_key, obs_key) in self.CAMERA_KEYS.items():
+            images[logical_name] = _as_rgb(vision[camera_key][obs_key], camera_key)
+
+        state_parts = []
+        for key, dim in self.STATE_KEYS:
+            state_parts.append(_as_vector(state_dict[key], dim, key))
+        state = np.concatenate(state_parts).astype(np.float32, copy=False)
+        return Observation(images=images, state=state)
+
+    def close(self):
+        env = getattr(self, "_env", None)
+        if env is None:
+            return
+        try:
+            model_client = getattr(env, "model_client", None)
+            close_client = getattr(model_client, "close", None)
+            if callable(close_client):
+                close_client()
+        finally:
+            try:
+                env.close()
+            finally:
+                self._env = None
+
+
+def _env_int(name, default):
+    value = os.environ.get(name)
+    return int(value) if value is not None and str(value).strip().lstrip("-").isdigit() else default
+
+
+def build_robodojo_env(node, *, simulation_app):
+    contract = node.contract
+    node.declare_parameter("robodojo_root", str(default_robodojo_root()))
+    node.declare_parameter("task_name", DEFAULT_TASK_NAME)
+    node.declare_parameter("env_cfg_type", DEFAULT_ENV_CFG_TYPE)
+    node.declare_parameter("eval_seed", 0)
+    node.declare_parameter("layout_id", 0)
+    node.declare_parameter("device_id", _env_int("ROBODOJO_DEVICE_ID", 0))
+    node.declare_parameter("additional_info", "lightx2v_ros,action_type=joint")
+    device_id = int(node.get_parameter("device_id").value)
+
+    return RoboDojoEnv(
+        contract,
+        simulation_app=simulation_app,
+        robodojo_root=node.get_parameter("robodojo_root").value,
+        task_name=node.get_parameter("task_name").value,
+        env_cfg_type=node.get_parameter("env_cfg_type").value,
+        eval_seed=int(node.get_parameter("eval_seed").value),
+        layout_id=int(node.get_parameter("layout_id").value),
+        device_id=device_id,
+        additional_info=node.get_parameter("additional_info").value,
+    )

--- a/lightx2v_ros/src/simulator/simulator/robodojo_node/main.py
+++ b/lightx2v_ros/src/simulator/simulator/robodojo_node/main.py
@@ -1,0 +1,92 @@
+import os
+import sys
+from pathlib import Path
+
+
+def _extract_ros_param(name, argv=None):
+    marker = f"{name}:="
+    for token in argv or sys.argv:
+        if token.startswith(marker):
+            return token[len(marker) :]
+    return None
+
+
+def _as_bool(value, default=False):
+    if value is None or value == "":
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _default_robodojo_root():
+    return Path(os.environ.get("ROBODOJO_ROOT", "/app/RoboDojo"))
+
+
+def _resolve_root(path=None):
+    raw = str(path).strip() if path is not None else ""
+    return Path(os.path.expandvars(raw)).expanduser().resolve() if raw else _default_robodojo_root().resolve()
+
+
+def _add_robodojo_paths(root):
+    paths = [str(root), str(root / "XPolicyLab")]
+    for path in paths:
+        while path in sys.path:
+            sys.path.remove(path)
+    sys.path[:0] = paths
+
+
+def _device_id_from_args(argv):
+    raw = _extract_ros_param("device_id", argv) or os.environ.get("ROBODOJO_DEVICE_ID", "0")
+    return int(raw)
+
+
+def _launch_isaac_sim():
+    original_argv = sys.argv[:]
+    robodojo_root = _resolve_root(_extract_ros_param("robodojo_root", original_argv))
+    _add_robodojo_paths(robodojo_root)
+    device_id = _device_id_from_args(original_argv)
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(device_id)
+
+    from isaaclab.app import AppLauncher
+
+    required_kit_args = "--enable isaacsim.replicator.behavior --enable isaacsim.sensors.camera"
+    extra_kit_args = os.environ.get("ROBODOJO_KIT_ARGS", "").strip()
+    kit_args = f"{required_kit_args} {extra_kit_args}".strip()
+
+    launcher_args = {
+        "enable_cameras": True,
+        "device": "cuda:0",
+        "headless": _as_bool(_extract_ros_param("headless", original_argv), os.environ.get("HEADLESS", "1") == "1"),
+        "livestream": int(os.environ.get("LIVESTREAM", "0")),
+        "kit_args": kit_args,
+    }
+
+    # Keep ROS arguments away from Kit, then restore them for rclpy.init().
+    try:
+        sys.argv = [sys.argv[0]]
+        launcher = AppLauncher(launcher_args)
+    finally:
+        sys.argv = original_argv
+    return launcher
+
+
+def main(args=None):
+    launcher = _launch_isaac_sim()
+    try:
+        from common.contract import get_contract
+        from simulator.robodojo_node.env import build_robodojo_env
+        from simulator.sim.node import run_simulator_node
+
+        contract = get_contract("robodojo")
+
+        def _factory(node):
+            return build_robodojo_env(node, simulation_app=launcher.app)
+
+        run_simulator_node(contract, _factory, node_name="robodojo_node", args=args)
+    finally:
+        launcher.app.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/lightx2v_ros/src/simulator/simulator/robolab_node/env.py
+++ b/lightx2v_ros/src/simulator/simulator/robolab_node/env.py
@@ -148,11 +148,11 @@ class RoboLabEnv(BaseSimEnv):
         action_tensor = torch.as_tensor(action, dtype=torch.float32, device=self._env.device)
         raw_obs, _, terminated, truncated, _ = self._env.step(action_tensor)
         self._raw_obs = raw_obs
-        success = bool(terminated.reshape(-1)[0].item())
-        # A timeout is reported as failure by SimulatorNode's matching step cap.
-        if bool(truncated.reshape(-1)[0].item()) and not success:
-            success = False
-        return self._convert_observation(raw_obs), success
+        terminated = bool(terminated.reshape(-1)[0].item())
+        truncated = bool(truncated.reshape(-1)[0].item())
+        success = terminated
+        done = terminated or truncated
+        return self._convert_observation(raw_obs), success, done
 
     def close(self):
         if self._env is not None:

--- a/lightx2v_ros/src/simulator/simulator/robotwin_node/env.py
+++ b/lightx2v_ros/src/simulator/simulator/robotwin_node/env.py
@@ -594,7 +594,7 @@ class RoboTwinEnv(BaseSimEnv):
             raise ValueError(f"RoboTwin expects a 14-D qpos or 16-D relative EE action, got {action.size}.")
         obs = self._observation()
         success = bool(getattr(self.env, "eval_success", False)) or bool(self.env.check_success())
-        return obs, success
+        return obs, success, success
 
     def _observation(self) -> Observation:
         raw = self.env.get_obs()

--- a/lightx2v_ros/src/simulator/simulator/sim/base_env.py
+++ b/lightx2v_ros/src/simulator/simulator/sim/base_env.py
@@ -37,8 +37,12 @@ class BaseSimEnv(ABC):
         """Reset the environment and return the first observation."""
 
     @abstractmethod
-    def step(self, action: np.ndarray) -> Tuple[Observation, bool]:
-        """Apply one action, returning (observation, success)."""
+    def step(self, action: np.ndarray) -> Tuple[Observation, bool, bool]:
+        """Apply one action, returning (observation, success, done).
+
+        ``done`` is explicit because some simulators can terminate an episode as
+        a failure before the generic max-step cap is reached.
+        """
 
     def new_episode(self) -> Observation:
         """Start a fresh episode and return its first observation.

--- a/lightx2v_ros/src/simulator/simulator/sim/node.py
+++ b/lightx2v_ros/src/simulator/simulator/sim/node.py
@@ -10,7 +10,7 @@ Evaluation control plane
 The node is a small state machine driven by JSON commands on
 ``{namespace}/control`` and reporting on ``{namespace}/status``:
 
-    ready ──start──▶ running ──success/step-cap──▶ success | failure
+    ready ──start──▶ running ──success/done/step-cap──▶ success | failure
       ▲                │  ▲                             │
       │              pause resume                    start/restart
       └────set_task────┴──┴─────────────────────────────┘
@@ -224,7 +224,7 @@ class SimulatorNode(Node):
 
         self._in_env_step = True
         try:
-            self.obs, success = self.env.step(action)
+            self.obs, success, done = self.env.step(action)
         finally:
             self._in_env_step = False
         self.step_index += 1
@@ -232,11 +232,12 @@ class SimulatorNode(Node):
         self.success = bool(success)
 
         capped = self.max_episode_steps > 0 and self.episode_step >= self.max_episode_steps
-        if self.success or capped:
+        if self.success or bool(done) or capped:
             self._finish_episode("success" if self.success else "failure")
             return
 
         self.publish_observation()
+        self.publish_status()
 
     def _finish_episode(self, outcome: str):
         self.state = SUCCESS if outcome == "success" else FAILURE

--- a/test_cases/test_fastwam_checkpoint_mmap.py
+++ b/test_cases/test_fastwam_checkpoint_mmap.py
@@ -1,0 +1,129 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import torch
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _stub_modules():
+    class BaseTransformerModel:
+        pass
+
+    fastwam_infer = types.ModuleType("lightx2v.models.networks.wan.infer.fastwam")
+    fastwam_infer.FastWAMPreInfer = type("FastWAMPreInfer", (), {})
+    fastwam_infer.FastWAMTransformerInfer = type("FastWAMTransformerInfer", (), {})
+
+    fastwam_weights = types.ModuleType("lightx2v.models.networks.wan.weights.fastwam")
+    fastwam_weights.FastWAMPreWeights = type("FastWAMPreWeights", (), {})
+    fastwam_weights.FastWAMTransformerWeights = type("FastWAMTransformerWeights", (), {})
+
+    fastwam_scheduler = types.ModuleType("lightx2v.models.schedulers.wan.fastwam")
+    fastwam_scheduler.FastWAMActionScheduler = type("FastWAMActionScheduler", (), {})
+
+    base_model = types.ModuleType("lightx2v.models.networks.base_model")
+    base_model.BaseTransformerModel = BaseTransformerModel
+
+    envs = types.ModuleType("lightx2v.utils.envs")
+    envs.GET_DTYPE = lambda: torch.float32
+    envs.GET_SENSITIVE_DTYPE = lambda: torch.float64
+
+    ops = types.ModuleType("lightx2v.common.ops")
+    ops.__all__ = []
+
+    return {
+        "lightx2v": _package("lightx2v"),
+        "lightx2v.common": _package("lightx2v.common"),
+        "lightx2v.common.ops": ops,
+        "lightx2v.models": _package("lightx2v.models"),
+        "lightx2v.models.networks": _package("lightx2v.models.networks"),
+        "lightx2v.models.networks.base_model": base_model,
+        "lightx2v.models.networks.wan": _package("lightx2v.models.networks.wan"),
+        "lightx2v.models.networks.wan.infer": _package("lightx2v.models.networks.wan.infer"),
+        "lightx2v.models.networks.wan.infer.fastwam": fastwam_infer,
+        "lightx2v.models.networks.wan.weights": _package("lightx2v.models.networks.wan.weights"),
+        "lightx2v.models.networks.wan.weights.fastwam": fastwam_weights,
+        "lightx2v.models.schedulers": _package("lightx2v.models.schedulers"),
+        "lightx2v.models.schedulers.wan": _package("lightx2v.models.schedulers.wan"),
+        "lightx2v.models.schedulers.wan.fastwam": fastwam_scheduler,
+        "lightx2v.utils": _package("lightx2v.utils"),
+        "lightx2v.utils.envs": envs,
+    }
+
+
+def _load_fastwam_model_module():
+    module_path = Path(__file__).resolve().parents[1] / "lightx2v/models/networks/wan/fastwam_model.py"
+    spec = importlib.util.spec_from_file_location("_fastwam_model_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, _stub_modules()):
+        spec.loader.exec_module(module)
+    return module
+
+
+class FastWAMCheckpointMmapTest(unittest.TestCase):
+    def _run_load_ckpt(self, extra_config=None, payload=None):
+        module = _load_fastwam_model_module()
+        model = object.__new__(module.FastWAMNativeModel)
+        model.device = torch.device("cpu")
+
+        calls = []
+
+        def fake_load(path, **kwargs):
+            calls.append((path, kwargs))
+            return payload or {
+                "mot": {"blocks.0.weight": torch.ones(2, 2)},
+                "proprio_encoder": {
+                    "weight": torch.ones(1, 2),
+                    "bias": torch.zeros(1),
+                },
+            }
+
+        with tempfile.NamedTemporaryFile(suffix=".pt") as ckpt:
+            config = {"adapter_model_path": ckpt.name}
+            if extra_config:
+                config.update(extra_config)
+            model.config = config
+            with mock.patch.object(module.torch, "load", side_effect=fake_load):
+                weight_dict = model._load_ckpt(unified_dtype=True, sensitive_layer=set())
+
+        self.assertEqual(len(calls), 1)
+        return calls[0], weight_dict
+
+    def test_default_config_passes_mmap_false_to_torch_load(self):
+        (_path, kwargs), weight_dict = self._run_load_ckpt()
+
+        self.assertEqual(kwargs["map_location"], "cpu")
+        self.assertIs(kwargs["weights_only"], True)
+        self.assertIs(kwargs["mmap"], False)
+        self.assertIn("blocks.0.weight", weight_dict)
+        self.assertIn("proprio_encoder.weight", weight_dict)
+        self.assertIn("proprio_encoder.bias", weight_dict)
+
+    def test_explicit_config_passes_mmap_true_to_torch_load(self):
+        (_path, kwargs), _weight_dict = self._run_load_ckpt({"checkpoint_mmap": True})
+
+        self.assertIs(kwargs["mmap"], True)
+
+    def test_checkpoint_schema_still_requires_mot(self):
+        module = _load_fastwam_model_module()
+        model = object.__new__(module.FastWAMNativeModel)
+        model.device = torch.device("cpu")
+
+        with tempfile.NamedTemporaryFile(suffix=".pt") as ckpt:
+            model.config = {"adapter_model_path": ckpt.name, "checkpoint_mmap": True}
+            with mock.patch.object(module.torch, "load", return_value={"not_mot": {}}):
+                with self.assertRaisesRegex(ValueError, "must contain `mot`"):
+                    model._load_ckpt(unified_dtype=True, sensitive_layer=set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_cases/test_simulator_status_updates.py
+++ b/test_cases/test_simulator_status_updates.py
@@ -1,0 +1,191 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+class _Msg:
+    def __init__(self):
+        self.header = SimpleNamespace(stamp=None, frame_id="")
+        self.data = None
+
+
+def _stub_modules():
+    rclpy = types.ModuleType("rclpy")
+    rclpy.init = lambda *args, **kwargs: None
+    rclpy.spin = lambda *args, **kwargs: None
+    rclpy.ok = lambda: False
+    rclpy.shutdown = lambda: None
+
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = type("Node", (), {})
+
+    common_contract = types.ModuleType("common.contract")
+    common_contract.EnvContract = type("EnvContract", (), {})
+
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs_msg.Image = type("Image", (_Msg,), {})
+
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.Bool = type("Bool", (_Msg,), {})
+    std_msgs_msg.Float32MultiArray = type("Float32MultiArray", (_Msg,), {})
+    std_msgs_msg.Int32 = type("Int32", (_Msg,), {})
+    std_msgs_msg.String = type("String", (_Msg,), {})
+
+    base_env = types.ModuleType("simulator.sim.base_env")
+    base_env.BaseSimEnv = type("BaseSimEnv", (), {})
+
+    return {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "common": _package("common"),
+        "common.contract": common_contract,
+        "sensor_msgs": _package("sensor_msgs"),
+        "sensor_msgs.msg": sensor_msgs_msg,
+        "std_msgs": _package("std_msgs"),
+        "std_msgs.msg": std_msgs_msg,
+        "simulator": _package("simulator"),
+        "simulator.sim": _package("simulator.sim"),
+        "simulator.sim.base_env": base_env,
+    }
+
+
+def _load_node_module():
+    module_path = Path(__file__).resolve().parents[1] / "lightx2v_ros/src/simulator/simulator/sim/node.py"
+    spec = importlib.util.spec_from_file_location("simulator.sim.node", module_path)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, _stub_modules()):
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    return module
+
+
+class _Logger:
+    def __init__(self):
+        self.errors = []
+        self.infos = []
+
+    def error(self, message):
+        self.errors.append(message)
+
+    def info(self, message):
+        self.infos.append(message)
+
+
+class _Env:
+    accepted_action_dims = (2,)
+    task_name = "stack_bowls"
+    task_config = "arx_x5/layout_0"
+    seed = 0
+    supports_task_switch = False
+
+    def __init__(self, *, success=False, done=False):
+        self.success = success
+        self.done = done
+        self.actions = []
+
+    @property
+    def task_description(self):
+        return "stack the bowls"
+
+    def step(self, action):
+        self.actions.append(np.asarray(action, dtype=np.float32).copy())
+        return SimpleNamespace(images={}, state=np.zeros(2, dtype=np.float32)), self.success, self.done
+
+    def list_tasks(self):
+        return []
+
+    def list_task_configs(self):
+        return []
+
+
+class SimulatorStatusUpdateTest(unittest.TestCase):
+    def _make_node(self, module, *, success=False, done=False, max_episode_steps=0):
+        node = object.__new__(module.SimulatorNode)
+        node.contract = SimpleNamespace(
+            name="robodojo",
+            cameras=("head_camera", "left_camera", "right_camera"),
+            policy_input_cameras=("head_camera", "left_camera", "right_camera"),
+        )
+        node.env = _Env(success=success, done=done)
+        node.state = module.RUNNING
+        node.step_index = 0
+        node.episode_step = 0
+        node.episode_index = 1
+        node.success = False
+        node.max_episode_steps = max_episode_steps
+        node.loop = False
+        node.history = []
+        node._in_env_step = False
+        node.logger = _Logger()
+        node.observation_count = 0
+        node.status_snapshots = []
+
+        def publish_observation():
+            node.observation_count += 1
+
+        def publish_status():
+            node.status_snapshots.append(node.build_status())
+
+        node.publish_observation = publish_observation
+        node.publish_status = publish_status
+        node.get_logger = lambda: node.logger
+        return node
+
+    def test_running_action_publishes_status_with_latest_episode_step(self):
+        module = _load_node_module()
+        node = self._make_node(module)
+
+        module.SimulatorNode.on_action(node, SimpleNamespace(data=[0.25, -0.5]))
+
+        self.assertEqual(node.episode_step, 1)
+        self.assertEqual(node.step_index, 1)
+        self.assertEqual(node.state, module.RUNNING)
+        self.assertEqual(node.observation_count, 1)
+        self.assertEqual(len(node.status_snapshots), 1)
+        self.assertEqual(node.status_snapshots[-1]["episode_step"], 1)
+        self.assertEqual(node.status_snapshots[-1]["state"], module.RUNNING)
+
+    def test_step_cap_finish_path_publishes_single_failure_status(self):
+        module = _load_node_module()
+        node = self._make_node(module, max_episode_steps=1)
+
+        module.SimulatorNode.on_action(node, SimpleNamespace(data=[0.0, 0.0]))
+
+        self.assertEqual(node.episode_step, 1)
+        self.assertEqual(node.state, module.FAILURE)
+        self.assertEqual(node.observation_count, 1)
+        self.assertEqual(len(node.status_snapshots), 1)
+        self.assertEqual(node.status_snapshots[-1]["state"], module.FAILURE)
+        self.assertEqual(node.status_snapshots[-1]["episode_step"], 1)
+        self.assertEqual(node.history[-1]["outcome"], "failure")
+        self.assertEqual(node.history[-1]["steps"], 1)
+
+    def test_success_finish_path_publishes_single_success_status(self):
+        module = _load_node_module()
+        node = self._make_node(module, success=True)
+
+        module.SimulatorNode.on_action(node, SimpleNamespace(data=[1.0, 1.0]))
+
+        self.assertEqual(node.episode_step, 1)
+        self.assertEqual(node.state, module.SUCCESS)
+        self.assertEqual(node.observation_count, 1)
+        self.assertEqual(len(node.status_snapshots), 1)
+        self.assertEqual(node.status_snapshots[-1]["state"], module.SUCCESS)
+        self.assertEqual(node.status_snapshots[-1]["episode_step"], 1)
+        self.assertEqual(node.history[-1]["outcome"], "success")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add RoboDojo as an independent ROS simulator environment
- connect RoboDojo observations/actions to the generic LightX2V FastWAM inference node
- add RoboDojo-specific FastWAM preprocessing and configuration for the official RoboDojo FastWAM checkpoint
- propagate simulator termination separately from task success
- add optional low-memory FastWAM checkpoint loading and model offload controls
- keep the existing contract-driven Web Viewer compatible with RoboDojo evaluation

## RoboDojo integration

The new RoboDojo ROS environment exposes:

- three RGB cameras: `head_camera`, `left_camera`, `right_camera`
- 14D dual-arm ARX-X5 state/action:
  - left arm: 6
  - left end-effector: 1
  - right arm: 6
  - right end-effector: 1
- task instructions from RoboDojo observations
- RoboDojo success and termination semantics

FastWAM uses an independent `robodojo` policy profile with the official three-camera preprocessing and z-score normalization expected by the RoboDojo FastWAM release.

## FastWAM runtime support

- add `configs/fastwam/robodojo_i2va.json`
- use the official RoboDojo FastWAM action horizon/replanning parameters
- add optional:
  - `t5_cpu_offload`
  - `vae_cpu_offload`
  - `checkpoint_mmap`

These options remain disabled by default and are not automatically enabled for RoboDojo.

## Validation

CPU-only checks:

- Python compilation for modified Python files
- `test_fastwam_checkpoint_mmap.py`: 3 tests passed
- `test_simulator_status_updates.py`: 3 tests passed
- RoboDojo FastWAM JSON validation
- `git diff --check`

Runtime validation on a single RTX 5090:

- RoboDojo / Isaac Lab simulator startup
- three-camera ROS observation publishing
- 14D state publishing
- LightX2V FastWAM inference using the official RoboDojo FastWAM checkpoint
- 14D action publication and execution in RoboDojo
- full episode termination and success/failure reporting
- Web Viewer camera/status/control integration
- successful full closed-loop rollout

A single-observation comparison against the official RoboDojo FastWAM runtime produced:

- mean absolute action error: `8.85e-4`
- max absolute action error: `6.96e-3`

This confirms close inference parity between the LightX2V integration and the official runtime.