### PR TITLE
fix(attn): enable GQA broadcast in torch_sdpa

### DIFF
--- a/lightx2v/common/ops/attn/torch_sdpa.py
+++ b/lightx2v/common/ops/attn/torch_sdpa.py
@@ -44,7 +44,17 @@ class TorchSDPAWeight(AttnWeightTemplate):
                 enable_mem_efficient=True,
             )
         with sdpa_ctx:
-            x = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, dropout_p=drop_rate, is_causal=causal)
+            # q/k/v are (B, H, S, D) here, so head count is dim 1. GQA models such as
+            # neopp (32 q heads, 8 kv heads) need SDPA to broadcast the kv groups.
+            x = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=drop_rate,
+                is_causal=causal,
+                enable_gqa=q.shape[1] != k.shape[1],
+            )
         x = x.transpose(1, 2)
         b, s, a, d = x.shape
         out = x.reshape(b, s, -1)


### PR DESCRIPTION
## Problem

`TorchSDPAWeight.apply()` calls `F.scaled_dot_product_attention()` without `enable_gqa`, so the backend only works when the query and key/value head counts match. Every grouped-query-attention model fails with a shape mismatch.

`torch_sdpa` is a registered, user-selectable backend (`@ATTN_WEIGHT_REGISTER("torch_sdpa")`) and is the dependency-free fallback wherever the default `flash_attn3` is unavailable. `neopp` (SenseNova-U1.5-8B-MoT) has 32 query heads and 8 key/value heads, so `"attn_type": "torch_sdpa"` in `configs/neopp/neopp_dense.json` fails immediately with `RuntimeError: The size of tensor a (32) must match the size of tensor b (8) at non-singleton dimension 1`.

## Fix

Pass `enable_gqa=q.shape[1] != k.shape[1]`. `q`/`k`/`v` are `(B, H, S, D)` at that point, so the head count is dim 1.

Non-GQA models are unaffected, since equal head counts make the expression `False` — PyTorch's default. The predicate is the repo's own: `ulysses_attn.py:361` already uses `is_gqa = q.shape[1] != k.shape[1]`, there only to reject unsupported combinations. `enable_gqa` requires PyTorch 2.5, which the repo already assumes elsewhere (`models/input_encoders/hf/minimax_h3/qwen3vl.py:178`).

## Validation

SenseNova-U1.5-8B-MoT text-to-image with `"attn_type": "torch_sdpa"` at 1024x1024, on both the 50-step base config and the 8-step distilled LoRA config. Images are correct; pixel distributions checked for uniform-colour and NaN frames. Hardware was AMD (gfx1100 / gfx1201, ROCm 7.2.3, PyTorch 2.10), but the defect is not vendor-specific.
