### PR TITLE
feat(minimax_h3): keep DiT pre/post weights resident

### DIFF
--- a/configs/minimax_h3/dmd/minimax_h3_fp8_4step_5090_with_fp8_vae_sla.json
+++ b/configs/minimax_h3/dmd/minimax_h3_fp8_4step_5090_with_fp8_vae_sla.json
@@ -8,6 +8,7 @@
   "enable_cfg": false,
   "cpu_offload": true,
   "offload_granularity": "block",
+  "dit_prepost_resident": true,
   "text_encoder_cpu_offload": true,
   "text_encoder_offload_granularity": "block",
   "vae_cpu_offload": false,

--- a/lightx2v/models/networks/minimax_h3/model.py
+++ b/lightx2v/models/networks/minimax_h3/model.py
@@ -48,6 +48,10 @@ class MiniMaxH3Model(BaseTransformerModel):
 
     def __init__(self, model_path, config, device, lora_path=None, lora_strength=1.0, lora_alpha=None):
         self.lora_alpha = lora_alpha
+        self.block_offload = config.get("cpu_offload", False) and config.get("offload_granularity", "model") == "block"
+        # Model offload moves pre/blocks/post together. Pre/post residency only applies
+        # to block offload and is ignored otherwise.
+        self.prepost_resident = self.block_offload and config.get("dit_prepost_resident", False)
         if GET_DTYPE() != torch.bfloat16:
             raise ValueError(
                 "MiniMax-H3 requires DTYPE=BF16. The native loader preserves the released checkpoint's 626 BF16 tensors and 12 FP32 projection/time/head tensors without dtype conversion."
@@ -484,14 +488,14 @@ class MiniMaxH3Model(BaseTransformerModel):
 
     @torch.no_grad()
     def infer(self, inputs):
-        block_offload = self.cpu_offload and self.offload_granularity == "block"
-        if block_offload and self.scheduler.step_index == 0:
+        prepost_offload = self.block_offload and not self.prepost_resident
+        if prepost_offload and self.scheduler.step_index == 0:
             self.pre_weight.to_cuda()
             self.post_weight.to_cuda()
         output = self._infer_cond_uncond(inputs, infer_condition=True)
         self.scheduler.video_noise_pred = output.video
         self.scheduler.audio_noise_pred = output.audio
-        if block_offload and self.scheduler.step_index == self.scheduler.infer_steps - 1:
+        if prepost_offload and self.scheduler.step_index == self.scheduler.infer_steps - 1:
             self.pre_weight.to_cpu()
             self.post_weight.to_cpu()
 

--- a/lightx2v/models/runners/minimax_h3/minimax_h3_runner.py
+++ b/lightx2v/models/runners/minimax_h3/minimax_h3_runner.py
@@ -106,6 +106,10 @@ class MiniMaxH3Runner(DefaultRunner):
     def init_modules(self):
         super().init_modules()
         self.run_input_encoder = self._run_input_encoder_local_h3
+        if self.model.prepost_resident:
+            self.model.pre_weight.to_cuda()
+            self.model.post_weight.to_cuda()
+            logger.info("MiniMax-H3 pre/post weights will remain on the accelerator across requests")
 
     @ProfilingContext4DebugL1("Warmup")
     def run_warmup(self):
@@ -577,10 +581,11 @@ class MiniMaxH3Runner(DefaultRunner):
     def _offload_transformer(self):
         if not self.config.get("cpu_offload", False):
             return
-        if self.config.get("offload_granularity", "model") == "block":
-            logger.info("Offloading MiniMax-H3 pre/post weights; retaining the two block-offload device buffers")
-            self.model.pre_weight.to_cpu()
-            self.model.post_weight.to_cpu()
+        if self.model.block_offload:
+            if not self.model.prepost_resident:
+                logger.info("Offloading MiniMax-H3 pre/post weights; retaining the two block-offload device buffers")
+                self.model.pre_weight.to_cpu()
+                self.model.post_weight.to_cpu()
         else:
             logger.info("Offloading MiniMax-H3 transformer before VAE decode")
             self.model.to_cpu()


### PR DESCRIPTION
Keep MiniMax-H3 DiT pre/post weights on the accelerator across requests while transformer blocks continue using block offload. The opt-in setting removes repeated pre/post transfers without changing the default behavior and remains compatible with dynamic LoRA switching.