### PR TITLE
Replace deprecated v2.ToTensor() with v2.ToImage() + v2.ToDtype(scale=True)

### DIFF
--- a/lightx2v/models/runners/wan/wan_matrix_game2_runner.py
+++ b/lightx2v/models/runners/wan/wan_matrix_game2_runner.py
@@ -157,7 +157,8 @@ class WanSFMtxg2Runner(WanSFRunner):
         self.frame_process = v2.Compose(
             [
                 v2.Resize(size=(352, 640), antialias=True),
-                v2.ToTensor(),
+                v2.ToImage(),
+                v2.ToDtype(torch.float32, scale=True),
                 v2.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
             ]
         )


### PR DESCRIPTION
## PR 正文

Fix #1418

## Summary

Replaces the deprecated `v2.ToTensor()` in `lightx2v/models/runners/wan/wan_matrix_game2_runner.py` with the officially recommended `v2.ToImage()` + `v2.ToDtype(torch.float32, scale=True)`.

`v2.ToTensor()` has emitted a `UserWarning` on construction since torchvision 0.15 (first release of the v2 namespace); the warning text explicitly recommends this exact replacement:

> The transform `ToTensor()` is deprecated and will be removed in a future release. Instead, please use `v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])`. Output is equivalent up to float precision.

## Changes

- `lightx2v/models/runners/wan/wan_matrix_game2_runner.py`: `v2.ToTensor()` → `v2.ToImage()` + `v2.ToDtype(torch.float32, scale=True)` inside the existing `v2.Compose`.

## Validation

Verified with torchvision 0.26.0 (CPU): the replacement pipeline constructs cleanly under `-W error::UserWarning`, and its output is identical to the old pipeline up to float precision (max abs diff ≈ 1e-7, single last-bit rounding on uint8→float32 scaling).