### PR TITLE
fix(wan-audio): restore the phase argument at the three multi-line _apply_rope_with_cache_range call sites

### DIFF
--- a/lightx2v/models/networks/wan/infer/audio/transformer_infer.py
+++ b/lightx2v/models/networks/wan/infer/audio/transformer_infer.py
@@ -404,6 +404,7 @@ class WanAudioARTransformerInfer(WanAudioPostAdapterMixin, WanSFTransformerInfer
                 attn_v = kv_cache.v_cache(self.block_idx, attn_start, local_end_idx)
                 if use_local_cache_rope:
                     attn_k = self._apply_rope_with_cache_range(
+                        phase,
                         attn_k,
                         freqs,
                         h,
@@ -432,6 +433,7 @@ class WanAudioARTransformerInfer(WanAudioPostAdapterMixin, WanSFTransformerInfer
             rope_global_end = None if use_local_cache_rope else current_end
             rope_sink_tokens = 0 if use_local_cache_rope else sink_tokens
             q = self._apply_rope_with_cache_range(
+                phase,
                 q,
                 freqs,
                 h,
@@ -446,6 +448,7 @@ class WanAudioARTransformerInfer(WanAudioPostAdapterMixin, WanSFTransformerInfer
                 sink_tokens=rope_sink_tokens,
             )
             attn_k = self._apply_rope_with_cache_range(
+                phase,
                 attn_k,
                 freqs,
                 h,


### PR DESCRIPTION
### What

`WanAudioARTransformerInfer.infer_self_attn_with_kvcache` calls
`self._apply_rope_with_cache_range(...)` in five places. Three of them are missing the
`phase` argument, so they raise:

```
TypeError: _apply_rope_with_cache_range() missing 1 required positional argument: 'local_per_frame'
```

### Why it happened

[#1238 "[refactor]: rope as module"](https://github.com/ModelTC/LightX2V/pull/1238) added `phase`
as the first parameter of the method (the body now needs it for `phase.causal_rope.apply_audio_cache`):

```diff
     def _apply_rope_with_cache_range(
         self,
+        phase,
         x,
         freqs,
```

The same commit updated the two call sites that fit on one line:

```diff
-                q_rope = self._apply_rope_with_cache_range(q, freqs, h, w, 1, 0, ...)
-                k_rope = self._apply_rope_with_cache_range(k, freqs, h, w, 1, 0, ...)
+                q_rope = self._apply_rope_with_cache_range(phase, q, freqs, h, w, 1, 0, ...)
+                k_rope = self._apply_rope_with_cache_range(phase, k, freqs, h, w, 1, 0, ...)
```

but the three call sites in the same method that are formatted across multiple lines
(`:406`, `:434`, `:448`) were left as they were. They still pass the tensor first, which
lands in the `phase` slot and shifts every remaining argument by one.

### Impact

`:434` and `:448` are in the **non-`seq_parallel` branch** — i.e. the plain single-GPU
Seko-AR audio path — so it fails on the first block, every run. `:406` is the
`seq_parallel and not replicated_ref_prefill` + `use_local_cache_rope` branch.

### Verification

No runtime here (no GPU), so I replayed the binding statically: parse the file, build a
stub from the real `ast.arguments` of the definition, and `inspect.Signature.bind` each of
the five call sites — with the two known-good sites as the control group.

Before:

```
line  353: OK   (11 pos)          <- updated by #1238
line  354: OK   (11 pos)          <- updated by #1238
line  406: FAIL -> TypeError: missing a required argument: 'local_per_frame'
line  434: FAIL -> TypeError: missing a required argument: 'local_per_frame'
line  448: FAIL -> TypeError: missing a required argument: 'local_per_frame'
```

After this patch all five bind cleanly. `phase` is already the first parameter of the
enclosing `infer_self_attn_with_kvcache`, so it is in scope at each site — this is purely
restoring the argument the refactor intended.

`ruff check` and `ruff format --check` (pinned `v0.11.0`, repo `pyproject.toml`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
