### PR TITLE
perf(minimax_h3): cache AdaLN outputs across requests

### DIFF
--- a/lightx2v/models/networks/minimax_h3/infer/offload/transformer_infer.py
+++ b/lightx2v/models/networks/minimax_h3/infer/offload/transformer_infer.py
@@ -26,8 +26,25 @@ class MiniMaxH3OffloadTransformerInfer(MiniMaxH3TransformerInfer):
         # model offload
         return super().get_compile_block_key(block_idx, block)
 
+    def _prefetch_weights_without_adaln(self, block_index, blocks):
+        with torch_device_module.stream(self.offload_manager.cuda_load_stream):
+            if hasattr(self.offload_manager, "cpu_buffers"):
+                source_block = self.offload_manager.cpu_buffers[0]
+            else:
+                source_block = blocks[block_index]
+            block_state_dict = source_block.state_dict()
+            weights_without_adaln = {}
+            for name, tensor in block_state_dict.items():
+                if ".adaln_proj." not in name:
+                    weights_without_adaln[name] = tensor
+            self.offload_manager.cuda_buffers[1].load_state_dict(weights_without_adaln, block_index)
+
     def infer_with_blocks_offload(self, blocks, hidden_states, pre_infer_out):
         num_blocks = len(blocks)
+        if self.use_adaln_cache and not self._adaln_cache_hit:
+            # The previous forward may have prefetched block 0 without AdaLN.
+            # Reload the full block when the current timestep misses.
+            self.offload_manager.need_init_first_buffer = True
         current_stream = torch_device_module.current_stream()
         self.offload_manager.compute_stream.wait_stream(current_stream)
 
@@ -35,11 +52,19 @@ class MiniMaxH3OffloadTransformerInfer(MiniMaxH3TransformerInfer):
             if self.offload_manager.need_init_first_buffer:
                 self.offload_manager.init_first_buffer(blocks)
 
-            self.offload_manager.prefetch_weights((block_index + 1) % num_blocks, blocks)
+            next_block_index = (block_index + 1) % num_blocks
+            if self.use_adaln_cache and self._adaln_cache_hit:
+                self._prefetch_weights_without_adaln(next_block_index, blocks)
+            else:
+                self.offload_manager.prefetch_weights(next_block_index, blocks)
             block = self.offload_manager.cuda_buffers[0]
             self.block_idx = block_index
             with torch_device_module.stream(self.offload_manager.compute_stream):
-                hidden_states = self.run_block(block_index, block, hidden_states, pre_infer_out)
+                if self.use_adaln_cache:
+                    adaln_table = self._get_or_build_adaln(block_index, block, pre_infer_out)
+                    hidden_states = self.run_block(block_index, block, hidden_states, pre_infer_out, adaln_table)
+                else:
+                    hidden_states = self.run_block(block_index, block, hidden_states, pre_infer_out)
             self.offload_manager.swap_blocks()
 
         return hidden_states

--- a/lightx2v/models/networks/minimax_h3/infer/transformer_infer.py
+++ b/lightx2v/models/networks/minimax_h3/infer/transformer_infer.py
@@ -35,6 +35,10 @@ class MiniMaxH3TransformerInfer(BaseTransformerInfer):
         else:
             self.seq_p_group = None
         self.infer_func = self.infer_without_offload
+        self.use_adaln_cache = bool(config.get("use_adaln_cache", False))
+        self._adaln_cache = {}
+        self._current_adaln_tables = None
+        self._adaln_cache_hit = False
         self.init_compile(config)
 
     def _gather_tp_last_dim(self, tensor):
@@ -103,12 +107,10 @@ class MiniMaxH3TransformerInfer(BaseTransformerInfer):
         value, gate = weights.in_proj.apply(hidden_states).chunk(2, dim=-1)
         return weights.out_proj.apply(value * F.silu(gate))
 
-    def infer_block(self, weights, hidden_states, pre_infer_out):
-        # Activation is evaluated in fp32, then cast to the inference dtype
-        # immediately before the (possibly quantized) AdaLN projection.
-        modulation = weights.adaln.apply(F.silu(pre_infer_out.temb).to(self.infer_dtype))
-        modulation = self._gather_tp_last_dim(modulation)
-        modulation = modulation.view(-1, 6 * self.hidden_size)
+    def infer_block(self, weights, hidden_states, pre_infer_out, modulation=None):
+        # Keep the Python cache lookup outside the compiled block.
+        if modulation is None:
+            modulation = self._compute_adaln_table(weights, pre_infer_out)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = modulation.chunk(6, dim=-1)
         indices = pre_infer_out.adaln_indices
 
