### PR TITLE
fix(rocm): make the aiter attention backend usable on gfx1100/gfx1201

### DIFF
--- a/lightx2v_platform/base/amd_rocm.py
+++ b/lightx2v_platform/base/amd_rocm.py
@@ -120,8 +120,13 @@ class AmdRocmDevice:
         # Inject aiter as sgl_kernel compatibility layer (REQUIRED)
         sgl_kernel = _get_aiter_sgl_kernel()
         sys.modules["sgl_kernel"] = sgl_kernel
-        # Update any module that already imported sgl_kernel
+        # Update any module that already imported sgl_kernel. torch.ops and
+        # torch.classes are ModuleType subclasses living in sys.modules whose
+        # attributes are operator namespaces rather than imported modules, so
+        # overwriting them would replace torch.ops.sgl_kernel itself.
         for mod_name, mod in list(sys.modules.items()):
+            if mod_name in ("torch.ops", "torch.classes"):
+                continue
             if mod is not None and hasattr(mod, "sgl_kernel"):
                 setattr(mod, "sgl_kernel", sgl_kernel)
         logger.info("  - aiter sgl_kernel compatibility layer enabled (RMSNorm, GEMM)")

--- a/lightx2v_platform/ops/attn/amd_rocm/flash_attn.py
+++ b/lightx2v_platform/ops/attn/amd_rocm/flash_attn.py
@@ -90,6 +90,13 @@ class AiterAttnWeight(AttnWeightTemplate):
             k = k.reshape(-1, k.shape[-2], k.shape[-1])
             v = v.reshape(-1, v.shape[-2], v.shape[-1])
 
+        # Callers may build cu_seqlens on CPU; the varlen kernel requires them on
+        # the compute device, same as the flash_attn2/flash_attn3 paths do.
+        if cu_seqlens_q is not None and cu_seqlens_q.is_cpu:
+            cu_seqlens_q = cu_seqlens_q.to(q.device, non_blocking=True)
+        if cu_seqlens_kv is not None and cu_seqlens_kv.is_cpu:
+            cu_seqlens_kv = cu_seqlens_kv.to(k.device, non_blocking=True)
+
         x = aiter_flash_attn_varlen_func(
             q,
             k,


### PR DESCRIPTION

## Problem

Two independent defects keep `"attn_type": "aiter_attn"` from running on ROCm.

**1. The sgl_kernel shim overwrites `torch.ops`.** After installing the aiter-backed shim as `sys.modules["sgl_kernel"]`, `AmdRocmDevice.init_device_env()` walks `sys.modules` to refresh every module that already imported it. But `torch.ops` and `torch.classes` synthesise an `_OpNamespace` for any attribute name, so `hasattr(mod, "sgl_kernel")` always succeeds there and the following `setattr` replaces the `torch.ops.sgl_kernel` operator namespace with the shim. `lightx2v/common/ops/mm/sgl_kernel.py:21` then dereferences `torch.ops.sgl_kernel.fp8_scaled_mm.default` and raises `AttributeError: 'function' object has no attribute 'default'`. Being an import-time failure, this breaks every `PLATFORM=amd_rocm` process regardless of quantisation settings, not only those selecting `aiter_attn`.

**2. `aiter_attn` never moves `cu_seqlens` to the compute device.** `AiterAttnWeight.apply()` hands the tensors to the varlen kernel as-is, so callers that build them on CPU — as `neopp` does — hit `RuntimeError: cu_seqlens_q must be on CUDA`. CUDA paths escape this because `neopp` passes 3-D `q`, sending `flash_attn3` down the dense branch that never reads `cu_seqlens`; aiter is always varlen.

## Fix

Skip `torch.ops` and `torch.classes` while walking `sys.modules`. The denylist is complete: of the `ModuleType` subclasses in `sys.modules` they are the only two that synthesise attributes on demand, and both hold operator namespaces rather than imported modules.

Move CPU-resident `cu_seqlens` to the compute device before the call, as `lightx2v/common/ops/attn/flash_attn.py` already does for `flash_attn2` (lines 68-71) and `flash_attn3` (lines 143-146). The `is not None` guards are needed because `AiterAttnWeight.apply()` defaults both arguments to `None`.

## Validation

Defect 1 reproduces with no GPU and no aiter installed, since the clobbering is pure Python; with the patch `torch.ops.sgl_kernel` stays an `_OpNamespace` and the import succeeds.

SenseNova-U1.5-8B-MoT text-to-image at 1024x1024, 50 steps with CFG, on gfx1201 (ROCm 7.2.3, PyTorch 2.10, aiter 0.1.21). Images are correct, and the attention output matches `torch_sdpa` to 9.77e-04 max absolute difference in bf16.

End-to-end speedup over `torch_sdpa` is 1.72x on gfx1100 and 1.09x on gfx1201.
