### PR TITLE
ci: avoid duplicate and mutating lint runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ name: lint
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v0.11.0
     hooks:
       - id: ruff
-        args: [--fix, --respect-gitignore, --config=pyproject.toml]
+        args: [--respect-gitignore, --config=pyproject.toml]
       - id: ruff-format
         args: [--config=pyproject.toml]
 


### PR DESCRIPTION
## Summary
- run the push-triggered lint workflow only for main
- keep pull_request linting for feature branches
- remove Ruff --fix from pre-commit so CI reports violations without rewriting files

## Trigger behavior
- feature branch with PR: one pull_request lint run
- direct push to main: one push lint run
- merged PR: a pull_request run before merge and a main push run after merge

## Validation
- both YAML files parse successfully
- git diff --check passes
- GitNexus change scan: 2 config files, 0 code symbols, LOW risk