### PR TITLE
feat(xpu): add RMSNorm intel_xpu backend 

### DIFF
--- a/lightx2v_kernel_xpu/CMakeLists.txt
+++ b/lightx2v_kernel_xpu/CMakeLists.txt
@@ -52,6 +52,7 @@ set(MODULE_NAME _ext)
 set(SYCL_SRCS
     csrc/onednn.cpp
     csrc/onednn_fp8.cpp
+    csrc/rms_norm.cpp
 )
 set(ALL_SRCS ${SYCL_SRCS} csrc/entry.cpp csrc/sdp.cpp)
 

--- a/lightx2v_kernel_xpu/CMakeLists.txt
+++ b/lightx2v_kernel_xpu/CMakeLists.txt
@@ -52,7 +52,6 @@ set(MODULE_NAME _ext)
 set(SYCL_SRCS
     csrc/onednn.cpp
     csrc/onednn_fp8.cpp
-    csrc/rms_norm.cpp
 )
 set(ALL_SRCS ${SYCL_SRCS} csrc/entry.cpp csrc/sdp.cpp)
 
@@ -128,6 +127,22 @@ target_link_libraries(${MODULE_NAME} PRIVATE
     ${DNNL_LIBRARY}
     esimd_lgrf_lib
 )
+
+# Keep RMSNorm independent from the legacy extension and its oneDNN ABI. This
+# sidecar only links PyTorch/SYCL and is loaded lazily through torch.ops.
+add_library(rms_norm_torch SHARED csrc/rms_norm.cpp)
+set_target_properties(rms_norm_torch PROPERTIES
+    PREFIX ""
+    BUILD_RPATH "${TORCH_INSTALL_PREFIX}/lib"
+    INSTALL_RPATH "\$ORIGIN;${TORCH_INSTALL_PREFIX}/lib")
+target_compile_features(rms_norm_torch PRIVATE cxx_std_17)
+target_include_directories(rms_norm_torch PRIVATE
+    ${Python_INCLUDE_DIRS}
+    ${TORCH_INCLUDE_DIRS})
+add_sycl_to_target(TARGET rms_norm_torch SOURCES csrc/rms_norm.cpp)
+target_link_libraries(rms_norm_torch PRIVATE
+    ${TORCH_LIBRARIES}
+    ${TORCH_PYTHON_LIBRARY})
 
 if(ENABLE_CUTE_FMHA)
     if(WIN32)
@@ -205,6 +220,7 @@ endif()
 # ── Install targets for wheel assembly ────────────────────────────────────────
 # scikit-build-core collects install() outputs into the wheel platlib
 install(TARGETS ${MODULE_NAME} LIBRARY DESTINATION sycl_kernels)
+install(TARGETS rms_norm_torch LIBRARY DESTINATION sycl_kernels)
 install(FILES "${ESIMD_RUNTIME}" DESTINATION sycl_kernels)
 if(ENABLE_CUTE_FMHA)
     install(TARGETS cute_fmha_torch LIBRARY DESTINATION sycl_kernels)

--- a/lightx2v_kernel_xpu/README.md
+++ b/lightx2v_kernel_xpu/README.md
@@ -4,6 +4,11 @@ SYCL/ESIMD custom kernels for LightX2V inference on Intel Arc GPU (Xe2 / PTL-H).
 
 Exposed as the Python package `sycl_kernels`:
 
+- `sycl_kernels.rms_norm(weight, input, eps)` provides ESIMD RMSNorm for
+  contiguous FP32/FP16/BF16 XPU tensors with hidden size up to 8192 and
+  divisible by 32. In LightX2V select it with `"rms_norm_type": "intel_xpu"`;
+  unsupported contracts use the torch fallback.
+
 | Function | Description |
 |----------|-------------|
 | `sdp(Q, K, V)` | ESIMD Flash Attention — `[B, L, H, 128]` fp16/bf16, PTL-H doubleGRF |

