### PR TITLE
fix(seedvr): restore distributed ops exports

### DIFF
--- a/lightx2v/models/networks/seedvr/utils/ops.py
+++ b/lightx2v/models/networks/seedvr/utils/ops.py
@@ -1,5 +1,12 @@
 import torch.nn.functional as F
 
+from lightx2v.models.video_encoders.hf.seedvr.common.distributed.ops import (
+    gather_heads_scatter_seq,
+    gather_outputs,
+    gather_seq_scatter_heads_qkv,
+    slice_inputs,
+)
+
 
 def safe_pad_operation(x, pad):
     return F.pad(x, pad)

--- a/lightx2v/models/networks/seedvr/utils/ops.py
+++ b/lightx2v/models/networks/seedvr/utils/ops.py
@@ -1,11 +1,11 @@
 import torch.nn.functional as F
 
-from lightx2v.models.video_encoders.hf.seedvr.common.distributed.ops import (
-    gather_heads_scatter_seq,
-    gather_outputs,
-    gather_seq_scatter_heads_qkv,
-    slice_inputs,
-)
+from lightx2v.models.video_encoders.hf.seedvr.common.distributed import ops as distributed_ops
+
+gather_heads_scatter_seq = distributed_ops.gather_heads_scatter_seq
+gather_outputs = distributed_ops.gather_outputs
+gather_seq_scatter_heads_qkv = distributed_ops.gather_seq_scatter_heads_qkv
+slice_inputs = distributed_ops.slice_inputs
 
 
 def safe_pad_operation(x, pad):


### PR DESCRIPTION
## Summary
- restore the four SeedVR distributed-op exports removed by #1345
- route existing SeedVR inference imports to the sequence-parallel implementations
- preserve single-GPU no-op behavior

## Validation
- SeedVR source imports pass in the CUDA runtime
- single-GPU semantics verified for all four exports
- full SeedVR2 3B BF16 inference passed (305-frame input, 1920x1080 output)
- full SeedVR2 3B FP8 inference passed (305-frame input, 1920x1080 output)

Without this change, both BF16 and FP8 fail before loading weights with ImportError for gather_heads_scatter_seq.