### PR TITLE
fix(minimax_h3): correct FP8 VAE decoder bias dtype

### DIFF
--- a/tools/convert/converter.py
+++ b/tools/convert/converter.py
@@ -846,6 +846,13 @@ def convert_weights(args):
                 comfyui_keys=args.comfyui_keys,
                 quantization_policy=args.quantization_policy,
             )
+            if args.model_type == "h3_video_vae_decoder" and args.linear_type == "fp8":
+                # FP8 decoder linears require FP16 bias; preserve other VAE tensors.
+                for key in converted_weights:
+                    if key.startswith("decoder.") and key.endswith(".weight_scale"):
+                        bias_key = key.removesuffix(".weight_scale") + ".bias"
+                        if bias_key in converted_weights:
+                            converted_weights[bias_key] = converted_weights[bias_key].to(torch.float16)
 
     os.makedirs(args.output, exist_ok=True)
 


### PR DESCRIPTION
Fix the H3 VAE decoder conversion path introduced in #1479 by exporting quantized Linear biases in FP16 while preserving other tensors' dtypes. This aligns newly converted checkpoints with the existing FP8-SGL and FP8-F16 loaders.