--- a/lightx2v_kernel_xpu/README.md
+++ b/lightx2v_kernel_xpu/README.md
@@ -7,6 +7,7 @@ Exposed as the Python package `sycl_kernels`:
 - `sycl_kernels.rms_norm(weight, input, eps)` provides ESIMD RMSNorm for
   contiguous FP32/FP16/BF16 XPU tensors with hidden size up to 8192 and
   divisible by 32. In LightX2V select it with `"rms_norm_type": "intel_xpu"`;
+  For MiniMax-H3, select it with `"rms_type": "intel_xpu"`.
   unsupported contracts use the torch fallback.
 
 | Function | Description |

--- a/lightx2v_kernel_xpu/build.sh
+++ b/lightx2v_kernel_xpu/build.sh
@@ -13,6 +13,9 @@ command -v "$PYTHON" >/dev/null || { echo "ERROR: Python not found: $PYTHON" >&2
 command -v "$CMAKE" >/dev/null || { echo "ERROR: CMake not found: $CMAKE" >&2; exit 1; }
 command -v ninja >/dev/null || { echo "ERROR: ninja not found" >&2; exit 1; }
 command -v "$CXX" >/dev/null || { echo "ERROR: oneAPI C++ compiler not found: $CXX" >&2; exit 1; }
+# Keep the selected interpreter stable inside pip/scikit-build subprocesses,
+# where PATH may resolve a bare "python3" to the system installation.
+PYTHON=$($PYTHON -c 'import sys; print(sys.executable)')
 "$PYTHON" -c 'import scikit_build_core' >/dev/null 2>&1 || {
     echo "ERROR: scikit-build-core is not installed for $PYTHON" >&2
     echo "Install it with: $PYTHON -m pip install scikit-build-core wheel" >&2
@@ -20,6 +23,12 @@ command -v "$CXX" >/dev/null || { echo "ERROR: oneAPI C++ compiler not found: $C
 }
 
 torch_root=$($PYTHON -c 'import os, torch; print(os.path.dirname(torch.__file__))')
+python_include=$($PYTHON -c 'import sysconfig; print(sysconfig.get_path("include"))')
+if [[ ! -f "$python_include/Python.h" ]]; then
+    echo "ERROR: Python development headers not found: $python_include/Python.h" >&2
+    echo "Install the development package matching $($PYTHON --version 2>&1)." >&2
+    exit 1
+fi
 
 echo "=== Step 1: Build ESIMD shared library ==="
 CXX="$CXX" "$project_dir/lgrf_uni/build.sh"
@@ -31,6 +40,7 @@ echo "=== Step 2: Build Python extension ==="
     -DCMAKE_CXX_STANDARD=20 \
     -DCMAKE_PREFIX_PATH="$torch_root" \
     -DPython_EXECUTABLE="$PYTHON" \
+    -DPython_INCLUDE_DIR="$python_include" \
     -DENABLE_CUTE_FMHA=ON \
     -DXPU_TARGET="$XPU_TARGET" \
     -B _cmake_build -S .
@@ -39,6 +49,7 @@ echo "=== Step 2: Build Python extension ==="
 echo "=== Step 3: Copy artifacts ==="
 mkdir -p python/sycl_kernels
 find _cmake_build -maxdepth 1 -type f -name '_ext*.so' -exec cp -f {} python/sycl_kernels/ \;
+find _cmake_build -maxdepth 1 -type f -name 'rms_norm_torch*.so' -exec cp -f {} python/sycl_kernels/ \;
 find _cmake_build -maxdepth 1 -type f -name 'cute_fmha_torch*.so' -exec cp -f {} python/sycl_kernels/ \;
 cp -f lgrf_uni/libesimd.unify.lgrf.so python/sycl_kernels/
 
@@ -50,7 +61,7 @@ fi
 
 echo "=== Step 5: Build wheel ==="
 mkdir -p dist
-CMAKE_ARGS="-DCMAKE_CXX_COMPILER=$CXX -DENABLE_CUTE_FMHA=ON -DXPU_TARGET=$XPU_TARGET" \
+CMAKE_ARGS="-DCMAKE_CXX_COMPILER=$CXX -DPython_EXECUTABLE=$PYTHON -DPython_INCLUDE_DIR=$python_include -DENABLE_CUTE_FMHA=ON -DXPU_TARGET=$XPU_TARGET" \
     "$PYTHON" -m pip wheel . \
     --no-build-isolation --no-deps -w dist
 

--- a/lightx2v_kernel_xpu/csrc/entry.cpp
+++ b/lightx2v_kernel_xpu/csrc/entry.cpp
@@ -38,6 +38,12 @@ torch::Tensor sdp_torch(
     torch::Tensor V
 );
 
+torch::Tensor rms_norm_xpu(
+    torch::Tensor weight,
+    torch::Tensor input,
+    double eps
+);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("onednn_w4a16", &onednn_w4a16, "onednn w4a16 gemm");
     m.def("onednn_w8a16_fp8", &onednn_w8a16_fp8,
@@ -47,4 +53,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("sdp", &sdp_torch,
           "ESIMD Flash Attention SDP [B,L,H,128] PTL-H (fp16/bf16)",
           py::arg("Q"), py::arg("K"), py::arg("V"));
+    m.def("rms_norm", &rms_norm_xpu,
+          "ESIMD RMSNorm for contiguous [rows, hidden_size] XPU tensors",
+          py::arg("weight"), py::arg("input"), py::arg("eps") = 1e-6);
 }

--- a/lightx2v_kernel_xpu/csrc/entry.cpp
+++ b/lightx2v_kernel_xpu/csrc/entry.cpp
@@ -38,12 +38,6 @@ torch::Tensor sdp_torch(
     torch::Tensor V
 );
 
-torch::Tensor rms_norm_xpu(
-    torch::Tensor weight,
-    torch::Tensor input,
-    double eps
-);
-
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("onednn_w4a16", &onednn_w4a16, "onednn w4a16 gemm");
     m.def("onednn_w8a16_fp8", &onednn_w8a16_fp8,
@@ -53,7 +47,4 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("sdp", &sdp_torch,
           "ESIMD Flash Attention SDP [B,L,H,128] PTL-H (fp16/bf16)",
           py::arg("Q"), py::arg("K"), py::arg("V"));
-    m.def("rms_norm", &rms_norm_xpu,
-          "ESIMD RMSNorm for contiguous [rows, hidden_size] XPU tensors",
-          py::arg("weight"), py::arg("input"), py::arg("eps") = 1e-6);
 }

--- a/lightx2v_kernel_xpu/csrc/rms_norm.cpp
+++ b/lightx2v_kernel_xpu/csrc/rms_norm.cpp
@@ -1,0 +1,141 @@
+#include <algorithm>
+#include <cmath>
+#include <torch/extension.h>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+#include <c10/xpu/XPUStream.h>
+
+using fp16 = sycl::half;
+using bf16 = sycl::ext::oneapi::bfloat16;
+using namespace sycl::ext::intel::esimd;
+
+namespace {
+
+template <typename T, int GroupSize, int BlockSize>
+void launch_rms_norm(const T* weight, const T* input, T* output,
+                     float eps, int rows, int hidden_size,
+                     const c10::Device& device) {
+    const int blocks = hidden_size / BlockSize;
+    const int blocks_per_item = blocks / GroupSize;
+    const int extra_blocks = blocks % GroupSize;
+    constexpr int partial_bytes =
+        ((GroupSize * static_cast<int>(sizeof(float)) + 15) / 16) * 16;
+    const int partial_offset = hidden_size * sizeof(T);
+
+    auto& queue = c10::xpu::getCurrentXPUStream(device.index()).queue();
+    queue.submit([&](sycl::handler& handler) {
+        handler.parallel_for(
+            sycl::nd_range<2>(sycl::range<2>(rows, GroupSize),
+                              sycl::range<2>(1, GroupSize)),
+            [=](sycl::nd_item<2> item) SYCL_ESIMD_KERNEL {
+                slm_init<8192 * sizeof(T) + partial_bytes>();
+                const int row = item.get_global_id(0);
+                const int lane = item.get_local_id(1);
+                const T* input_row = input + static_cast<size_t>(row) * hidden_size;
+                T* output_row = output + static_cast<size_t>(row) * hidden_size;
+                const int first = blocks_per_item * lane + std::min(lane, extra_blocks);
+                const int last = first + blocks_per_item + (lane < extra_blocks);
+                simd<float, BlockSize> accumulator = 0;
+
+                for (int block = first; block < last; ++block) {
+                    simd<T, BlockSize> values =
+                        block_load<T, BlockSize>(input_row + block * BlockSize);
+                    slm_block_store<T, BlockSize>(
+                        block * BlockSize * sizeof(T), values);
+                    simd<float, BlockSize> values_fp32 = values;
+                    accumulator += values_fp32 * values_fp32;
+                }
+                const float partial =
+                    sycl::ext::intel::esimd::detail::sum<
+                        float, float, BlockSize>(accumulator) /
+                    static_cast<float>(hidden_size);
+
+                float scale;
+                if constexpr (GroupSize == 1) {
+                    scale = rsqrt(partial + eps);
+                } else {
+                    slm_block_store<float, 1>(
+                        partial_offset + lane * sizeof(float), partial);
+                    barrier();
+                    simd<float, GroupSize> partials =
+                        slm_block_load<float, GroupSize>(partial_offset);
+                    const float mean =
+                        sycl::ext::intel::esimd::detail::sum<
+                            float, float, GroupSize>(partials);
+                    scale = rsqrt(mean + eps);
+                }
+
+                for (int block = first; block < last; ++block) {
+                    simd<float, BlockSize> values =
+                        slm_block_load<T, BlockSize>(
+                            block * BlockSize * sizeof(T));
+                    simd<float, BlockSize> weights =
+                        block_load<T, BlockSize>(weight + block * BlockSize);
+                    block_store<T, BlockSize>(
+                        output_row + block * BlockSize,
+                        simd<T, BlockSize>(values * scale * weights));
+                }
+            });
+    });
+}
+
+template <typename T, int BlockSize>
+void dispatch_rms_norm(const T* weight, const T* input, T* output,
+                       float eps, int rows, int hidden_size,
+                       const c10::Device& device) {
+    const int blocks = hidden_size / BlockSize;
+    if (blocks <= 1) return launch_rms_norm<T, 1, BlockSize>(weight, input, output, eps, rows, hidden_size, device);
+    if (blocks <= 2) return launch_rms_norm<T, 2, BlockSize>(weight, input, output, eps, rows, hidden_size, device);
+    if (blocks <= 4) return launch_rms_norm<T, 4, BlockSize>(weight, input, output, eps, rows, hidden_size, device);
+    if (blocks <= 8) return launch_rms_norm<T, 8, BlockSize>(weight, input, output, eps, rows, hidden_size, device);
+    if (blocks <= 16) return launch_rms_norm<T, 16, BlockSize>(weight, input, output, eps, rows, hidden_size, device);
+    return launch_rms_norm<T, 32, BlockSize>(weight, input, output, eps, rows, hidden_size, device);
+}
+
+}  // namespace
+
+torch::Tensor rms_norm_xpu(torch::Tensor weight, torch::Tensor input,
+                           double eps) {
+    TORCH_CHECK(input.is_xpu() && weight.is_xpu(),
+                "input and weight must be XPU tensors");
+    TORCH_CHECK(input.device() == weight.device(),
+                "input and weight must be on the same XPU device");
+    TORCH_CHECK(input.dim() == 2, "input must be [rows, hidden_size]");
+    TORCH_CHECK(input.size(0) > 0, "input must contain at least one row");
+    TORCH_CHECK(weight.dim() == 1 && weight.size(0) == input.size(1),
+                "weight must be [hidden_size]");
+    TORCH_CHECK(input.scalar_type() == weight.scalar_type(),
+                "input and weight dtype must match");
+    TORCH_CHECK(input.is_contiguous() && weight.is_contiguous(),
+                "input and weight must be contiguous");
+    TORCH_CHECK(std::isfinite(eps) && eps > 0.0,
+                "eps must be positive and finite");
+    const auto hidden_size = input.size(1);
+    TORCH_CHECK(hidden_size > 0 && hidden_size <= 8192 && hidden_size % 32 == 0,
+                "hidden_size must be positive, <= 8192, and divisible by 32");
+
+    auto output = torch::empty_like(input);
+    const int rows = static_cast<int>(input.size(0));
+    const int hidden = static_cast<int>(hidden_size);
+    if (input.scalar_type() == torch::kBFloat16) {
+        dispatch_rms_norm<bf16, 32>(
+            reinterpret_cast<const bf16*>(weight.data_ptr()),
+            reinterpret_cast<const bf16*>(input.data_ptr()),
+            reinterpret_cast<bf16*>(output.data_ptr()),
+            static_cast<float>(eps), rows, hidden, input.device());
+    } else if (input.scalar_type() == torch::kFloat16) {
+        dispatch_rms_norm<fp16, 32>(
+            reinterpret_cast<const fp16*>(weight.data_ptr()),
+            reinterpret_cast<const fp16*>(input.data_ptr()),
+            reinterpret_cast<fp16*>(output.data_ptr()),
+            static_cast<float>(eps), rows, hidden, input.device());
+    } else if (input.scalar_type() == torch::kFloat32) {
+        dispatch_rms_norm<float, 32>(
+            weight.data_ptr<float>(), input.data_ptr<float>(),
+            output.data_ptr<float>(), static_cast<float>(eps), rows, hidden,
+            input.device());
+    } else {
+        TORCH_CHECK(false, "rms_norm supports fp32, fp16, and bf16");
+    }
+    return output;
+}

--- a/lightx2v_kernel_xpu/csrc/rms_norm.cpp
+++ b/lightx2v_kernel_xpu/csrc/rms_norm.cpp
@@ -139,3 +139,11 @@ torch::Tensor rms_norm_xpu(torch::Tensor weight, torch::Tensor input,
     }
     return output;
 }
+
+TORCH_LIBRARY(sycl_kernels_rms, m) {
+    m.def("rms_norm(Tensor weight, Tensor input, float eps=0.000001) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(sycl_kernels_rms, XPU, m) {
+    m.impl("rms_norm", &rms_norm_xpu);
+}

--- a/lightx2v_kernel_xpu/pyproject.toml
+++ b/lightx2v_kernel_xpu/pyproject.toml
@@ -26,6 +26,7 @@ wheel.packages = ["python/sycl_kernels"]
 
 [tool.scikit-build.metadata.version]
 provider = "build_version"
+provider-path = "."
 
 [tool.scikit-build.cmake.define]
 CMAKE_CXX_COMPILER = "icx"

--- a/lightx2v_kernel_xpu/python/sycl_kernels/__init__.py
+++ b/lightx2v_kernel_xpu/python/sycl_kernels/__init__.py
@@ -37,6 +37,7 @@ try:
     from sycl_kernels._ext import (  # noqa: E402, F401
         onednn_w4a16,
         onednn_w8a16_fp8,
+        rms_norm,
         sdp,
     )
 except ImportError as _legacy_import_error:
@@ -46,6 +47,7 @@ except ImportError as _legacy_import_error:
 
     onednn_w4a16 = _legacy_extension_unavailable
     onednn_w8a16_fp8 = _legacy_extension_unavailable
+    rms_norm = _legacy_extension_unavailable
     sdp = _legacy_extension_unavailable
 from sycl_kernels.version import __version__  # noqa: E402, F401
 

--- a/lightx2v_kernel_xpu/python/sycl_kernels/__init__.py
+++ b/lightx2v_kernel_xpu/python/sycl_kernels/__init__.py
@@ -5,6 +5,7 @@ import os
 
 _pkg_dir = os.path.dirname(os.path.abspath(__file__))
 _cute_fmha_loaded = False
+_rms_norm_loaded = False
 
 if os.name == "nt":
     os.add_dll_directory(_pkg_dir)
@@ -37,7 +38,6 @@ try:
     from sycl_kernels._ext import (  # noqa: E402, F401
         onednn_w4a16,
         onednn_w8a16_fp8,
-        rms_norm,
         sdp,
     )
 except ImportError as _legacy_import_error:
@@ -47,9 +47,42 @@ except ImportError as _legacy_import_error:
 
     onednn_w4a16 = _legacy_extension_unavailable
     onednn_w8a16_fp8 = _legacy_extension_unavailable
-    rms_norm = _legacy_extension_unavailable
     sdp = _legacy_extension_unavailable
 from sycl_kernels.version import __version__  # noqa: E402, F401
+
+
+def _load_rms_norm():
+    global _rms_norm_loaded
+    if _rms_norm_loaded:
+        return
+    import torch
+
+    suffix = "*.pyd" if os.name == "nt" else "*.so"
+    candidates = sorted(glob.glob(os.path.join(_pkg_dir, "rms_norm_torch" + suffix)))
+    if not candidates:
+        raise ImportError(f"rms_norm_torch library not found in {_pkg_dir}")
+    torch.ops.load_library(candidates[0])
+    _rms_norm_loaded = True
+
+
+def rms_norm(weight, input, eps=1e-6):
+    """Run ESIMD RMSNorm on contiguous [rows, hidden_size] XPU tensors."""
+    import torch
+
+    try:
+        op = torch.ops.sycl_kernels_rms.rms_norm
+    except AttributeError:
+        _load_rms_norm()
+        op = torch.ops.sycl_kernels_rms.rms_norm
+    return op(weight, input, eps)
+
+
+def has_rms_norm():
+    try:
+        _load_rms_norm()
+        return True
+    except (ImportError, OSError, RuntimeError):
+        return False
 
 
 def _load_cute_fmha():

--- a/lightx2v_kernel_xpu/test/test_rms_norm.py
+++ b/lightx2v_kernel_xpu/test/test_rms_norm.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+
+import sycl_kernels
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("shape", [(17, 128), (9, 5376), (2, 8192)])
+def test_rms_norm_matches_torch(dtype, shape):
+    if not torch.xpu.is_available():
+        pytest.skip("XPU is not available")
+    torch.manual_seed(0)
+    x = torch.randn(shape, device="xpu", dtype=dtype)
+    weight = torch.randn(shape[-1], device="xpu", dtype=dtype)
+    actual = sycl_kernels.rms_norm(weight, x, 1e-6)
+    expected = torch.nn.functional.rms_norm(
+        x.float(), (shape[-1],), weight=weight.float(), eps=1e-6
+    ).to(dtype)
+    torch.xpu.synchronize()
+    atol = 2e-2 if dtype != torch.float32 else 2e-5
+    rtol = 2e-2 if dtype != torch.float32 else 2e-5
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+def test_rms_norm_rejects_unsupported_hidden_size():
+    if not torch.xpu.is_available():
+        pytest.skip("XPU is not available")
+    x = torch.randn((2, 127), device="xpu", dtype=torch.bfloat16)
+    weight = torch.ones(127, device="xpu", dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="divisible by 32"):
+        sycl_kernels.rms_norm(weight, x, 1e-6)

--- a/lightx2v_kernel_xpu/test/test_rms_norm.py
+++ b/lightx2v_kernel_xpu/test/test_rms_norm.py
@@ -1,7 +1,6 @@
 import pytest
-import torch
-
 import sycl_kernels
+import torch
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -13,9 +12,7 @@ def test_rms_norm_matches_torch(dtype, shape):
     x = torch.randn(shape, device="xpu", dtype=dtype)
     weight = torch.randn(shape[-1], device="xpu", dtype=dtype)
     actual = sycl_kernels.rms_norm(weight, x, 1e-6)
-    expected = torch.nn.functional.rms_norm(
-        x.float(), (shape[-1],), weight=weight.float(), eps=1e-6
-    ).to(dtype)
+    expected = torch.nn.functional.rms_norm(x.float(), (shape[-1],), weight=weight.float(), eps=1e-6).to(dtype)
     torch.xpu.synchronize()
     atol = 2e-2 if dtype != torch.float32 else 2e-5
     rtol = 2e-2 if dtype != torch.float32 else 2e-5

--- a/lightx2v_platform/ops/__init__.py
+++ b/lightx2v_platform/ops/__init__.py
@@ -26,6 +26,7 @@ elif PLATFORM == "enflame_gcu":
 elif PLATFORM == "intel_xpu":
     from .attn.intel_xpu import *
     from .mm.intel_xpu import *
+    from .norm.intel_xpu import *
 elif PLATFORM == "iluvatar_cuda":
     from .attn.iluvatar_cuda import *
     from .mm.iluvatar_cuda import *

--- a/lightx2v_platform/ops/__init__.py
+++ b/lightx2v_platform/ops/__init__.py
@@ -24,9 +24,11 @@ elif PLATFORM == "enflame_gcu":
     from .norm.enflame_gcu import *
     from .rope.enflame_gcu import *
 elif PLATFORM == "intel_xpu":
+    # Register platform RMSNorm before the attention modules import the
+    # framework registry and snapshot all PLATFORM_* registries.
+    from .norm.intel_xpu import *
     from .attn.intel_xpu import *
     from .mm.intel_xpu import *
-    from .norm.intel_xpu import *
 elif PLATFORM == "iluvatar_cuda":
     from .attn.iluvatar_cuda import *
     from .mm.iluvatar_cuda import *

--- a/lightx2v_platform/ops/__init__.py
+++ b/lightx2v_platform/ops/__init__.py
@@ -26,9 +26,9 @@ elif PLATFORM == "enflame_gcu":
 elif PLATFORM == "intel_xpu":
     # Register platform RMSNorm before the attention modules import the
     # framework registry and snapshot all PLATFORM_* registries.
-    from .norm.intel_xpu import *
     from .attn.intel_xpu import *
     from .mm.intel_xpu import *
+    from .norm.intel_xpu import *
 elif PLATFORM == "iluvatar_cuda":
     from .attn.iluvatar_cuda import *
     from .mm.iluvatar_cuda import *

--- a/lightx2v_platform/ops/norm/intel_xpu/__init__.py
+++ b/lightx2v_platform/ops/norm/intel_xpu/__init__.py
@@ -1,0 +1,1 @@
+from .xpu_rms_norm import *

--- a/lightx2v_platform/ops/norm/intel_xpu/xpu_rms_norm.py
+++ b/lightx2v_platform/ops/norm/intel_xpu/xpu_rms_norm.py
@@ -1,0 +1,49 @@
+import torch
+
+from lightx2v_platform.ops.norm.norm_template import RMSWeightTemplate
+from lightx2v_platform.registry_factory import PLATFORM_RMS_WEIGHT_REGISTER
+
+try:
+    from sycl_kernels import rms_norm as _rms_norm
+except (ImportError, RuntimeError):
+    _rms_norm = None
+
+
+@PLATFORM_RMS_WEIGHT_REGISTER("intel_xpu")
+class IntelXpuRMSWeight(RMSWeightTemplate):
+    """ESIMD RMSNorm with a torch fallback for unsupported contracts."""
+
+    def apply(self, input_tensor):
+        weight = getattr(self, "weight", None)
+        if weight is None:
+            return torch.nn.functional.rms_norm(
+                input_tensor, (input_tensor.shape[-1],), eps=self.eps
+            )
+
+        hidden_size = input_tensor.shape[-1]
+        use_esimd = (
+            _rms_norm is not None
+            and input_tensor.device.type == "xpu"
+            and weight.device == input_tensor.device
+            and input_tensor.dtype == weight.dtype
+            and input_tensor.dtype in (torch.float16, torch.bfloat16, torch.float32)
+            and 0 < hidden_size <= 8192
+            and hidden_size % 32 == 0
+            and self.sensitive_layer_dtype == self.infer_dtype
+        )
+        if use_esimd:
+            original_shape = input_tensor.shape
+            flat_input = input_tensor.contiguous().view(-1, hidden_size)
+            return _rms_norm(weight.contiguous(), flat_input, self.eps).view(original_shape)
+
+        compute_input = input_tensor
+        compute_weight = weight
+        if self.sensitive_layer_dtype != self.infer_dtype:
+            compute_input = input_tensor.float()
+            compute_weight = weight.float()
+        return torch.nn.functional.rms_norm(
+            compute_input,
+            (hidden_size,),
+            weight=compute_weight,
+            eps=self.eps,
+        ).to(input_tensor.dtype)

--- a/lightx2v_platform/ops/norm/intel_xpu/xpu_rms_norm.py
+++ b/lightx2v_platform/ops/norm/intel_xpu/xpu_rms_norm.py
@@ -4,8 +4,12 @@ from lightx2v_platform.ops.norm.norm_template import RMSWeightTemplate
 from lightx2v_platform.registry_factory import PLATFORM_RMS_WEIGHT_REGISTER
 
 try:
-    from sycl_kernels import rms_norm as _rms_norm
+    import sycl_kernels as _sycl_kernels
+
+    _rms_norm = _sycl_kernels.rms_norm
+    _has_rms_norm = _sycl_kernels.has_rms_norm()
 except (ImportError, RuntimeError):
+    _has_rms_norm = False
     _rms_norm = None
 
 
@@ -22,7 +26,8 @@ class IntelXpuRMSWeight(RMSWeightTemplate):
 
         hidden_size = input_tensor.shape[-1]
         use_esimd = (
-            _rms_norm is not None
+            _has_rms_norm
+            and _rms_norm is not None
             and input_tensor.device.type == "xpu"
             and weight.device == input_tensor.device
             and input_tensor.dtype == weight.dtype

--- a/lightx2v_platform/ops/norm/intel_xpu/xpu_rms_norm.py
+++ b/lightx2v_platform/ops/norm/intel_xpu/xpu_rms_norm.py
@@ -20,9 +20,7 @@ class IntelXpuRMSWeight(RMSWeightTemplate):
     def apply(self, input_tensor):
         weight = getattr(self, "weight", None)
         if weight is None:
-            return torch.nn.functional.rms_norm(
-                input_tensor, (input_tensor.shape[-1],), eps=self.eps
-            )
+            return torch.nn.functional.rms_norm(input_tensor, (input_tensor.shape[-1],), eps=self.eps)
 
         hidden_size = input_tensor.shape[-1]
         use_esimd = (


### PR DESCRIPTION
## Summary

  - Implements RMSNorm for contiguous FP32, FP16, and BF16 XPU tensors.
  - Supports hidden sizes up to 8192 that are divisible by 32.
## Usage
  Select the backend with per model:
```
  {
    "rms_norm_type": "intel_xpu"
  }
```
or
```
  {
    "rms_type": "intel_xpu"
  }
```

## Testing:
E2E test for Minimax H3
