### PR TITLE
fix(audio_io): remove unreachable duplicate except in torchcodec probe

### DIFF
--- a/lightx2v/utils/audio_io.py
+++ b/lightx2v/utils/audio_io.py
@@ -15,8 +15,6 @@ def _torchaudio_decode_available() -> bool:
     if _TORCHAUDIO_DECODE_AVAILABLE is None:
         try:
             import torchcodec  # noqa: F401
-        except Exception:
-            _TORCHAUDIO_DECODE_AVAILABLE = False
         except Exception as e:
             print(f"Error importing torchcodec: {e}")
             _TORCHAUDIO_DECODE_AVAILABLE = False


### PR DESCRIPTION
### Problem

In `lightx2v/utils/audio_io.py`, the `torchcodec` import probe declares two identical `except Exception` handlers:

```python
try:
    import torchcodec  # noqa: F401
except Exception:
    _TORCHAUDIO_DECODE_AVAILABLE = False
except Exception as e:                       # unreachable
    print(f"Error importing torchcodec: {e}")
    _TORCHAUDIO_DECODE_AVAILABLE = False
else:
    _TORCHAUDIO_DECODE_AVAILABLE = True
```

Two handlers for the same exception type in one `try` are evaluated top-down, so the first (silent) handler always wins and the second — the one that actually logs *why* the probe failed — is unreachable dead code.

### Fix

Drop the redundant silent handler and keep the informative one, so an import failure is reported instead of swallowed:

```python
try:
    import torchcodec  # noqa: F401
except Exception as e:
    print(f"Error importing torchcodec: {e}")
    _TORCHAUDIO_DECODE_AVAILABLE = False
else:
    _TORCHAUDIO_DECODE_AVAILABLE = True
```

One-hunk change; behavior on success is unchanged, and a failing probe now surfaces the underlying error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
