### PR TITLE
fix: reset request state and align inference workflows

### DIFF
--- a/configs/worldplay/worldplay_ar_i2v_480p.json
+++ b/configs/worldplay/worldplay_ar_i2v_480p.json
@@ -3,6 +3,7 @@
     "task": "i2v",
     "infer_steps": 50,
     "transformer_model_name": "480p_i2v",
+    "action_ckpt": "/path/to/HY-WorldPlay/ar_model/diffusion_pytorch_model.safetensors",
     "target_video_length": 125,
     "vae_stride": [4, 16, 16],
     "sample_shift": 7.0,

--- a/configs/worldplay/worldplay_ar_i2v_480p_sp4.json
+++ b/configs/worldplay/worldplay_ar_i2v_480p_sp4.json
@@ -3,6 +3,7 @@
     "task": "i2v",
     "infer_steps": 50,
     "transformer_model_name": "480p_i2v",
+    "action_ckpt": "/path/to/HY-WorldPlay/ar_model/diffusion_pytorch_model.safetensors",
     "target_video_length": 125,
     "vae_stride": [4, 16, 16],
     "sample_shift": 7.0,

--- a/configs/worldplay/worldplay_bi_i2v_480p.json
+++ b/configs/worldplay/worldplay_bi_i2v_480p.json
@@ -3,6 +3,7 @@
     "task": "i2v",
     "infer_steps": 50,
     "transformer_model_name": "480p_i2v",
+    "action_ckpt": "/path/to/HY-WorldPlay/bidirectional_model/diffusion_pytorch_model.safetensors",
     "target_video_length": 125,
     "vae_stride": [4, 16, 16],
     "sample_shift": 7.0,

--- a/configs/worldplay/worldplay_distill_i2v_480p.json
+++ b/configs/worldplay/worldplay_distill_i2v_480p.json
@@ -4,6 +4,7 @@
     "infer_steps": 4,
     "denoising_step_list": [0, 250, 500, 750],
     "transformer_model_name": "480p_i2v",
+    "action_ckpt": "/path/to/HY-WorldPlay/ar_distilled_action_model/diffusion_pytorch_model.safetensors",
     "target_video_length": 125,
     "aspect_ratio": "16:9",
     "vae_stride": [4, 16, 16],

--- a/lightx2v/disagg/examples/run_service.py
+++ b/lightx2v/disagg/examples/run_service.py
@@ -17,7 +17,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--model_path", type=str, required=True)
     parser.add_argument("--config_json", type=str, required=True)
 
-    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--seed", type=int, default=None)
     parser.add_argument(
         "--prompt",
         type=str,
@@ -100,7 +100,10 @@ def _build_runtime_config(args: argparse.Namespace) -> tuple[dict, dict]:
     config = _normalize_disagg_config(config)
     raw_cfg = _normalize_disagg_config(raw_cfg)
 
-    config["seed"] = args.seed
+    if args.seed is not None:
+        config["seed"] = args.seed
+    elif config.get("seed") is None:
+        config["seed"] = 42
     config["prompt"] = args.prompt
     config["negative_prompt"] = args.negative_prompt
     config["save_path"] = args.save_result_path
@@ -116,7 +119,7 @@ def main():
         rank_key = f"{service_mode}_engine_rank"
         config[rank_key] = int(args.engine_rank)
 
-    seed_all(args.seed)
+    seed_all(config["seed"])
     logger.info("Starting disagg service mode={}", service_mode)
 
     if service_mode == "encoder":

--- a/lightx2v/disagg/services/controller.py
+++ b/lightx2v/disagg/services/controller.py
@@ -164,8 +164,6 @@ class ControllerService(BaseService):
             str(instance_cfg.get("model_path")),
             "--config_json",
             service_config_json,
-            "--seed",
-            str(instance_cfg.get("seed", 42)),
             "--prompt",
             str(instance_cfg.get("prompt", "")),
             "--negative_prompt",
@@ -2083,6 +2081,9 @@ class ControllerService(BaseService):
 
                 request_config = dict(config)
                 request_config.update(self._to_plain(workload_config))
+                if request_config.get("seed") is None:
+                    seed = config.get("seed")
+                    request_config["seed"] = 42 if seed is None else seed
 
                 room = request_config.get("data_bootstrap_room", next_room)
                 try:

--- a/lightx2v/disagg/services/decoder.py
+++ b/lightx2v/disagg/services/decoder.py
@@ -134,9 +134,6 @@ class DecoderService(BaseService):
         self._phase2_slots = shared_slots
         self._phase2_slot_size = shared_slot_size
 
-        if "seed" in self.config:
-            seed_all(self.config["seed"])
-
         data_bootstrap_addr = self.config.get("data_bootstrap_addr", "127.0.0.1")
         data_bootstrap_room = self.config.get("data_bootstrap_room", 0)
 
@@ -192,6 +189,7 @@ class DecoderService(BaseService):
         return MemoryHandle(buffers=buffers)
 
     def process(self, config):
+        seed_all(config["seed"])
         self.logger.info("Starting processing in DecoderService...")
         room = config.get("data_bootstrap_room", 0)
         decoder_metrics = config.setdefault("request_metrics", {}).setdefault("stages", {}).setdefault("decoder", {})

--- a/lightx2v/disagg/services/encoder.py
+++ b/lightx2v/disagg/services/encoder.py
@@ -378,10 +378,6 @@ class EncoderService(BaseService):
         self._phase1_slots = shared_slots
         self._phase1_slot_size = shared_slot_size
 
-        # Seed everything if seed is in config
-        if "seed" in self.config:
-            seed_all(self.config["seed"])
-
         data_bootstrap_addr = self.config.get("data_bootstrap_addr", "127.0.0.1")
         data_bootstrap_room = self.config.get("data_bootstrap_room", 0)
 
@@ -517,6 +513,7 @@ class EncoderService(BaseService):
         """
         Generates encoder outputs from prompt and image input.
         """
+        seed_all(config["seed"])
         self.logger.info("Starting processing in EncoderService...")
         room = int(config.get("data_bootstrap_room", 0))
         encoder_metrics = config.setdefault("request_metrics", {}).setdefault("stages", {}).setdefault("encoder", {})

--- a/lightx2v/disagg/services/transformer.py
+++ b/lightx2v/disagg/services/transformer.py
@@ -388,13 +388,6 @@ class TransformerService(BaseService):
         self._phase2_slots = shared_slots
         self._phase2_slot_size = shared_slot_size
 
-        if self.scheduler is not None:
-            self.scheduler.refresh_from_config(self.config)
-
-        # Set global seed if present in config, though specific process calls might reuse it
-        if "seed" in self.config:
-            seed_all(self.config["seed"])
-
         data_bootstrap_addr = self.config.get("data_bootstrap_addr", "127.0.0.1")
         data_bootstrap_room = self.config.get("data_bootstrap_room", 0)
 
@@ -550,9 +543,12 @@ class TransformerService(BaseService):
         """
         Executes the diffusion process and video decoding.
         """
+        seed = config["seed"]
+        seed_all(seed)
         self.logger.info("Starting processing in TransformerService...")
         # Re-sync scheduler with the current request to avoid cross-request config bleed.
         if self.scheduler is not None:
+            self.scheduler.clear()
             self.scheduler.refresh_from_config(config)
         room = config.get("data_bootstrap_room", 0)
         transformer_metrics = config.setdefault("request_metrics", {}).setdefault("stages", {}).setdefault("transformer", {})
@@ -805,10 +801,6 @@ class TransformerService(BaseService):
             "image_encoder_output": image_encoder_output,
             "latent_shape": latent_shape,
         }
