### PR TITLE
fix(sekotalk-ar): pass phase to cached RoPE

### DIFF
--- a/lightx2v/models/networks/wan/infer/audio/transformer_infer.py
+++ b/lightx2v/models/networks/wan/infer/audio/transformer_infer.py
@@ -432,6 +432,7 @@ class WanAudioARTransformerInfer(WanAudioPostAdapterMixin, WanSFTransformerInfer
             rope_global_end = None if use_local_cache_rope else current_end
             rope_sink_tokens = 0 if use_local_cache_rope else sink_tokens
             q = self._apply_rope_with_cache_range(
+                phase,
                 q,
                 freqs,
                 h,
@@ -446,6 +447,7 @@ class WanAudioARTransformerInfer(WanAudioPostAdapterMixin, WanSFTransformerInfer
                 sink_tokens=rope_sink_tokens,
             )
             attn_k = self._apply_rope_with_cache_range(
+                phase,
                 attn_k,
                 freqs,
                 h,


### PR DESCRIPTION
## Summary
- pass the missing `phase` argument in non-sequence-parallel AR cached RoPE calls
- fix argument shifting that caused `missing 1 required positional argument: local_per_frame`

## Validation
- single-card H100 SekoTalk AR FP8 test completed 60/60 chunks
- FFmpeg exited successfully and generated the MP4 output