### PR TITLE
reuse: support cross-worker and prefix-segment reuse

### DIFF
--- a/configs/infinitetalk/infinitetalk_480p_multi_reuse.json
+++ b/configs/infinitetalk/infinitetalk_480p_multi_reuse.json
@@ -32,5 +32,6 @@
     "norm_output_audio": true,
     "mxfp8_fuse_enable": false,
     "use_timestep_transform": true,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/infinitetalk_480p_multi_reuse"
 }

--- a/configs/qwen_image/qwen_image_i2i_2511_reuse.json
+++ b/configs/qwen_image/qwen_image_i2i_2511_reuse.json
@@ -10,5 +10,6 @@
     "CONDITION_IMAGE_SIZE": 147456,
     "USE_IMAGE_ID_IN_PROMPT": true,
     "use_compile": true,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/qwen_image_i2i_2511"
 }

--- a/configs/qwen_image/qwen_image_t2i_2512_reuse.json
+++ b/configs/qwen_image/qwen_image_t2i_2512_reuse.json
@@ -8,5 +8,6 @@
     "enable_cfg": true,
     "sample_guide_scale": 4.0,
     "use_compile": true,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/qwen_image_t2i_2512"
 }

--- a/configs/wan/wan_i2v_reuse.json
+++ b/configs/wan/wan_i2v_reuse.json
@@ -10,5 +10,6 @@
     "sample_shift": 3,
     "enable_cfg": true,
     "cpu_offload": false,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/wan_i2v"
 }

--- a/configs/wan/wan_t2v_reuse.json
+++ b/configs/wan/wan_t2v_reuse.json
@@ -11,5 +11,6 @@
     "sample_shift": 8,
     "enable_cfg": true,
     "cpu_offload": false,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/wan_t2v"
 }

--- a/configs/wan22/wan_moe_i2v_reuse.json
+++ b/configs/wan22/wan_moe_i2v_reuse.json
@@ -17,5 +17,6 @@
     "offload_granularity": "model",
     "boundary": 0.900,
     "use_image_encoder": false,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/wan22_moe_i2v"
 }

--- a/configs/wan22/wan_moe_t2v_reuse.json
+++ b/configs/wan22/wan_moe_t2v_reuse.json
@@ -18,5 +18,6 @@
     "t5_cpu_offload": false,
     "vae_cpu_offload": false,
     "boundary": 0.875,
-    "enable_reuse": true
+    "enable_reuse": true,
+    "reuse_cache_path": "save_results/reuse_cache/wan22_moe_t2v"
 }

--- a/lightx2v/models/runners/base_runner.py
+++ b/lightx2v/models/runners/base_runner.py
@@ -22,7 +22,7 @@ class BaseRunner(ABC):
         self.input_info = None
         self.enable_reuse = config.get("enable_reuse", False)
         self.reuse = False
-        self._reuse_cache = None
+        self.reuse_prefix_segments = 0
         self._gc_frozen = False  # one-shot guard for _maybe_freeze_gc()
         self._init_modules_depth = 0
         self._warmup_done = False
@@ -68,24 +68,25 @@ class BaseRunner(ABC):
         if self.config.get("warmup", False):
             raise NotImplementedError(f"Warmup is not supported for {type(self).__name__}")
 
-    def set_reuse(self, reuse):
+    def set_reuse(self, reuse, reuse_prefix_segments=0):
         if reuse and not self.enable_reuse:
             raise ValueError(f"This {type(self).__name__} service does not enable reuse")
         if reuse and self.config.get("disagg_mode"):
             raise NotImplementedError(f"{type(self).__name__} reuse does not support disaggregated inference")
+        if reuse_prefix_segments and not reuse:
+            raise ValueError("reuse_prefix_segments requires reuse=true")
+        if reuse:
+            self.check_reuse_support()
+        if reuse_prefix_segments:
+            self.check_segment_reuse_support()
         self.reuse = reuse
+        self.reuse_prefix_segments = reuse_prefix_segments
 
-    def _reuse_key(self):
-        raise NotImplementedError
+    def check_reuse_support(self):
+        raise NotImplementedError(f"{type(self).__name__} does not support reuse")
 
-    def _get_reused_inputs(self):
-        reuse_cache = self._reuse_cache
-        if reuse_cache is None:
-            raise RuntimeError("No previous successful request is available for reuse")
-        if self._reuse_key() != reuse_cache["reuse_key"]:
-            raise ValueError("Reuse inputs must match the previous successful request")
-        logger.info("[Reuse] Reusing the previous request's input encoder output")
-        return reuse_cache["inputs"]
+    def check_segment_reuse_support(self):
+        raise NotImplementedError(f"{type(self).__name__} does not support segment reuse")
 
     def _maybe_freeze_gc(self):
         """Move the steady-state object graph into the GC's permanent generation once."""