-
-        seed = config.get("seed")
-        if seed is None:
-            raise ValueError("seed is required in config.")
 
         if latent_shape is None:
             raise ValueError("latent_shape is required in inputs.")

--- a/lightx2v/models/networks/worldplay/pose_utils.py
+++ b/lightx2v/models/networks/worldplay/pose_utils.py
@@ -278,7 +278,8 @@ def pose_to_input(pose_data, latent_num, tps=False):
 
     pose_keys = list(pose_json.keys())
     latent_num_from_pose = len(pose_keys)
-    assert latent_num_from_pose == latent_num, f"pose corresponds to {latent_num_from_pose * 4 - 3} frames, num_frames must be set to {latent_num_from_pose * 4 - 3} to ensure alignment."
+    if latent_num_from_pose != latent_num:
+        raise ValueError(f"pose corresponds to {latent_num_from_pose * 4 - 3} frames, num_frames must be set to {latent_num_from_pose * 4 - 3} to ensure alignment.")
 
     intrinsic_list = []
     w2c_list = []

--- a/lightx2v/models/runners/minimax_h3/minimax_h3_runner.py
+++ b/lightx2v/models/runners/minimax_h3/minimax_h3_runner.py
@@ -180,14 +180,21 @@ class MiniMaxH3Runner(DefaultRunner):
         else:
             self.input_info = Ref2AVInputInfo(**common, image_path=image)
 
-    def clear_warmup_state(self):
-        self.scheduler.clear()
+    def clear_conditioning_state(self):
         self.condition_video_latents = []
         self.condition_audio_latents = []
         self.keyframe_anchors = ()
         self.prepared_references = None
+
+    def clear_warmup_state(self):
+        self.scheduler.clear()
+        self.clear_conditioning_state()
         self.input_info = None
         self.__dict__.pop("inputs", None)
+
+    def end_run(self):
+        self.clear_conditioning_state()
+        super().end_run()
 
     def init_scheduler(self):
         self.scheduler = MiniMaxH3Scheduler(self.config)
@@ -501,10 +508,7 @@ class MiniMaxH3Runner(DefaultRunner):
                 f"loaded {self.loaded_transformer_partition!r}, requested {requested_partition!r}. "
                 "Create a separate LightX2VPipeline for ref2av."
             )
-        self.condition_video_latents = []
-        self.condition_audio_latents = []
-        self.keyframe_anchors = ()
-        self.prepared_references = None
+        self.clear_conditioning_state()
         if task == "ref2av":
             self._resolve_request_geometry()
             self.prepared_references = self._prepare_references()

--- a/lightx2v/models/runners/neopp/neopp_runner.py
+++ b/lightx2v/models/runners/neopp/neopp_runner.py
@@ -220,10 +220,11 @@ class NeoppRunner(DefaultRunner):
                 timestep_shift=3.0,
             )
 
-        self.inputs = self.run_input_encoder()
-        gen_result = self.run_main()
-        self.clear_kvcache()
-        return gen_result
+        try:
+            self.inputs = self.run_input_encoder()
+            return self.run_main()
+        finally:
+            self.clear_kvcache()
 
     def load_kvcache(self, to_x2v_cond_kv_path, to_x2v_uncond_kv_path=None):
         cfg_p_rank = self._get_cfg_p_rank()
@@ -262,6 +263,7 @@ class NeoppRunner(DefaultRunner):
     def clear_kvcache(self):
         self.past_key_values_cond = None
         self.past_key_values_uncond = None
+        self.inputs = {}
         self.model.transformer_infer.kv_cache.clear()
 
     def init_run(self):

--- a/lightx2v/models/runners/seedvr/seedvr_runner.py
+++ b/lightx2v/models/runners/seedvr/seedvr_runner.py
@@ -389,6 +389,10 @@ class SeedVRRunner(DefaultRunner):
         self.gen_video_final = raw_video
         return self.process_images_after_vae_decoder()
 
+    def end_run(self):
+        self._input = None
+        super().end_run()
+
     def _save_sr_segment_video(self, raw_video, output_path, fps):
         video = wan_vae_to_comfy(raw_video).float().clamp(0.0, 1.0)
         save_to_video(video, output_path, fps=fps, method="ffmpeg")
