### PR TITLE
fix(attention): use SageAttention dispatcher on SM120

### DIFF
--- a/lightx2v/common/ops/attn/sage_attn.py
+++ b/lightx2v/common/ops/attn/sage_attn.py
@@ -25,7 +25,7 @@ except ImportError:
 
 capability = torch.cuda.get_device_capability(0) if torch.cuda.is_available() else None
 # Keep the legacy SM89 override; SM120 follows SageAttention's dispatcher.
-if capability in [(8, 9), (12, 0)]:
+if capability == (8, 9):
     try:
         from sageattention import sageattn_qk_int8_pv_fp16_triton as sageattn
     except ImportError:


### PR DESCRIPTION
Keep the legacy SM89 override, but let SM120 select its backend through SageAttention hardware dispatch. This requires the updated SageAttention build in the 5090 container image.