--- a/lightx2v/models/runners/default_runner.py
+++ b/lightx2v/models/runners/default_runner.py
@@ -1,5 +1,7 @@
 import gc
+import json
 import os
+import shutil
 
 import numpy as np
 import requests
@@ -16,7 +18,7 @@ from lightx2v.utils.envs import *
 from lightx2v.utils.generate_task_id import generate_task_id
 from lightx2v.utils.global_paras import CALIB
 from lightx2v.utils.profiler import *
-from lightx2v.utils.utils import fixed_shape_resize, get_optimal_patched_size_with_sp, isotropic_crop_resize, mux_audio_from_video, save_to_image, save_to_video, wan_vae_to_comfy
+from lightx2v.utils.utils import fixed_shape_resize, get_optimal_patched_size_with_sp, is_main_process, isotropic_crop_resize, mux_audio_from_video, save_to_image, save_to_video, wan_vae_to_comfy
 from lightx2v_platform.base.global_var import AI_DEVICE
 
 torch_device_module = getattr(torch, AI_DEVICE)
@@ -88,6 +90,14 @@ class DefaultRunner(BaseRunner):
         super().__init__(config)
         self.has_prompt_enhancer = False
         self.progress_callback = None
+        self.reuse_cache_path = self.config.get("reuse_cache_path")
+        if self.enable_reuse and not self.reuse_cache_path:
+            raise ValueError("enable_reuse requires reuse_cache_path")
+        self.reuse_cache_dir = None
+        self.reuse_cache_stage_dir = None
+        self.final_result_path = None
+        self.previous_result_path = None
+        self.work_result_path = None
         if self.config["task"] == "t2v" and self.config.get("sub_servers", {}).get("prompt_enhancer") is not None:
             self.has_prompt_enhancer = True
             if not self.check_sub_servers("prompt_enhancer"):
@@ -97,6 +107,116 @@ class DefaultRunner(BaseRunner):
             self.config["use_prompt_enhancer"] = False
         self.set_init_device()
         self.init_scheduler()