@@ -872,7 +876,6 @@ class SeedVRRunner(DefaultRunner):
                             del raw
                         self.gen_video = None
                         self.gen_video_final = None
-                        self._input = None
                         torch.cuda.empty_cache()
                         gc.collect()
                     elif is_sp_root:

--- a/lightx2v/models/runners/worldplay/worldplay_ar_runner.py
+++ b/lightx2v/models/runners/worldplay/worldplay_ar_runner.py
@@ -161,21 +161,12 @@ class WorldPlayARRunner(HunyuanVideo15Runner):
         Returns:
             Dict with viewmats, Ks, action tensors
         """
-        try:
-            viewmats, Ks, action = pose_to_input(pose_data, latent_num)
-
-            viewmats = viewmats.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32)
-            Ks = Ks.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32)
-            action = action.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.long)
-
-            return {
-                "viewmats": viewmats,
-                "Ks": Ks,
-                "action": action,
-            }
-        except Exception as e:
-            logger.warning(f"Failed to process pose input: {e}. Continuing without pose conditioning.")
-            return None
+        viewmats, Ks, action = pose_to_input(pose_data, latent_num)
+        return {
+            "viewmats": viewmats.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32),
+            "Ks": Ks.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32),
+            "action": action.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.long),
+        }
 
     def init_run(self):
         """Initialize run with pose conditioning support."""

--- a/lightx2v/models/runners/worldplay/worldplay_bi_runner.py
+++ b/lightx2v/models/runners/worldplay/worldplay_bi_runner.py
@@ -284,21 +284,12 @@ class WorldPlayBIRunner(HunyuanVideo15Runner):
         Returns:
             Dict with viewmats, Ks, action tensors
         """
-        try:
-            viewmats, Ks, action = pose_to_input(pose_data, latent_num)
-
-            viewmats = viewmats.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32)
-            Ks = Ks.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32)
-            action = action.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.long)
-
-            return {
-                "viewmats": viewmats,
-                "Ks": Ks,
-                "action": action,
-            }
-        except Exception as e:
-            logger.warning(f"Failed to process pose input: {e}. Continuing without pose conditioning.")
-            return None
+        viewmats, Ks, action = pose_to_input(pose_data, latent_num)
+        return {
+            "viewmats": viewmats.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32),
+            "Ks": Ks.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32),
+            "action": action.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.long),
+        }
 
     def init_run(self):
         """Initialize run with pose conditioning support."""

--- a/lightx2v/models/runners/worldplay/worldplay_distill_runner.py
+++ b/lightx2v/models/runners/worldplay/worldplay_distill_runner.py
@@ -1,7 +1,6 @@
 import gc
 
 import torch
-from loguru import logger
 
 from lightx2v.models.networks.worldplay.model import WorldPlayModel
 from lightx2v.models.networks.worldplay.pose_utils import pose_to_input
@@ -140,22 +139,12 @@ class WorldPlayDistillRunner(HunyuanVideo15Runner):
         Returns:
             Dict with viewmats, Ks, action tensors
         """
-        try:
-            viewmats, Ks, action = pose_to_input(pose_data, latent_num)
-
-            # Move to device and add batch dimension
-            viewmats = viewmats.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32)
-            Ks = Ks.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32)
-            action = action.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.long)
-
-            return {
-                "viewmats": viewmats,
-                "Ks": Ks,
-                "action": action,
-            }
-        except Exception as e:
-            logger.warning(f"Failed to process pose input: {e}. Continuing without pose conditioning.")
-            return None
+        viewmats, Ks, action = pose_to_input(pose_data, latent_num)
+        return {
+            "viewmats": viewmats.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32),
+            "Ks": Ks.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.float32),
+            "action": action.unsqueeze(0).to(device=AI_DEVICE, dtype=torch.long),
+        }
 
     def init_run(self):
         """Initialize run with pose conditioning support."""

--- a/lightx2v/models/schedulers/ernie_image/scheduler.py
+++ b/lightx2v/models/schedulers/ernie_image/scheduler.py
@@ -43,8 +43,7 @@ class ErnieImageScheduler(BaseScheduler):
 
     def prepare(self, input_info):
         self.rope_request_id += 1
-        if self.generator is None:
-            self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
+        self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
         self.prepare_latents(input_info)
         self.set_timesteps()
 

--- a/lightx2v/models/schedulers/longcat_image/scheduler.py
+++ b/lightx2v/models/schedulers/longcat_image/scheduler.py
@@ -9,7 +9,6 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
-from loguru import logger
 from torch import nn
 
 from lightx2v.models.schedulers.scheduler import BaseScheduler
@@ -361,10 +360,7 @@ class LongCatImageScheduler(BaseScheduler):
 
     def prepare(self, input_info):
         """Prepare scheduler for inference."""
-        if self.generator is None:
-            self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
-        else:
-            logger.info(f"Generator is not None, using existing generator for latents")
+        self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
         self.prepare_latents(input_info)
         self.set_timesteps()
 
@@ -420,10 +416,7 @@ class LongCatImageScheduler(BaseScheduler):
             input_image: Input image tensor [B, C, H, W] (preprocessed)
             vae: VAE model for encoding
         """
-        if self.generator is None:
-            self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
-        else:
-            logger.info(f"Generator is not None, using existing generator for latents")
+        self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
         self.vae = vae
         self.prepare_latents(input_info)
         self.set_timesteps()

--- a/lightx2v/models/schedulers/z_image/scheduler.py
+++ b/lightx2v/models/schedulers/z_image/scheduler.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
-from loguru import logger
 from torch.nn import functional as F
 
 from lightx2v.models.schedulers.scheduler import BaseScheduler
@@ -443,10 +442,7 @@ class ZImageScheduler(BaseScheduler):
         self.rope_request_id += 1
         self.freqs_cis_cache = {}
 
-        if self.generator is None:
-            self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
-        else:
-            logger.info(f"Generator is not None, using existing generator for latents")
+        self.generator = torch.Generator(device=AI_DEVICE).manual_seed(input_info.seed)
         self.prepare_latents(input_info)
         self.set_timesteps()
         strength = self._get_i2i_denoise_strength(input_info)