@@ -125,11 +127,47 @@ class MiniMaxH3TransformerInfer(BaseTransformerInfer):
         hidden_states = residual + gate_mlp.index_select(0, indices) * self._ff(weights.ff, normed)
         return hidden_states
 
+    def _compute_adaln_table(self, weights, pre_infer_out):
+        # Activation is evaluated in fp32, then cast to the inference dtype
+        # immediately before the (possibly quantized) AdaLN projection.
+        modulation = weights.adaln.apply(F.silu(pre_infer_out.temb).to(self.infer_dtype))
+        modulation = self._gather_tp_last_dim(modulation)
+        return modulation.view(-1, 6 * self.hidden_size)
+
+    def _clear_adaln_cache(self):
+        self._adaln_cache.clear()
+        self._current_adaln_tables = None
+        self._adaln_cache_hit = False
+
+    def _prepare_adaln_cache(self):
+        current_timesteps = tuple(self.scheduler.unique_timesteps_cpu.tolist())
+        cached_tables = self._adaln_cache.get(current_timesteps)
+        if cached_tables is not None:
+            self._current_adaln_tables = cached_tables
+            self._adaln_cache_hit = True
+        else:
+            self._current_adaln_tables = []
+            self._adaln_cache[current_timesteps] = self._current_adaln_tables
+            self._adaln_cache_hit = False
+
+    def _get_or_build_adaln(self, block_index, weights, pre_infer_out):
+        if self._adaln_cache_hit:
+            return self._current_adaln_tables[block_index]
+        adaln_table = self._compute_adaln_table(weights, pre_infer_out)
+        self._current_adaln_tables.append(adaln_table)
+        return adaln_table
+
     def infer_without_offload(self, blocks, hidden_states, pre_infer_out):
         for block_index, block in enumerate(blocks):
             self.block_idx = block_index
-            hidden_states = self.run_block(block_index, block, hidden_states, pre_infer_out)
+            if self.use_adaln_cache:
+                adaln_table = self._get_or_build_adaln(block_index, block, pre_infer_out)
+                hidden_states = self.run_block(block_index, block, hidden_states, pre_infer_out, adaln_table)
+            else:
+                hidden_states = self.run_block(block_index, block, hidden_states, pre_infer_out)
         return hidden_states
 
     def infer(self, block_weights, pre_infer_out):
+        if self.use_adaln_cache:
+            self._prepare_adaln_cache()
         return self.infer_func(block_weights.blocks, pre_infer_out.hidden_states, pre_infer_out)

--- a/lightx2v/models/networks/minimax_h3/model.py
+++ b/lightx2v/models/networks/minimax_h3/model.py
@@ -265,6 +265,12 @@ class MiniMaxH3Model(BaseTransformerModel):
         if offload_manager is not None:
             offload_manager.need_init_first_buffer = True
 
+    def _remove_lora(self):
+        super()._remove_lora()
+        transformer_infer = getattr(self, "transformer_infer", None)
+        if transformer_infer is not None:
+            transformer_infer._clear_adaln_cache()
+
     def _update_lora(self, lora_path, strength, alpha=None):
         if isinstance(lora_path, dict):
             raise NotImplementedError("MiniMax-H3 dynamic LoRA switching expects one checkpoint path, not a merged tensor dictionary")

--- a/lightx2v/models/schedulers/minimax_h3/scheduler.py
+++ b/lightx2v/models/schedulers/minimax_h3/scheduler.py
@@ -146,6 +146,7 @@ class MiniMaxH3Scheduler(BaseScheduler):
         video_timestep = float(self.video_timesteps[self.step_index])
         audio_timestep = float(self.audio_timesteps[self.step_index])
         unique, inverse = build_row_timesteps(self.layout_cpu, video_timestep, audio_timestep)
+        self.unique_timesteps_cpu = unique
         self.unique_timesteps = unique.to(AI_DEVICE)
         self.timestep_indices = inverse.to(AI_DEVICE)
 
@@ -193,6 +194,7 @@ class MiniMaxH3Scheduler(BaseScheduler):
             "audio_noise_pred",
             "layout",
             "layout_cpu",
+            "unique_timesteps_cpu",
             "unique_timesteps",
             "timestep_indices",
         ):


### PR DESCRIPTION
Caches MiniMax-H3 AdaLN outputs by timestep and reuses them across requests. Cache hits skip repeated AdaLN projection, TP communication, and block-offload weight transfers. Cached outputs automatically refresh after dynamic LoRA updates to preserve correctness.