+
+    def reuse_key(self):
+        raise NotImplementedError
+
+    def reuse_inputs_path(self, cache_dir):
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        return os.path.join(cache_dir, f"inputs_rank_{rank:05d}.pt")
+
+    def reuse_input_info(self):
+        return {}
+
+    def load_reuse_state(self, map_location=AI_DEVICE):
+        manifest_path = os.path.join(self.reuse_cache_dir, "manifest.json")
+        if not os.path.isfile(manifest_path):
+            raise RuntimeError(f"No previous successful {type(self).__name__} request is available for reuse")
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = json.load(f)
+        if manifest["reuse_key"] != self.reuse_key():
+            raise ValueError("Reuse inputs must match the previous successful request")
+        self.previous_result_path = manifest["result_path"]
+        return torch.load(self.reuse_inputs_path(self.reuse_cache_dir), map_location=map_location, weights_only=True)
+
+    def load_reused_inputs(self):
+        cached = self.load_reuse_state()
+        for name, value in cached["input_info"].items():
+            setattr(self.input_info, name, value)
+        logger.info("[Reuse] Loaded the previous request's input encoder output from disk")
+        return cached["inputs"]
+
+    def save_reuse_inputs(self):
+        torch.save(
+            {"inputs": self.inputs, "input_info": self.reuse_input_info()},
+            self.reuse_inputs_path(self.reuse_cache_stage_dir),
+        )
+
+    def prepare_reuse_output(self):
+        self.reuse_cache_dir = None
+        self.reuse_cache_stage_dir = None
+        self.final_result_path = None
+        self.previous_result_path = None
+        self.work_result_path = None
+
+        output_path = self.input_info.save_result_path
+        local_output = bool(output_path) and not output_path.startswith(("http://", "https://", "rtmp://"))
+        reuse_cache_enabled = self.enable_reuse and local_output and not self.input_info.return_result_tensor
+        if self.reuse and not reuse_cache_enabled:
+            raise ValueError(f"{type(self).__name__} reuse requires a local output and return_result_tensor=false")
+        if not reuse_cache_enabled:
+            return
+
+        self.final_result_path = os.path.abspath(os.path.expanduser(output_path))
+        self.reuse_cache_dir = os.path.abspath(os.path.expanduser(self.reuse_cache_path))
+        self.reuse_cache_stage_dir = f"{self.reuse_cache_dir}.tmp"
+
+    def stage_reuse_cache(self):
+        if self.reuse_cache_dir is None:
+            return
+
+        if is_main_process():
+            shutil.rmtree(self.reuse_cache_stage_dir, ignore_errors=True)
+            os.makedirs(self.reuse_cache_stage_dir)
+        if dist.is_initialized():
+            dist.barrier()
+
+        if self.reuse:
+            shutil.copy2(
+                self.reuse_inputs_path(self.reuse_cache_dir),
+                self.reuse_inputs_path(self.reuse_cache_stage_dir),
+            )
+        else:
+            self.save_reuse_inputs()
+
+        if dist.is_initialized():
+            dist.barrier()
+        if is_main_process():
+            with open(os.path.join(self.reuse_cache_stage_dir, "manifest.json"), "w", encoding="utf-8") as f:
+                json.dump(
+                    {"reuse_key": self.reuse_key(), "result_path": self.final_result_path},
+                    f,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+
+    def commit_reuse_result(self):
+        if self.reuse_cache_dir is None or not is_main_process():
+            return
+
+        cache_backup_dir = f"{self.reuse_cache_dir}.old"
+        shutil.rmtree(cache_backup_dir, ignore_errors=True)
+        cache_backed_up = os.path.isdir(self.reuse_cache_dir)
+        if cache_backed_up:
+            os.replace(self.reuse_cache_dir, cache_backup_dir)
+        try:
+            os.replace(self.reuse_cache_stage_dir, self.reuse_cache_dir)
+            if self.work_result_path is not None:
+                os.replace(self.work_result_path, self.final_result_path)
+        except Exception:
+            shutil.rmtree(self.reuse_cache_dir, ignore_errors=True)
+            if cache_backed_up:
+                os.replace(cache_backup_dir, self.reuse_cache_dir)
+            raise
+        shutil.rmtree(cache_backup_dir, ignore_errors=True)
+
+    def discard_reuse_result(self):
+        if not is_main_process():
+            return
+        if self.reuse_cache_stage_dir:
+            shutil.rmtree(self.reuse_cache_stage_dir, ignore_errors=True)
+        if self.work_result_path and os.path.exists(self.work_result_path):
+            os.remove(self.work_result_path)
 
     def warmup(self):
         if not self.config.get("warmup", False):

--- a/lightx2v/models/runners/qwen_image/qwen_image_runner.py
+++ b/lightx2v/models/runners/qwen_image/qwen_image_runner.py
@@ -73,6 +73,9 @@ class QwenImageRunner(DisaggMixin, DefaultRunner):
         if self.text_encoder_type in ["lightllm_service", "lightllm_kernel"]:
             logger.info(f"Using LightLLM text encoder: {self.text_encoder_type}")
 
+    def check_reuse_support(self):
+        pass
+
     @ProfilingContext4DebugL1("Warmup")
     def run_warmup(self):
         task = self.config.get("task")
@@ -567,29 +570,44 @@ class QwenImageRunner(DisaggMixin, DefaultRunner):
         elif input_info.save_result_path is not None:
             return {"images": None}
 
-    def _reuse_key(self):
-        reuse_key = (self.input_info.prompt, self.input_info.negative_prompt)
+    def reuse_key(self):
+        reuse_key = {
+            "prompt": self.input_info.prompt,
+            "negative_prompt": self.input_info.negative_prompt,
+        }
         if self.config["task"] == "i2i":
-            reuse_key += (tuple(self.input_info.image_path.split(",")),)
+            reuse_key["image_path"] = self.input_info.image_path.split(",")
         return reuse_key
 
+    def reuse_input_info(self):
+        input_info = {"txt_seq_lens": list(self.input_info.txt_seq_lens)}
+        if self.config["task"] == "i2i":
+            input_info["original_size"] = list(self.input_info.original_size)
+        return input_info
+
     def _run_pipeline_local(self, input_info):
-        if self.reuse:
-            self.inputs = self._get_reused_inputs()
-        else:
-            self.inputs = self.run_input_encoder()
-            if self.enable_reuse:
-                self._reuse_cache = {"reuse_key": self._reuse_key(), "inputs": self.inputs}
-        if self.config["task"] == "i2i" and "image_encoder_output" in self.inputs:
-            self.input_info.image_encoder_output = self.inputs["image_encoder_output"]
-        self.set_target_shape()
-        self.set_img_shapes()
-        logger.info(f"input_info: {self.input_info}")
-        latents, generator = self.run_dit()
-        images = self.run_vae_decoder(latents)
-        self.end_run()
-        self._save_images(images, input_info, log_prefix="Image saved")
-        return self._finalize_pipeline_outputs(input_info, images, latents=latents, generator=generator)
+        self.prepare_reuse_output()
+        try:
+            self.inputs = self.load_reused_inputs() if self.reuse else self.run_input_encoder()
+            self.stage_reuse_cache()
+            if self.config["task"] == "i2i" and "image_encoder_output" in self.inputs:
+                self.input_info.image_encoder_output = self.inputs["image_encoder_output"]
+            self.set_target_shape()
+            self.set_img_shapes()
+            logger.info(f"input_info: {self.input_info}")
+            latents, generator = self.run_dit()
+            images = self.run_vae_decoder(latents)
+            self.end_run()
+            self._save_images(images, input_info, log_prefix="Image saved")
+            result = self._finalize_pipeline_outputs(input_info, images, latents=latents, generator=generator)
+            self.commit_reuse_result()
+            return result
+        except Exception:
+            self.discard_reuse_result()
+            raise
+        finally:
+            if self.input_info is not None:
+                self.end_run()
 
     def _run_pipeline_disagg_encoder(self):
         self.inputs = self.run_input_encoder()

--- a/lightx2v/models/runners/wan/wan_infinitetalk_runner.py
+++ b/lightx2v/models/runners/wan/wan_infinitetalk_runner.py
@@ -2,6 +2,7 @@ import gc
 import json
 import math
 import os
+import shutil
 import subprocess
 import tempfile
 
@@ -124,6 +125,9 @@ class InfiniteTalkRunner(WanRunner):
 
     def init_scheduler(self):
         self.scheduler = InfiniteTalkScheduler(self.config)
+
+    def check_segment_reuse_support(self):
+        pass
 
     def init_modules(self):
         logger.info("Initializing InfiniteTalk runner modules...")
@@ -501,14 +505,124 @@ class InfiniteTalkRunner(WanRunner):
         self._write_sum_audio(input_data, speech)
         return [self._load_or_encode_audio(speech)]
 
-    def _reuse_key(self):
+    def reuse_key(self):
         prompt = self.input_info.prompt_enhanced if self.config["use_prompt_enhancer"] else self.input_info.prompt
-        return (
-            prompt,
-            self.input_info.negative_prompt,
-            tuple(self._sorted_person_items(self.input_data["cond_audio"])),
-            self.input_data.get("audio_type", "para"),
+        return {
+            "prompt": prompt,
+            "negative_prompt": self.input_info.negative_prompt,
+            "cond_audio": self.input_data["cond_audio"],
+            "audio_type": self.input_data.get("audio_type", "para"),
+            "cond_video": self.input_data["cond_video"],
+            "mask_files": self.input_data.get("mask_files") or {},
+            "bbox": self.input_data.get("bbox") or {},
+            "target_video_length": self.resolve_frame_num(),
+            "video_duration": self._resolve_video_duration(),
+            "infer_steps": self.config["infer_steps"],
+            "target_shape": list(self.input_info.target_shape),
+            "target_fps": self.target_fps,
+            "motion_frame": self.config.get("motion_frame", 9),
+        }
+
+    def load_reused_inputs(self):
+        cached = self.load_reuse_state(map_location="cpu")
+        inputs = cached["inputs"]
+        inputs["text_encoder_output"] = {name: value.to(AI_DEVICE) if value is not None else None for name, value in inputs["text_encoder_output"].items()}
+        self._write_sum_audio(self.input_data, cached["video_audio_array"].numpy())
+        logger.info("[Reuse] Loaded InfiniteTalk input encoder output from disk")
+        return inputs
+
+    def save_reuse_inputs(self):
+        inputs = {
+            "text_encoder_output": {name: value.detach().cpu() if value is not None else None for name, value in self.inputs["text_encoder_output"].items()},
+            "full_audio_embs": [value.detach().cpu() for value in self.inputs["full_audio_embs"]],
+            "human_num": self.inputs["human_num"],
+        }
+        torch.save(
+            {
+                "inputs": inputs,
+                "video_audio_array": torch.as_tensor(self.video_audio_array),
+            },
+            self.reuse_inputs_path(self.reuse_cache_stage_dir),
         )
+
+    def prepare_reuse_output(self):
+        super().prepare_reuse_output()
+        if self.final_result_path is None:
+            return
+
+        output_stem, output_ext = os.path.splitext(self.final_result_path)
+        self.work_result_path = f"{output_stem}.infinitetalk-work{output_ext or '.mp4'}"
+        self.input_info.save_result_path = self.work_result_path
+
+    def stage_reuse_cache(self):
+        super().stage_reuse_cache()
+        if self.reuse_cache_dir is None or not self.reuse or not is_main_process():
+            return
+
+        for boundary_idx in range(self.reuse_prefix_segments):
+            name = f"boundary_{boundary_idx:05d}.pt"
+            shutil.copy2(os.path.join(self.reuse_cache_dir, name), os.path.join(self.reuse_cache_stage_dir, name))
+
+    def load_cached_motion_latent(self, boundary_idx):
+        path = os.path.join(self.reuse_cache_dir, f"boundary_{boundary_idx:05d}.pt")
+        logger.info(f"[Reuse] Loading InfiniteTalk boundary latent: {path}")
+        return torch.load(path, map_location=AI_DEVICE, weights_only=True)
+
+    def save_motion_latent(self, boundary_idx, latent_motion_frames):
+        if self.reuse_cache_stage_dir is None or not is_main_process():
+            return
+        path = os.path.join(self.reuse_cache_stage_dir, f"boundary_{boundary_idx:05d}.pt")
+        torch.save(latent_motion_frames.detach().cpu(), path)
+
+    def merge_reused_video(self):
+        output_stem, output_ext = os.path.splitext(self.final_result_path)
+        merged_video_path = f"{output_stem}.infinitetalk-merged{output_ext or '.mp4'}"
+        prefix_frames = self.reuse_prefix_frame_count()
+        filter_graph = ";".join(
+            [
+                f"[0:v]trim=end_frame={prefix_frames},setpts=PTS-STARTPTS[prefix]",
+                "[1:v]setpts=PTS-STARTPTS[suffix]",
+                "[prefix][suffix]concat=n=2:v=1:a=0[video]",
+            ]
+        )
+        try:
+            subprocess.run(
+                [
+                    ffmpeg.get_ffmpeg_exe(),
+                    "-y",
+                    "-i",
+                    self.previous_result_path,
+                    "-i",
+                    self.work_result_path,
+                    "-filter_complex",
+                    filter_graph,
+                    "-map",
+                    "[video]",
+                    "-map",
+                    "0:a?",
+                    "-c:v",
+                    "libx264",
+                    "-r",
+                    str(self.target_fps),
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:a",
+                    "copy",
+                    merged_video_path,
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            os.replace(merged_video_path, self.work_result_path)
+        finally:
+            if os.path.exists(merged_video_path):
+                os.remove(merged_video_path)
+
+    def commit_reuse_result(self):
+        if self.reuse_cache_dir is not None and self.reuse_prefix_segments and is_main_process():
+            self.merge_reused_video()
+        super().commit_reuse_result()
 
     def _close_cond_video_reader(self):
         if self.cond_video_reader is not None:
@@ -756,6 +870,12 @@ class InfiniteTalkRunner(WanRunner):
             return None
         return float(video_duration)
 
+    def resolve_frame_num(self):
+        frame_num = getattr(self.input_info, "target_video_length", UNSET)
+        if frame_num is UNSET or frame_num is None or frame_num <= 0:
+            frame_num = self.config["target_video_length"]
+        return int(frame_num)
+
     def _resolve_expected_frames(self):
         audio_frames = min(int(audio_emb.shape[0]) for audio_emb in self.full_audio_embs)
         if audio_frames <= 0:
@@ -789,6 +909,11 @@ class InfiniteTalkRunner(WanRunner):
     def _segment_start_frame(self, segment_idx):
         return segment_idx * self.segment_stride
 
+    def reuse_prefix_frame_count(self):
+        if not self.reuse_prefix_segments:
+            return 0
+        return self._segment_start_frame(self.reuse_prefix_segments) + self.motion_frame
+
     def _ensure_audio_padding(self, audio_end_idx):
         for idx, full_audio_emb in enumerate(self.full_audio_embs):
             if audio_end_idx < full_audio_emb.shape[0]:
@@ -798,10 +923,7 @@ class InfiniteTalkRunner(WanRunner):
             self.full_audio_embs[idx] = torch.cat([full_audio_emb, add_audio_emb], dim=0)
 
     def init_run(self):
-        self.frame_num = int(self.config["target_video_length"])
-        input_frame_num = getattr(self.input_info, "target_video_length", UNSET)
-        if input_frame_num is not UNSET and input_frame_num is not None and input_frame_num > 0:
-            self.frame_num = int(input_frame_num)
+        self.frame_num = self.resolve_frame_num()
         self.motion_frame = int(self.config.get("motion_frame", 9))
         self.segment_stride = self.frame_num - self.motion_frame
         if self.segment_stride <= 0:
@@ -845,13 +967,18 @@ class InfiniteTalkRunner(WanRunner):
         latent_h, latent_w = vae_encoder_out.shape[-2:]
         cur_motion_frames_latent_num = int(1 + (self.current_motion_frames_num - 1) // 4)
 
-        if self.is_first_segment:
-            latent_motion_input = self.cond_image
+        if not self.is_first_segment and segment_idx == self.reuse_prefix_segments:
+            latent_motion_frames = self.load_cached_motion_latent(segment_idx - 1)
         else:
-            if self.cond_frame is None:
-                raise RuntimeError("InfiniteTalk non-first segment requires previous decoded motion frames.")
-            latent_motion_input = self.cond_frame
-        latent_motion_frames = self.vae_encoder.encode(latent_motion_input.to(GET_DTYPE()))
+            if self.is_first_segment:
+                latent_motion_input = self.cond_image
+            else:
+                if self.cond_frame is None:
+                    raise RuntimeError("InfiniteTalk non-first segment requires previous decoded motion frames.")
+                latent_motion_input = self.cond_frame
+            latent_motion_frames = self.vae_encoder.encode(latent_motion_input.to(GET_DTYPE()))
+            if not self.is_first_segment:
+                self.save_motion_latent(segment_idx - 1, latent_motion_frames)
 
         ref_target_masks = self._build_ref_target_masks(self.human_num, latent_h, latent_w)
         latent_shape = (16, (self.frame_num - 1) // 4 + 1, latent_h, latent_w)
@@ -954,9 +1081,19 @@ class InfiniteTalkRunner(WanRunner):
         self.stream_save_video = self._should_stream_save_video()
         self.init_run()
         self.get_video_segment_num()
+        if self.reuse_prefix_segments >= self.video_segment_num:
+            raise ValueError(f"reuse_prefix_segments must be smaller than the video segment count ({self.video_segment_num})")
+
+        self.stage_reuse_cache()
         self._init_stream_video_controller()
 
-        for segment_idx in range(self.video_segment_num):
+        start_segment = self.reuse_prefix_segments
+        if start_segment:
+            if _is_video(self.cond_file_path):
+                self.cond_image = self._prepare_cond_image(self._segment_start_frame(start_segment))
+            self.scheduler.begin_request()
+
+        for segment_idx in range(start_segment, self.video_segment_num):
             logger.info(f"start InfiniteTalk segment {segment_idx + 1}/{self.video_segment_num}")
             with ProfilingContext4DebugL1(f"segment end2end {segment_idx + 1}/{self.video_segment_num}"):
                 self.check_stop()
@@ -968,14 +1105,15 @@ class InfiniteTalkRunner(WanRunner):
         if self.stream_save_video:
             return self.process_images_after_vae_decoder()
 
-        self.gen_video = torch.cat(self.gen_video_list, dim=2)[:, :, : self.expected_frames].to(torch.float32)
+        suffix_frames = self.expected_frames - self.reuse_prefix_frame_count()
+        self.gen_video = torch.cat(self.gen_video_list, dim=2)[:, :, :suffix_frames].to(torch.float32)
         return self.process_images_after_vae_decoder()
 
     @ProfilingContext4DebugL1("Process after vae decoder")
     def process_images_after_vae_decoder(self):
         if self.stream_save_video:
             if self.input_info.save_result_path is not None and is_main_process():
-                self.stream_saved_video_needs_audio_remux = True
+                self.stream_saved_video_needs_audio_remux = not self.reuse_prefix_segments
                 logger.info(f"Video saved to {self.input_info.save_result_path}")
             return {"video": None}
 
@@ -999,6 +1137,9 @@ class InfiniteTalkRunner(WanRunner):
         os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
         logger.info(f"Saving InfiniteTalk video to {out_path}")
         save_to_video(self.gen_video_final, out_path, fps=self.target_fps, method="ffmpeg")
+        if self.reuse_prefix_segments:
+            logger.info(f"[Reuse] Saved regenerated InfiniteTalk suffix to {out_path}")
+            return {"video": None}
         audio_input = getattr(self.input_info, "audio_path", None) or self.config.get("audio_path", "")
         mux_audio = self._resolve_mux_audio_path()
         if not mux_audio or not os.path.isfile(mux_audio):
@@ -1125,22 +1266,22 @@ class InfiniteTalkRunner(WanRunner):
             monitor_cli.lightx2v_worker_request_count.inc()
         self.input_info = input_info
         self.stream_saved_video_needs_audio_remux = False
+        self.prepare_reuse_output()
+
         try:
-            self._prepare_input_data()
-            if self.reuse:
-                self.inputs = self._get_reused_inputs()
-                self._write_sum_audio(self.input_data, self._reuse_cache["video_audio_array"])
-            else:
-                self.inputs = self.run_input_encoder()
-                if self.enable_reuse:
-                    self._reuse_cache = {
-                        "reuse_key": self._reuse_key(),
-                        "inputs": self.inputs,
-                        "video_audio_array": self.video_audio_array,
-                    }
-            result = self.run_main()
+            try:
+                self._prepare_input_data()
+                self.inputs = self.load_reused_inputs() if self.reuse else self.run_input_encoder()
+                result = self.run_main()
+            finally:
+                self.end_run()
+            self.commit_reuse_result()
+        except Exception:
+            self.discard_reuse_result()
+            raise
         finally:
-            self.end_run()
+            if self.final_result_path is not None:
+                self.input_info.save_result_path = self.final_result_path
         if GET_RECORDER_MODE():
             monitor_cli.lightx2v_worker_request_success.inc()
         return result

--- a/lightx2v/models/runners/wan/wan_runner.py
+++ b/lightx2v/models/runners/wan/wan_runner.py
@@ -84,8 +84,9 @@ class WanRunner(DisaggMixin, DefaultRunner):
         self.vae_name = config.get("vae_name", "Wan2.1_VAE.pth")
         self.tiny_vae_name = "taew2_1.pth"
 
-    def set_reuse(self, reuse):
-        if reuse and self.config["model_cls"] not in (
+    def check_reuse_support(self):
+        model_cls = self.config["model_cls"]
+        if model_cls not in (
             "wan2.1",
             "wan2.1_distill",
             "wan2.1_mean_flow_distill",
@@ -95,9 +96,8 @@ class WanRunner(DisaggMixin, DefaultRunner):
             "infinitetalk",
         ):
             raise NotImplementedError("Wan reuse currently supports Wan2.1, Wan2.2, and InfiniteTalk only")
-        if reuse and self.config["model_cls"] != "infinitetalk" and self.config["task"] not in ("t2v", "i2v"):
+        if model_cls != "infinitetalk" and self.config["task"] not in ("t2v", "i2v"):
             raise NotImplementedError(f"Wan reuse does not support task: {self.config['task']}")
-        super().set_reuse(reuse)
 
     @ProfilingContext4DebugL1("Warmup")
     def run_warmup(self):
@@ -496,33 +496,50 @@ class WanRunner(DisaggMixin, DefaultRunner):
         self.end_run()
         return gen_video_final
 
-    def _reuse_key(self):
+    def reuse_key(self):
         prompt = self.input_info.prompt_enhanced if self.config["use_prompt_enhancer"] else self.input_info.prompt
-        reuse_key = (
-            prompt,
-            self.input_info.negative_prompt,
-            self.config["target_video_length"],
-        )
+        reuse_key = {
+            "prompt": prompt,
+            "negative_prompt": self.input_info.negative_prompt,
+            "target_video_length": self.config["target_video_length"],
+        }
         if self.config["task"] == "i2v":
-            reuse_key += (self.config.get("resize_mode"), tuple(self.input_info.image_path.split(",")))
-        else:
-            reuse_key += (tuple(self.input_info.target_shape),)
+            reuse_key.update(
+                {
+                    "image_path": self.input_info.image_path.split(","),
+                    "resize_mode": self.config.get("resize_mode"),
+                }
+            )
+        elif self.config["task"] == "t2v":
+            target_shape = self.input_info.target_shape or (
+                self.config["target_height"],
+                self.config["target_width"],
+            )
+            reuse_key["target_shape"] = list(target_shape)
         return reuse_key
+
+    def reuse_input_info(self):
+        return {
+            "latent_shape": list(self.input_info.latent_shape),
+            "target_shape": list(self.input_info.target_shape),
+        }
 
     def _run_pipeline_local(self):
         if self.config["use_prompt_enhancer"]:
             self.input_info.prompt_enhanced = self.post_prompt_enhancer()
-        if self.reuse:
-            self.inputs = self._get_reused_inputs()
-        else:
-            self.inputs = self.run_input_encoder()
-            if self.enable_reuse:
-                self._reuse_cache = {"reuse_key": self._reuse_key(), "inputs": self.inputs}
-        if self.enable_reuse and self.config["model_cls"] == "wan2.2" and self.config["task"] == "i2v":
-            # wan2.2 dense init_run clears this request's VAE output after scheduler.prepare; keep the cached container intact.
-            self.inputs = self.inputs.copy()
-            self.inputs["image_encoder_output"] = self.inputs["image_encoder_output"].copy()
-        return self.run_main()
+        self.prepare_reuse_output()
+        try:
+            self.inputs = self.load_reused_inputs() if self.reuse else self.run_input_encoder()
+            self.stage_reuse_cache()
+            result = self.run_main()
+            self.commit_reuse_result()
+            return result
+        except Exception:
+            self.discard_reuse_result()
+            raise
+        finally:
+            if self.input_info is not None:
+                self.end_run()
 
     def _run_pipeline_disagg_encoder(self):
         if self.config["use_prompt_enhancer"]:

--- a/lightx2v/models/schedulers/wan/infinitetalk/scheduler.py
+++ b/lightx2v/models/schedulers/wan/infinitetalk/scheduler.py
@@ -36,9 +36,12 @@ class InfiniteTalkScheduler(BaseScheduler):
         torch.backends.cudnn.deterministic = True
         return seed
 
+    def begin_request(self):
+        self.rope_request_id += 1
+
     def prepare(self, seed, latent_shape, latent_motion_frames=None, is_first_clip=True, cur_motion_frames_latent_num=1):
         if is_first_clip:
-            self.rope_request_id += 1
+            self.begin_request()
         self.latents = torch.randn(*latent_shape, dtype=torch.float32, device=AI_DEVICE)
         self.latent_motion_frames = latent_motion_frames
         self.is_first_clip = is_first_clip

--- a/lightx2v/server/schema.py
+++ b/lightx2v/server/schema.py
@@ -76,6 +76,11 @@ class BaseTaskRequest(DisaggOverrideRequest):
 class VideoTaskRequest(BaseTaskRequest):
     num_fragments: int = Field(1, description="Number of fragments")
     target_video_length: int = Field(81, description="Target video length")
+    reuse_prefix_segments: int = Field(
+        0,
+        ge=0,
+        description="Number of prefix segments to reuse from the previous successful request",
+    )
     video_path: str = Field("", description="Input video path (for SR/V2V-like tasks)")
     sr_ratio: float = Field(2.0, gt=0, description="Super-resolution scale factor used when target_shape is not set")
     audio_path: str = Field("", description="Input audio path (Wan-Audio)")

--- a/lightx2v/server/services/inference/worker.py
+++ b/lightx2v/server/services/inference/worker.py
@@ -82,6 +82,7 @@ class TorchrunInferenceWorker:
             lora_name = task_data.pop("lora_name", None)
             lora_strength = task_data.pop("lora_strength", 1.0)
             reuse = task_data.pop("reuse", False)
+            reuse_prefix_segments = task_data.pop("reuse_prefix_segments", 0)
 
             if self.lora_dir:
                 self.switch_lora(lora_name, lora_strength)
@@ -105,7 +106,7 @@ class TorchrunInferenceWorker:
                 self.input_info = init_empty_input_info(self.runner.config["task"])
             update_input_info_from_dict(self.input_info, task_data)
 
-            self.runner.set_reuse(reuse)
+            self.runner.set_reuse(reuse, reuse_prefix_segments)
             self.runner.set_config(task_data)
             pipeline_return = self.runner.run_pipeline(self.input_info)
 

--- a/scripts/server/post_reuse.py
+++ b/scripts/server/post_reuse.py
@@ -9,6 +9,8 @@ if __name__ == "__main__":
         "negative_prompt": "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走",
         "image_path": "",
         "reuse": True,
+        # 0: ordinary reuse; N > 0: also reuse the previous result's first N segments.
+        "reuse_prefix_segments": 0,
         "seed": 42,
         "save_result_path": "./cat_boxing_seed42.mp4",
     }


### PR DESCRIPTION
- Persist encoder outputs and request metadata in shared disk caches for Wan,
  Qwen-Image, and InfiniteTalk.
- Add InfiniteTalk prefix-segment reuse with cached motion boundaries and
  previous-result prefix merging.
- Publish reuse caches only after successful generation and reject reuse for
  streaming or tensor-returning requests.
- Add reuse capability checks, request schema wiring, cache configuration, and
  a request example.