### PR TITLE
fix(attention): enable SageAttention dispatcher on SM120

### DIFF
--- a/lightx2v/common/ops/attn/sage_attn.py
+++ b/lightx2v/common/ops/attn/sage_attn.py
@@ -25,7 +25,7 @@ except ImportError:
 
 capability = torch.cuda.get_device_capability(0) if torch.cuda.is_available() else None
 # Keep the legacy SM89 override; SM120 follows SageAttention's dispatcher.
-if capability in [(8, 9), (12, 0)]:
+if capability == (8, 9):
     try:
         from sageattention import sageattn_qk_int8_pv_fp16_triton as sageattn
     except ImportError:


### PR DESCRIPTION
Use SageAttention’s official dispatcher on SM120 while retaining the legacy Triton override for SM89. This depends on ModelTC/SageAttention commit 836889a, which fixes kernel launches on non-default CUDA streams.