### PR TITLE
fix(minimax-h3): materialize TP column shards

### DIFF
--- a/lightx2v/models/networks/minimax_h3/model.py
+++ b/lightx2v/models/networks/minimax_h3/model.py
@@ -344,7 +344,10 @@ class MiniMaxH3Model(BaseTransformerModel):
 
         if tensor.shape[0] % self.tp_size:
             raise ValueError(f"Cannot column-shard {key} shape {tuple(tensor.shape)} across TP size {self.tp_size}")
-        return torch.chunk(tensor, self.tp_size, dim=0)[self.tp_rank].contiguous()
+        # A dim-0 chunk is already contiguous, so ``.contiguous()`` would keep
+        # it as a view backed by the full checkpoint tensor. Materialize the
+        # local shard so CPU loading does not retain peer ranks' storage.
+        return torch.chunk(tensor, self.tp_size, dim=0)[self.tp_rank].clone(memory_format=torch.contiguous_format)
 
     def _should_load_weights(self):
         # Each TP rank reads its own slices.  This is also correct for TP+SP,

--- a/test_cases/test_minimax_h3_tp_shards.py
+++ b/test_cases/test_minimax_h3_tp_shards.py
@@ -1,0 +1,21 @@
+import torch
+
+from lightx2v.models.networks.minimax_h3.model import MiniMaxH3Model
+
+
+def test_column_tp_shard_owns_only_local_storage():
+    model = MiniMaxH3Model.__new__(MiniMaxH3Model)
+    model.config = {"tensor_parallel": True}
+    model.tp_rank = 2
+    model.tp_size = 4
+
+    source = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+    shard = model._select_tensor_parallel_shard(
+        "transformer_blocks.0.attn.to_q.weight",
+        source,
+    )
+
+    torch.testing.assert_close(shard, source[4:6])
+    assert shard.is_contiguous()
+    assert shard.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()
+    assert shard.untyped_storage().nbytes() == shard.numel() * shard.element_size()


### PR DESCRIPTION
## Summary

- materialize MiniMax-H3 dim-0 tensor-parallel shards with `clone`
- add a regression test for shard values, contiguity, storage ownership, and storage size

## Why

`torch.chunk(..., dim=0)` returns a contiguous view. Calling `.contiguous()` on that view does not allocate new storage, so a rank-local CPU shard can keep the complete checkpoint tensor backing storage alive.

The local shard now owns only its expected storage. This does not change shard values, shapes, dtypes, non-TP loading, or inference numerics.

## Upstream alignment

Rebased onto current upstream `main` at `f8aee98b5462cca8d7288888146ebd95592bf266` after MiniMax-H3 AdaLN caching landed in #1413. The shard fix remains independent and applies cleanly.

## Validation

- repository-pinned `pre-commit run --all-files`
- Ruff 0.11 lint and format checks
- Python bytecode compilation
- PyTorch 2.11 CPU storage regression check against `_select_tensor_parallel_shard`

## V100 TP4 integration validation

Validated PR head `16e3a5fce94ad14b66c12c463c0fc2f67d69959d` on four Tesla V100 PCIe 32 GB GPUs with a full MiniMax-H3 workload (864x480, 124 frames, 20 evaluations). The downstream V100 runtime uses the exact loader expression introduced by this PR:

```python
torch.chunk(tensor, self.tp_size, dim=0)[self.tp_rank].clone(
    memory_format=torch.contiguous_format
)
```

Results were consistent across all four ranks:

- source tensor storage: `40,225,668,128` bytes (`37.463 GiB`) per rank before local materialization
- retained tensors: `10,543,386,144` bytes (`9.819 GiB`) per rank, or `26.21%` of source storage; the excess over exactly 25% comes from intentionally replicated tensors
- CUDA allocated after load: `9.840 GiB` per rank
- TP4 NVML peak: `14,078 MiB` per GPU
- 20/20 model evaluations and 1000/1000 finite checks; latent finite; media decode passed
- TP4 process exit 0, `OOMKilled=false`; corrected and uncorrected volatile ECC remained 0

This confirms that each TP rank owns its local shard instead of retaining the complete 37.46 GiB source checkpoint storage.

Scope note: the end-to-end run used a downstream branch that also contains separate V100 compatibility work. This validates the identical shard-materialization path on V100; it does not claim that this PR alone provides all changes required for complete V100 inference.