--- a/lightx2v/server/api/openai_images.py
+++ b/lightx2v/server/api/openai_images.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import re
 import time
-import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Literal, Optional
@@ -12,6 +11,7 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from ..schema import ImageTaskRequest, Usage
+from ..services.file_service import FileService
 from ..task_manager import TaskStatus, task_manager
 from .deps import get_services
 
@@ -37,11 +37,6 @@ class OpenAIImageResponse(BaseModel):
     output_format: Optional[Literal["png", "webp", "jpeg"]] = None
     size: Optional[str] = None
     usage: Optional[Usage] = None
-
-
-def _write_file_sync(file_path: Path, content: bytes) -> None:
-    with open(file_path, "wb") as buffer:
-        buffer.write(content)
 
 
 def _shape_from_size(size: str) -> tuple[int, int]:
@@ -152,7 +147,7 @@ def _build_url_response(request: Request, task_id: str, image_bytes: bytes) -> s
     file_name = f"{task_id}.png"
     output_path = services.file_service.output_video_dir / file_name
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    _write_file_sync(output_path, image_bytes)
+    output_path.write_bytes(image_bytes)
 
     base = str(request.base_url).rstrip("/")
     return f"{base}/v1/files/download/{file_name}"
@@ -231,18 +226,16 @@ async def create_openai_image_generation(request: Request, body: OpenAIImageGene
     return _build_openai_response(request, message.task_id, result_png, body.response_format, usage, size=body.size)
 
 
-async def _save_upload_file(file: UploadFile, target_dir: Path) -> str:
+async def _save_upload_file(file: UploadFile, file_service: FileService) -> str:
     if not file.filename:
         raise HTTPException(status_code=400, detail="Uploaded file has no filename")
 
-    file_extension = Path(file.filename).suffix or ".png"
-    unique_filename = f"{uuid.uuid4()}{file_extension}"
-    file_path = target_dir / unique_filename
+    filename = file.filename if Path(file.filename).suffix else file.filename + ".png"
 
     content = await file.read()
     if not content:
         raise HTTPException(status_code=400, detail=f"Uploaded file is empty: {file.filename}")
-    await asyncio.to_thread(_write_file_sync, file_path, content)
+    file_path = await asyncio.to_thread(file_service.save_uploaded_file, content, filename)
     return str(file_path)
 
 
@@ -290,12 +283,12 @@ async def create_openai_image_edit(
 
     image_paths = []
     for image_upload in image_uploads:
-        image_paths.append(await _save_upload_file(image_upload, services.file_service.input_image_dir))
+        image_paths.append(await _save_upload_file(image_upload, services.file_service))
     image_path = ",".join(image_paths)
 
     image_mask_path = ""
     if mask is not None:
-        image_mask_path = await _save_upload_file(mask, services.file_service.input_image_dir)
+        image_mask_path = await _save_upload_file(mask, services.file_service)
 
     message = _build_image_task_request(
         prompt=prompt,

--- a/lightx2v/server/api/tasks/image.py
+++ b/lightx2v/server/api/tasks/image.py
@@ -1,7 +1,5 @@
 import asyncio
 import time
-import uuid
-from pathlib import Path
 
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import Response
@@ -12,11 +10,6 @@ from ...task_manager import TaskStatus, task_manager
 from ..deps import get_services, validate_url_async
 
 router = APIRouter()
-
-
-def _write_file_sync(file_path: Path, content: bytes) -> None:
-    with open(file_path, "wb") as buffer:
-        buffer.write(content)
 
 
 async def _wait_task_and_stream_result(task_id: str, timeout_seconds: int, poll_interval_seconds: float):
@@ -195,22 +188,10 @@ async def create_image_task_form(
     services = get_services()
     assert services.file_service is not None, "File service is not initialized"
 
-    async def save_file_async(file: UploadFile, target_dir: Path) -> str:
-        if not file or not file.filename:
-            return ""
-
-        file_extension = Path(file.filename).suffix
-        unique_filename = f"{uuid.uuid4()}{file_extension}"
-        file_path = target_dir / unique_filename
-
-        content = await file.read()
-        await asyncio.to_thread(_write_file_sync, file_path, content)
-
-        return str(file_path)
-
     image_path = ""
     if image_file and image_file.filename:
-        image_path = await save_file_async(image_file, services.file_service.input_image_dir)
+        content = await image_file.read()
+        image_path = str(await asyncio.to_thread(services.file_service.save_uploaded_file, content, image_file.filename))
 
     message = ImageTaskRequest(
         prompt=prompt,
@@ -222,20 +203,4 @@ async def create_image_task_form(
         aspect_ratio=aspect_ratio,
     )
 
-    try:
-        message.prefer_memory_result = False
-        task_id = task_manager.create_task(message)
-        message.task_id = task_id
-
-        return TaskResponse(
-            task_id=task_id,
-            task_status="pending",
-            save_result_path=message.save_result_path,
-        )
-    except RuntimeError as e:
-        if getattr(e, "original_error_type", "") == "ValueError":
-            raise HTTPException(status_code=413, detail=str(e))
-        raise HTTPException(status_code=503, detail=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create image form task: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    return await create_image_task(message)

--- a/lightx2v/server/api/tasks/video.py
+++ b/lightx2v/server/api/tasks/video.py
@@ -1,6 +1,4 @@
 import asyncio
-import uuid
-from pathlib import Path
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from loguru import logger
@@ -10,11 +8,6 @@ from ...task_manager import task_manager
 from ..deps import get_services, validate_url_async
 
 router = APIRouter()
-
-
-def _write_file_sync(file_path: Path, content: bytes) -> None:
-    with open(file_path, "wb") as buffer:
-        buffer.write(content)
 
 
 @router.post("/", response_model=TaskResponse)
@@ -56,30 +49,20 @@ async def create_video_task_form(
     services = get_services()
     assert services.file_service is not None, "File service is not initialized"
 
-    async def save_file_async(file: UploadFile, target_dir: Path) -> str:
-        if not file or not file.filename:
-            return ""
-
-        file_extension = Path(file.filename).suffix
-        unique_filename = f"{uuid.uuid4()}{file_extension}"
-        file_path = target_dir / unique_filename
-
-        content = await file.read()
-        await asyncio.to_thread(_write_file_sync, file_path, content)
-
-        return str(file_path)
-
     image_path = ""
     if image_file and image_file.filename:
-        image_path = await save_file_async(image_file, services.file_service.input_image_dir)
+        content = await image_file.read()
+        image_path = str(await asyncio.to_thread(services.file_service.save_uploaded_file, content, image_file.filename))
 
     last_frame_path = ""
     if last_frame_file and last_frame_file.filename:
-        last_frame_path = await save_file_async(last_frame_file, services.file_service.input_image_dir)
+        content = await last_frame_file.read()
+        last_frame_path = str(await asyncio.to_thread(services.file_service.save_uploaded_file, content, last_frame_file.filename))
 
     audio_path = ""
     if audio_file and audio_file.filename:
-        audio_path = await save_file_async(audio_file, services.file_service.input_audio_dir)
+        content = await audio_file.read()
+        audio_path = str(await asyncio.to_thread(services.file_service.save_uploaded_file, content, audio_file.filename, services.file_service.input_audio_dir))
 
     message = VideoTaskRequest(
         prompt=prompt,
@@ -95,17 +78,4 @@ async def create_video_task_form(
         target_fps=target_fps,
     )
 
-    try:
-        task_id = task_manager.create_task(message)
-        message.task_id = task_id
-
-        return TaskResponse(
-            task_id=task_id,
-            task_status="pending",
-            save_result_path=message.save_result_path,
-        )
-    except RuntimeError as e:
-        raise HTTPException(status_code=503, detail=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create video form task: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    return await create_video_task(message)

--- a/lightx2v/server/services/file_service.py
+++ b/lightx2v/server/services/file_service.py
@@ -93,18 +93,14 @@ class FileService:
             media_name = Path(parsed_url.path).name
             if not media_name:
                 default_ext = "jpg" if media_type == "image" else "mp3"
-                media_name = f"{uuid.uuid4()}.{default_ext}"
+                media_name = f"download.{default_ext}"
 
             if media_type == "image":
                 target_dir = self.input_image_dir
             else:
                 target_dir = self.input_audio_dir
 
-            media_path = target_dir / media_name
-            media_path.parent.mkdir(parents=True, exist_ok=True)
-
-            with open(media_path, "wb") as f:
-                f.write(response.content)
+            media_path = self.save_uploaded_file(response.content, media_name, target_dir)
 
             logger.info(f"Successfully downloaded {media_type} from {url} to {media_path}")
             return media_path
@@ -191,13 +187,11 @@ class FileService:
             error_msg += f": {str(last_exception)}"
         raise ValueError(error_msg)
 
-    def save_uploaded_file(self, file_content: bytes, filename: str) -> Path:
+    def save_uploaded_file(self, file_content: bytes, filename: str, target_dir: Optional[Path] = None) -> Path:
         file_extension = Path(filename).suffix
         unique_filename = f"{uuid.uuid4()}{file_extension}"
-        file_path = self.input_image_dir / unique_filename
-
-        with open(file_path, "wb") as f:
-            f.write(file_content)
+        file_path = (target_dir or self.input_image_dir) / unique_filename
+        file_path.write_bytes(file_content)
 
         return file_path
 

--- a/lightx2v/server/services/generation/base.py
+++ b/lightx2v/server/services/generation/base.py
@@ -45,15 +45,6 @@ class BaseGenerationService(ABC):
         else:
             return image_path
 
-    async def _process_image_path(self, image_path: str, task_data: Dict[str, Any]) -> None:
-        task_data["image_path"] = await self._resolve_image_path(image_path)
-
-    async def _process_image_mask_path(self, image_mask_path: str, task_data: Dict[str, Any]) -> None:
-        if not image_mask_path:
-            return
-
-        task_data["image_mask_path"] = await self._resolve_image_path(image_mask_path)
-
     def _pack_image_and_mask_as_dir(self, task_data: Dict[str, Any]) -> None:
         image_path = task_data.get("image_path", "")
         image_mask_path = task_data.get("image_mask_path", "")
@@ -117,14 +108,7 @@ class BaseGenerationService(ABC):
             else:
                 task_data["talk_objects"][index]["audio"] = talk_object.audio
 
-            if talk_object.mask.startswith("http"):
-                mask_path = await self.file_service.download_image(talk_object.mask)
-                task_data["talk_objects"][index]["mask"] = str(mask_path)
-            elif is_base64_image(talk_object.mask):
-                mask_path = save_base64_image(talk_object.mask, str(self.file_service.input_image_dir))
-                task_data["talk_objects"][index]["mask"] = str(mask_path)
-            else:
-                task_data["talk_objects"][index]["mask"] = talk_object.mask
+            task_data["talk_objects"][index]["mask"] = await self._resolve_image_path(talk_object.mask)
 
         temp_path = self.file_service.cache_dir / uuid.uuid4().hex[:8]
         temp_path.mkdir(parents=True, exist_ok=True)
@@ -151,11 +135,15 @@ class BaseGenerationService(ABC):
                 return None
 
             if hasattr(message, "image_path") and message.image_path:
-                await self._process_image_path(message.image_path, task_data)
+                task_data["image_path"] = await self._resolve_image_path(message.image_path)
                 logger.info(f"Task {message.task_id} image path: {task_data.get('image_path')}")
 
+            if message.last_frame_path:
+                task_data["last_frame_path"] = await self._resolve_image_path(message.last_frame_path)
+                logger.info(f"Task {message.task_id} last frame path: {task_data.get('last_frame_path')}")
+
             if hasattr(message, "image_mask_path") and message.image_mask_path:
-                await self._process_image_mask_path(message.image_mask_path, task_data)
+                task_data["image_mask_path"] = await self._resolve_image_path(message.image_mask_path)
                 logger.info(f"Task {message.task_id} image mask path: {task_data.get('image_mask_path')}")
                 self._pack_image_and_mask_as_dir(task_data)
                 logger.info(f"Task {message.task_id} packed image+mask dir: {task_data.get('image_path')}")

--- a/lightx2v/server/services/generation/image.py
+++ b/lightx2v/server/services/generation/image.py
@@ -3,15 +3,10 @@ from typing import Any, Optional
 from loguru import logger
 
 from ...schema import TaskResponse
-from ..file_service import FileService
-from ..inference import DistributedInferenceService
 from .base import BaseGenerationService
 
 
 class ImageGenerationService(BaseGenerationService):
-    def __init__(self, file_service: FileService, inference_service: DistributedInferenceService):
-        super().__init__(file_service, inference_service)
-
     def get_output_extension(self) -> str:
         return ".png"
 
@@ -34,11 +29,11 @@ class ImageGenerationService(BaseGenerationService):
                 return None
 
             if hasattr(message, "image_path") and message.image_path:
-                await self._process_image_path(message.image_path, task_data)
+                task_data["image_path"] = await self._resolve_image_path(message.image_path)
                 logger.info(f"Task {message.task_id} image path: {task_data.get('image_path')}")
 
             if hasattr(message, "image_mask_path") and message.image_mask_path:
-                await self._process_image_mask_path(message.image_mask_path, task_data)
+                task_data["image_mask_path"] = await self._resolve_image_path(message.image_mask_path)
                 logger.info(f"Task {message.task_id} image mask path: {task_data.get('image_mask_path')}")
                 self._pack_image_and_mask_as_dir(task_data)
                 logger.info(f"Task {message.task_id} packed image+mask dir: {task_data.get('image_path')}")
@@ -90,6 +85,3 @@ class ImageGenerationService(BaseGenerationService):
         except Exception as e:
             logger.exception(f"Task {message.task_id} processing failed: {str(e)}")
             raise
-
-    async def generate_image_with_stop_event(self, message: Any, stop_event) -> Optional[Any]:
-        return await self.generate_with_stop_event(message, stop_event)

--- a/lightx2v/server/services/generation/sensenova_vision.py
+++ b/lightx2v/server/services/generation/sensenova_vision.py
@@ -25,8 +25,6 @@ from ...schema import (
     SenseNovaVisionTaskRequest,
     SenseNovaVisionTaskResult,
 )
-from ..file_service import FileService
-from ..inference import DistributedInferenceService
 from .base import BaseGenerationService
 
 SenseNovaTaskSpec = OmniVisionTaskSpec
@@ -115,9 +113,6 @@ def validate_sensenova_request(message: SenseNovaVisionTaskRequest) -> tuple[str
 
 
 class SenseNovaVisionGenerationService(BaseGenerationService):
-    def __init__(self, file_service: FileService, inference_service: DistributedInferenceService):
-        super().__init__(file_service, inference_service)
-
     def get_output_extension(self) -> str:
         return ".json"
 

--- a/lightx2v/server/services/generation/video.py
+++ b/lightx2v/server/services/generation/video.py
@@ -1,22 +1,9 @@
-from typing import Any, Optional
-
-from ..file_service import FileService
-from ..inference import DistributedInferenceService
 from .base import BaseGenerationService
 
 
 class VideoGenerationService(BaseGenerationService):
-    def __init__(self, file_service: FileService, inference_service: DistributedInferenceService):
-        super().__init__(file_service, inference_service)
-
     def get_output_extension(self) -> str:
         return ".mp4"
 
     def get_task_type(self) -> str:
         return "t2v,i2v,s2v"
-
-    async def generate_with_stop_event(self, message: Any, stop_event) -> Optional[Any]:
-        return await super().generate_with_stop_event(message, stop_event)
-
-    async def generate_video_with_stop_event(self, message: Any, stop_event) -> Optional[Any]:
-        return await self.generate_with_stop_event(message, stop_event)

--- a/scripts/disagg/run_dynamic.sh
+++ b/scripts/disagg/run_dynamic.sh
@@ -98,7 +98,10 @@ else
     user_max_requests=${DISAGG_AUTO_REQUEST_COUNT}
 fi
 
-seed=${SEED:-42}
+seed_args=()
+if [[ -v SEED ]]; then
+    seed_args=(--seed "${SEED}")
+fi
 prompt=${PROMPT:-"Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard."}
 negative_prompt=${NEGATIVE_PROMPT:-"镜头晃动，色调艳丽，过曝，静态"}
 save_result_path=${SAVE_RESULT_PATH:-${lightx2v_path}/save_results/wan22_i2v_dynamic.mp4}
@@ -477,7 +480,7 @@ python -m lightx2v.disagg.examples.run_service \
     --task i2v \
     --model_path ${model_path} \
     --config_json ${controller_cfg} \
-    --seed ${seed} \
+    "${seed_args[@]}" \
     --prompt "${prompt}" \
     --negative_prompt "${negative_prompt}" \
     --save_result_path ${save_result_path} \

--- a/scripts/wan/run_wan_flf2v.sh
+++ b/scripts/wan/run_wan_flf2v.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
 
-# set path firstly
-lightx2v_path=
-model_path=
+lightx2v_path=/path/to/LightX2V
+model_path=/path/to/Wan2.1-FLF2V-14B-720P
 
-export CUDA_VISIBLE_DEVICES=1
-
-# set environment variables
+export CUDA_VISIBLE_DEVICES=0
 source ${lightx2v_path}/scripts/base/base.sh
 
 python -m lightx2v.infer \
---model_cls wan2.1 \
---task flf2v \
---model_path $model_path \
---config_json ${lightx2v_path}/configs/wan/wan_flf2v.json \
---prompt "CG animation style, a small blue bird takes off from the ground, flapping its wings. The bird’s feathers are delicate, with a unique pattern on its chest. The background shows a blue sky with white clouds under bright sunshine. The camera follows the bird upward, capturing its flight and the vastness of the sky from a close-up, low-angle perspective." \
---negative_prompt "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
---image_path ${lightx2v_path}/assets/inputs/imgs/flf2v_input_first_frame-fs8.png \
---last_frame_path ${lightx2v_path}/assets/inputs/imgs/flf2v_input_last_frame-fs8.png \
---save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_flf2v.mp4
+  --model_cls wan2.1 \
+  --task flf2v \
+  --model_path $model_path \
+  --config_json ${lightx2v_path}/configs/wan/wan_flf2v.json \
+  --prompt "CG animation style, a small blue bird takes off from the ground, flapping its wings. The bird’s feathers are delicate, with a unique pattern on its chest. The background shows a blue sky with white clouds under bright sunshine. The camera follows the bird upward, capturing its flight and the vastness of the sky from a close-up, low-angle perspective." \
+  --negative_prompt "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
+  --image_path ${lightx2v_path}/assets/inputs/imgs/flf2v_input_first_frame-fs8.png \
+  --last_frame_path ${lightx2v_path}/assets/inputs/imgs/flf2v_input_last_frame-fs8.png \
+  --seed 42 \
+  --save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_flf2v.mp4

--- a/scripts/wan/run_wan_i2v.sh
+++ b/scripts/wan/run_wan_i2v.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 
-# set path firstly
-lightx2v_path=
-model_path=
+lightx2v_path=/path/to/LightX2V
+model_path=/path/to/Wan2.1-I2V-14B-480P
 
 export CUDA_VISIBLE_DEVICES=0
-
-# set environment variables
 source ${lightx2v_path}/scripts/base/base.sh
 
 python -m lightx2v.infer \
---model_cls wan2.1 \
---task i2v \
---model_path $model_path \
---config_json ${lightx2v_path}/configs/wan/wan_i2v.json \
---prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
---negative_prompt "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
---image_path ${lightx2v_path}/assets/inputs/imgs/img_0.jpg \
---save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_i2v.mp4
+  --model_cls wan2.1 \
+  --task i2v \
+  --model_path $model_path \
+  --config_json ${lightx2v_path}/configs/wan/wan_i2v.json \
+  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
+  --negative_prompt "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
+  --image_path ${lightx2v_path}/assets/inputs/imgs/img_0.jpg \
+  --seed 42 \
+  --save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_i2v.mp4

--- a/scripts/wan/run_wan_t2v.sh
+++ b/scripts/wan/run_wan_t2v.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
-# set path firstly
-lightx2v_path=/data/nvme1/wushuo/LightX2V
-model_path=/data/nvme1/wushuo/hf_models/models/Wan2.1-T2V-1.3B
+lightx2v_path=/path/to/LightX2V
+model_path=/path/to/Wan2.1-T2V-1.3B
 
 export CUDA_VISIBLE_DEVICES=0
-
-# set environment variables
 source ${lightx2v_path}/scripts/base/base.sh
 
 python -m lightx2v.infer \
---model_cls wan2.1 \
---task t2v \
---model_path $model_path \
---config_json ${lightx2v_path}/configs/wan/wan_t2v.json \
---prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
---negative_prompt "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
---save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_t2v.mp4
+  --model_cls wan2.1 \
+  --task t2v \
+  --model_path $model_path \
+  --config_json ${lightx2v_path}/configs/wan/wan_t2v.json \
+  --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
+  --negative_prompt "镜头晃动，色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
+  --target_shape 480 832 \
+  --seed 42 \
+  --save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_t2v.mp4

--- a/scripts/wan/run_wan_vace.sh
+++ b/scripts/wan/run_wan_vace.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 
-# set path firstly
-lightx2v_path=
-model_path=
+lightx2v_path=/path/to/LightX2V
+model_path=/path/to/Wan2.1-VACE-14B
 
-export CUDA_VISIBLE_DEVICES=1
-
-# set environment variables
+export CUDA_VISIBLE_DEVICES=0
 source ${lightx2v_path}/scripts/base/base.sh
 
 python -m lightx2v.infer \
---model_cls wan2.1_vace \
---task vace \
---model_path $model_path \
---config_json ${lightx2v_path}/configs/wan/wan_vace.json \
---prompt "在一个欢乐而充满节日气氛的场景中，穿着鲜艳红色春服的小女孩正与她的可爱卡通蛇嬉戏。她的春服上绣着金色吉祥图案，散发着喜庆的气息，脸上洋溢着灿烂的笑容。蛇身呈现出亮眼的绿色，形状圆润，宽大的眼睛让它显得既友善又幽默。小女孩欢快地用手轻轻抚摸着蛇的头部，共同享受着这温馨的时刻。周围五彩斑斓的灯笼和彩带装饰着环境，阳光透过洒在她们身上，营造出一个充满友爱与幸福的新年氛围。" \
---negative_prompt "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
---src_ref_images ${lightx2v_path}/assets/inputs/imgs/girl.png,${lightx2v_path}/assets/inputs/imgs/snake.png \
---save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_vace.mp4\
+  --model_cls wan2.1_vace \
+  --task vace \
+  --model_path $model_path \
+  --config_json ${lightx2v_path}/configs/wan/wan_vace.json \
+  --prompt "在一个欢乐而充满节日气氛的场景中，穿着鲜艳红色春服的小女孩正与她的可爱卡通蛇嬉戏。她的春服上绣着金色吉祥图案，散发着喜庆的气息，脸上洋溢着灿烂的笑容。蛇身呈现出亮眼的绿色，形状圆润，宽大的眼睛让它显得既友善又幽默。小女孩欢快地用手轻轻抚摸着蛇的头部，共同享受着这温馨的时刻。周围五彩斑斓的灯笼和彩带装饰着环境，阳光透过洒在她们身上，营造出一个充满友爱与幸福的新年氛围。" \
+  --negative_prompt "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" \
+  --src_ref_images ${lightx2v_path}/assets/inputs/imgs/girl.png,${lightx2v_path}/assets/inputs/imgs/snake.png \
+  --seed 42 \
+  --save_result_path ${lightx2v_path}/save_results/output_lightx2v_wan_vace.mp4

--- a/scripts/worldplay/run_worldplay_ar.sh
+++ b/scripts/worldplay/run_worldplay_ar.sh
@@ -6,7 +6,6 @@ export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
 
 # Model paths
 MODEL_PATH=/data/nvme1/models/hunyuan/HunyuanVideo-1.5
-AR_ACTION_MODEL_PATH=/data/nvme1/models/hunyuan/HY-WorldPlay/ar_model/diffusion_pytorch_model.safetensors
 
 # Input parameters
 PROMPT='A paved pathway leads towards a stone arch bridge spanning a calm body of water. Lush green trees and foliage line the path and the far bank of the water. A traditional-style pavilion with a tiered, reddish-brown roof sits on the far shore. The water reflects the surrounding greenery and the sky. The scene is bathed in soft, natural light, creating a tranquil and serene atmosphere.'
@@ -29,7 +28,6 @@ python /workspace/LightX2V/lightx2v/infer.py \
     --prompt "$PROMPT" \
     --image_path $IMAGE_PATH \
     --pose "$POSE" \
-    --action_ckpt $AR_ACTION_MODEL_PATH \
     --seed $SEED \
     --save_result_path $OUTPUT_PATH
 

--- a/scripts/worldplay/run_worldplay_ar_sp4.sh
+++ b/scripts/worldplay/run_worldplay_ar_sp4.sh
@@ -7,7 +7,6 @@ export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
 
 # Model paths
 MODEL_PATH=/data/nvme1/models/hunyuan/HunyuanVideo-1.5
-AR_ACTION_MODEL_PATH=/data/nvme1/models/hunyuan/HY-WorldPlay/ar_model/diffusion_pytorch_model.safetensors
 
 # Input parameters
 PROMPT='A paved pathway leads towards a stone arch bridge spanning a calm body of water. Lush green trees and foliage line the path and the far bank of the water.'
@@ -28,7 +27,6 @@ torchrun --nproc_per_node=4 -m lightx2v.infer \
     --prompt "$PROMPT" \
     --image_path $IMAGE_PATH \
     --pose "$POSE" \
-    --action_ckpt $AR_ACTION_MODEL_PATH \
     --seed $SEED \
     --save_result_path $OUTPUT_PATH
 

--- a/scripts/worldplay/run_worldplay_bi.sh
+++ b/scripts/worldplay/run_worldplay_bi.sh
@@ -6,7 +6,6 @@ export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
 
 # Model paths
 MODEL_PATH=/data/nvme1/models/hunyuan/hf_cache/hub/models--tencent--HunyuanVideo-1.5/snapshots/9b49404b3f5df2a8f0b31df27a0c7ab872e7b038
-BI_ACTION_MODEL_PATH=/data/nvme1/models/hunyuan/HY-WorldPlay/bidirectional_model/diffusion_pytorch_model.safetensors
 
 # Input parameters
 PROMPT='A paved pathway leads towards a stone arch bridge spanning a calm body of water. Lush green trees and foliage line the path and the far bank of the water. A traditional-style pavilion with a tiered, reddish-brown roof sits on the far shore. The water reflects the surrounding greenery and the sky. The scene is bathed in soft, natural light, creating a tranquil and serene atmosphere.'
@@ -29,7 +28,6 @@ python /workspace/LightX2V/lightx2v/infer.py \
     --prompt "$PROMPT" \
     --image_path $IMAGE_PATH \
     --pose "$POSE" \
-    --action_ckpt $BI_ACTION_MODEL_PATH \
     --seed $SEED \
     --save_result_path $OUTPUT_PATH
 

--- a/scripts/worldplay/run_worldplay_distill.sh
+++ b/scripts/worldplay/run_worldplay_distill.sh
@@ -6,7 +6,6 @@ export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
 
 # Model paths
 MODEL_PATH=/data/nvme1/models/hunyuan/hf_cache/hub/models--tencent--HunyuanVideo-1.5/snapshots/9b49404b3f5df2a8f0b31df27a0c7ab872e7b038
-DISTILL_ACTION_MODEL_PATH=/data/nvme1/models/hunyuan/HY-WorldPlay/ar_distilled_action_model/diffusion_pytorch_model.safetensors
 
 # Input parameters
 PROMPT='A paved pathway leads towards a stone arch bridge spanning a calm body of water. Lush green trees and foliage line the path and the far bank of the water. A traditional-style pavilion with a tiered, reddish-brown roof sits on the far shore. The water reflects the surrounding greenery and the sky. The scene is bathed in soft, natural light, creating a tranquil and serene atmosphere.'
@@ -29,7 +28,6 @@ python /workspace/LightX2V/lightx2v/infer.py \
     --prompt "$PROMPT" \
     --image_path $IMAGE_PATH \
     --pose "$POSE" \
-    --action_ckpt $DISTILL_ACTION_MODEL_PATH \
     --seed $SEED \
     --save_result_path $OUTPUT_PATH
 


### PR DESCRIPTION
Fix state reuse across inference requests and consolidate media handling.

- Reset ErnieImage, LongCatImage and ZImage generators for each request.
- Release MiniMax/SeedVR conditioning state and clear NeoPP KV references after execution, including encoder/main failures.
- Preserve Disagg seed precedence with a fallback of 42, seed before model loading, and reseed each execution stage per request.
- Reuse file and media handling, prevent downloads with identical filenames from overwriting inputs, and remove redundant service wrappers.
- Move WorldPlay action checkpoint paths into JSON and propagate invalid pose errors.
- Make Wan example paths and request parameters explicit.