### PR TITLE
fix(minimax_h3): shard column-parallel biases for TP

### DIFF
--- a/lightx2v/models/networks/minimax_h3/model.py
+++ b/lightx2v/models/networks/minimax_h3/model.py
@@ -325,10 +325,16 @@ class MiniMaxH3Model(BaseTransformerModel):
         split_type = self._tp_split_type(key)
         if split_type is None:
             return tensor
-        if tensor.ndim < 2:
+        # Scalar metadata such as ConvRot's group size is shared by all TP
+        # ranks.  One-dimensional column biases/scales still need sharding.
+        if tensor.ndim == 0:
             return tensor
 
         if split_type == "row":
+            # Row-parallel biases belong to the fully reduced output and stay
+            # replicated.  Other one-dimensional metadata is replicated too.
+            if tensor.ndim < 2:
+                return tensor
             # Per-output-channel quantization scales remain replicated for a
             # row-parallel weight; only the weight's input dimension is split.
             if key.endswith(".weight_scale"):


### PR DESCRIPTION


Fix MiniMax-H3 tensor-parallel sharding for 1D tensors in column-parallel layers.

  ## Problem

https://github.com/ModelTC/LightX2V/pull/1441 skipped TP sharding for all tensors with fewer than two dimensions. This correctly preserved ConvRot's scalar `convrot_groupsize`, but unintentionally left  column-parallel biases unsharded.

 For example, with TP=2, the AdaLN weight output dimension was 48384 while its bias remained 96768, causing `torch.addmm` to fail.

  ## Fix

  Handle tensors according to their role:

  - Keep 0-D metadata such as `convrot_groupsize` replicated.
  - Shard 1-D column-parallel biases and scales.
  - Keep row-parallel biases replicated.